### PR TITLE
[Fix]：add initial_sentences param and fix custom tokenizer does not work

### DIFF
--- a/src/chonkie/chunker/base.py
+++ b/src/chonkie/chunker/base.py
@@ -30,8 +30,10 @@ class BaseChunker(ABC):
         if isinstance(tokenizer_or_token_counter, str):
             self.tokenizer = self._load_tokenizer(tokenizer_or_token_counter)
             self.token_counter = self._get_tokenizer_counter()
-        # Then check if the tokenizer_or_token_counter is a function via inspect
-        elif inspect.isfunction(tokenizer_or_token_counter):
+        # Then check if the tokenizer_or_token_counter is a function via inspect or method (e.g., a custom tokenizer function)
+        elif inspect.isfunction(tokenizer_or_token_counter) or inspect.ismethod(
+            tokenizer_or_token_counter
+        ):
             self.tokenizer = None
             self._tokenizer_backend = "callable"
             self.token_counter = tokenizer_or_token_counter

--- a/src/chonkie/chunker/semantic.py
+++ b/src/chonkie/chunker/semantic.py
@@ -31,6 +31,7 @@ class SemanticChunker(BaseChunker):
         self,
         embedding_model: Union[str, BaseEmbeddings] = "minishlab/potion-base-8M",
         mode: str = "window",
+        initial_sentences: int = 1,
         threshold: Union[str, float, int] = "auto",
         chunk_size: int = 512,
         similarity_window: int = 1,
@@ -47,6 +48,7 @@ class SemanticChunker(BaseChunker):
         Args:
             embedding_model: Name of the sentence-transformers model to load
             mode: Mode for grouping sentences, either "cumulative" or "window"
+            initial_sentences： Number of sentences to use as initial context when starting a new chunk in cumulative mode (default: 1, only used when mode="cumulative")
             threshold: Threshold for semantic similarity (0-1) or percentile (1-100), defaults to "auto"
             chunk_size: Maximum tokens allowed per chunk
             similarity_window: Number of sentences to consider for similarity threshold calculation
@@ -85,6 +87,7 @@ class SemanticChunker(BaseChunker):
             raise ValueError("threshold (int) must be between 1 and 100")
 
         self.mode = mode
+        self.initial_sentences = initial_sentences
         self.chunk_size = chunk_size
         self.threshold = threshold
         self.similarity_window = similarity_window


### PR DESCRIPTION
Feature Enhancement and Bug Fixes for Semantic Chunking
1. SemanticChunker: Added initial_sentence Parameter

Introduced a new initial_sentence parameter to the SemanticChunker class
Allows users to specify the number of sentences used as initial context when starting a new chunk in accumulation mode
Default value set to 1
Provides increased flexibility in controlling semantic-based sentence grouping

2. Improved Tokenizer Validation in BaseChunker

Enhanced input validation for the tokenizer_or_token_counter parameter
Added support for methods using inspect.ismethod() check
Increases robustness of tokenizer input processing
Enables more versatile tokenization strategies

Fixes for Current Version (v0.2.2)

Resolves TypeError when setting initial_sentences
Addresses ValueError related to custom tokenizer usage
Supports broader range of tokenization approaches
