### PR TITLE
[FEAT] Add LateChunker 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Chonkie provides several chunkers to help you split your text efficiently for RA
 - **SentenceChunker**: Splits text into chunks based on sentences.
 - **SemanticChunker**: Splits text into chunks based on semantic similarity.
 - **SDPMChunker**: Splits text using a Semantic Double-Pass Merge approach.
+- **LateChunker (experimental)**: Embeds text and then splits it to have better chunk embeddings.
 
 More on these methods and the approaches taken inside the [DOCS](https://docs.chonkie.ai)
 

--- a/src/chonkie/chunker/late.py
+++ b/src/chonkie/chunker/late.py
@@ -1,0 +1,425 @@
+"""Class definition for Late Chunking."""
+
+import importlib
+from bisect import bisect_left
+from itertools import accumulate
+from typing import TYPE_CHECKING, List, Union
+
+from chonkie.embeddings import BaseEmbeddings, SentenceTransformerEmbeddings
+from chonkie.types import LateChunk, Sentence
+
+from .base import BaseChunker
+
+if TYPE_CHECKING:
+    import numpy as np
+
+class LateChunker(BaseChunker):
+    """Class for Late Chunking.
+
+    In late chunking, we first take the embeddings of the entire text,
+    after which we split the text into chunks. When we split the text, 
+    we can use the embeddings generated earlier, mean pool them and 
+    use them as the sentence embeddings for the chunks. 
+
+    This class particularly implements the Sentence-style LateChunking 
+    approach by changing the way we prepare the sentences before the 
+    chunking. 
+
+    Args:
+        embedding_model: The embedding model to use for the LateChunker
+        mode: Mode of the LateChunker to split the text in
+        chunk_size: Maximum number of tokens per chunk
+        min_sentences_per_chunk: Minimum number of sentences per chunk (defaults to 1)
+        min_characters_per_sentence: Minimum number of characters per sentence (defaults to 12)
+        delim: Delimiters to split sentences on
+        **kwargs: Additional keyword arguments to pass to the EmbeddingModel
+        
+    """  
+
+    def __init__(self,
+                 embedding_model: Union[str, BaseEmbeddings] = "all-minilm-l6-v2", 
+                 mode: str = "sentence",
+                 chunk_size: int = 512, 
+                 min_sentences_per_chunk: int = 1, 
+                 min_characters_per_sentence: int = 12,
+                 approximate: bool = True,
+                 delim: Union[str, List[str]] = ['.', '!', '?', '\n'],
+                 **kwargs
+                 ) -> None:
+        """Initialise the LateChunker."""
+        # Assign the values if they make sense
+        if mode not in ['token', 'sentence']:
+            raise ValueError(
+                "Mode must be one of the following: ['token', 'sentence']"
+            )
+        if chunk_size <= 0: 
+            raise ValueError("chunk_size must be a positive non-zero value!")
+        if min_sentences_per_chunk < 0 and mode == 'sentence':
+            raise ValueError(f"min_sentences_per_chunk was assigned {min_sentences_per_chunk}; but it must be non-negative value!")
+        if min_characters_per_sentence <= 0:
+            raise ValueError("min_characters_per_sentence must be a positive non-zero value!")
+        if type(delim) not in [str, list]:
+            raise TypeError("delim must be of type str or list of str")
+        
+        self.mode = mode
+        self.chunk_size = chunk_size
+        self.min_sentences_per_chunk = min_sentences_per_chunk
+        self.min_characters_per_sentence = min_characters_per_sentence
+        self.approximate = approximate
+        self.delim = delim
+        self.sep = '🦛'
+
+        # Initialise the embeddings via AutoEmbeddings
+        if isinstance(embedding_model, BaseEmbeddings): 
+            self.embedding_model = embedding_model
+        elif isinstance(embedding_model, str):
+            from chonkie.embeddings.auto import AutoEmbeddings
+            self.embedding_model = AutoEmbeddings.get_embeddings(embedding_model, **kwargs)
+        else:
+            raise ValueError(
+                "ooops! seems like your embedding model is of the wrong type " +
+                "currently, this class only supports BaseEmbeddings objects or str objects "+
+                f"and it received {type(embedding_model)} object!"
+            )
+
+        # Check if the embedding model has been assigned properly
+        if self.embedding_model is None:
+            raise ImportError(
+                "embedding_model is not a valid embedding model",
+                "Please install the `st` extra to use this feature"
+            )
+        
+        if type(self.embedding_model) != SentenceTransformerEmbeddings:
+            raise ValueError("LateChunker (currently) only works with SentenceTransformerEmbeddings", 
+                             "Please install the `st` extra to use this feature")
+        
+        # Import numpy here as to not import it when it's not needed
+        if importlib.util.find_spec('numpy') is not None:
+            global np
+            import numpy as np
+
+        # Keeping the tokenizer the same as the sentence model is important 
+        # for the semantic meaning to be calculated properly
+        super().__init__(self.embedding_model.get_tokenizer_or_token_counter())
+
+    def _create_token_chunks(self,
+                            chunk_texts: List[str],
+                            token_counts: List[int],
+                            decoded_text: str,
+                            ) -> List[LateChunk]:
+        """Create chunks from a list of texts."""
+        # package everything as Chunk objects and send out the result
+        chunks = []
+        current_index = 0
+        for chunk_text, token_count in zip(chunk_texts, token_counts):
+            start_index = decoded_text.find(
+                chunk_text, current_index
+            )  # Find needs to be run every single time because of unknown overlap length
+            end_index = start_index + len(chunk_text)
+            chunks.append(
+                LateChunk(
+                    text=chunk_text,
+                    start_index=start_index,
+                    end_index=end_index,
+                    token_count=token_count,
+                )
+            )
+            current_index = end_index
+        return chunks
+
+    def _token_chunk(self, text: str) -> List[LateChunk]:
+        """Split text into overlapping chunks of specified token size.
+
+        Args:
+            text: Input text to be chunked
+
+        Returns:
+            List of Chunk objects containing the chunked text and metadata
+
+        """
+        if not text.strip():
+            return []
+
+        # Encode full text
+        text_tokens = self._encode(text)
+
+        # We decode the text because the tokenizer might result in a different output than text
+        decoded_text = self._decode(text_tokens)
+
+        # Calculate chunk positions
+        token_groups = [
+            text_tokens[
+                start_index : min(start_index + self.chunk_size, len(text_tokens))
+            ]
+            for start_index in range(
+                0, len(text_tokens), self.chunk_size
+            )
+        ]
+        token_counts = [
+            len(toks) for toks in token_groups
+        ]  # get the token counts; it's prolly chunk_size, but len doesn't take too long
+
+        chunk_texts = self._decode_batch(
+            token_groups
+        )  # decrease the time by decoding in one go (?)
+
+        chunks = self._create_token_chunks(chunk_texts, token_counts, decoded_text)
+
+        return chunks
+
+
+    def _split_sentences(
+        self,
+        text: str,
+    ) -> List[str]:
+        """Fast sentence splitting while maintaining accuracy.
+
+        This method is faster than using regex for sentence splitting and is more accurate than using the spaCy sentence tokenizer.
+
+        Args:
+            text: Input text to be split into sentences
+            delim: Delimiters to split sentences on
+            sep: Separator to use when splitting sentences
+
+        Returns:
+            List of sentences
+
+        """
+        t = text
+        for c in self.delim:
+            t = t.replace(c, c + self.sep)
+
+        # Initial split
+        splits = [s for s in t.split(self.sep) if s != ""]
+        # print(splits)
+
+        # Combine short splits with previous sentence
+        sentences = []
+        current = ""
+
+        for s in splits:
+            if len(s.strip()) < self.min_characters_per_sentence:
+                current += s
+            else:
+                if current:
+                    sentences.append(current)
+                current = s
+
+        if current:
+            sentences.append(current)
+
+        return sentences
+
+    def _get_token_counts(self, sentences: List[str]) -> List[int]:
+        """Get token counts for a list of sentences in batch.
+
+        Args:
+            sentences: List of sentences
+
+        Returns:
+            List of token counts for each sentence
+
+        """
+        # Batch encode all sentences at once
+        encoded_sentences = self._encode_batch(sentences)
+        return [len(encoded) for encoded in encoded_sentences]
+
+    def _estimate_token_counts(self, text: str) -> int:
+        """Estimate token count using character length."""
+        CHARS_PER_TOKEN = 6.0  # Avg. char per token for llama3 is b/w 6-7
+        if type(text) is str:
+            return max(1, int(len(text) / CHARS_PER_TOKEN))
+        elif type(text) is list and type(text[0]) is str:
+            return [max(1, int(len(t) / CHARS_PER_TOKEN)) for t in text]
+        else:
+            raise ValueError(
+                f"Unknown type passed to _estimate_token_count: {type(text)}"
+            )
+    def _get_feedback(self, estimate: int, actual: int) -> float:
+        """Validate against the actual token counts and correct the estimates."""
+        feedback = 1 - ((estimate - actual) / estimate)
+        return feedback
+    
+    def _prepare_sentences(self, text: str) -> List[Sentence]:
+        """Split text into sentences and calculate token counts for each sentence.
+
+        Args:
+            text: Input text to be split into sentences
+
+        Returns:
+            List of Sentence objects
+
+        """
+        # Split text into sentences
+        sentence_texts = self._split_sentences(text)
+        if not sentence_texts:
+            return []
+
+        # Calculate positions once
+        positions = []
+        current_pos = 0
+        for sent in sentence_texts:
+            positions.append(current_pos)
+            current_pos += len(sent)  # No +1 space because sentences are already separated by spaces
+
+        if not self.approximate:
+            # Get accurate token counts in batch
+            token_counts = self._get_token_counts(sentence_texts)
+        else:
+            # Estimate token counts using character length
+            token_counts = self._estimate_token_counts(sentence_texts)
+
+        # Create sentence objects
+        return [
+            Sentence(
+                text=sent, start_index=pos, end_index=pos + len(sent), token_count=count
+            )
+            for sent, pos, count in zip(sentence_texts, positions, token_counts)
+        ]
+    
+    def _create_sentence_chunk(self, sentences: List[Sentence], token_count: int) -> LateChunk:
+        """Create a chunk from a list of sentences.
+
+        Args:
+            sentences: List of sentences to create chunk from
+            token_count: Total token count for the chunk
+
+        Returns:
+            Chunk object
+
+        """
+        chunk_text = "".join([sentence.text for sentence in sentences])
+        return LateChunk(
+            text=chunk_text,
+            start_index=sentences[0].start_index,
+            end_index=sentences[-1].end_index,
+            token_count=token_count,
+            sentences=sentences,
+        )
+
+    def _sentence_chunk(self, text: str) -> List[LateChunk]:
+        """Chunk the text into sentences."""
+        """Split text into overlapping chunks based on sentences while respecting token limits.
+
+        Args:
+            text: Input text to be chunked
+
+        Returns:
+            List of Chunk objects containing the chunked text and metadata
+
+        """
+        if not text.strip():
+            return []
+
+        # Get prepared sentences with token counts
+        sentences = self._prepare_sentences(text)  # 28mus
+        if not sentences:
+            return []
+
+        # Pre-calculate cumulative token counts for bisect
+        # Add 1 token for spaces between sentences
+        token_sums = list(
+            accumulate(
+                [s.token_count for s in sentences], lambda a, b: a + b, initial=0
+            )
+        )
+
+        chunks = []
+        feedback = 1.0
+        pos = 0
+
+        while pos < len(sentences):
+            # use updated feedback on the token sums
+            token_sums = [int(s * feedback) for s in token_sums]
+
+            # Use bisect_left to find initial split point
+            target_tokens = token_sums[pos] + self.chunk_size
+            split_idx = bisect_left(token_sums, target_tokens) - 1
+            split_idx = min(split_idx, len(sentences))
+
+            # Ensure we include at least one sentence beyond pos
+            split_idx = max(split_idx, pos + 1)
+
+            # Handle minimum sentences requirement
+            if split_idx - pos < self.min_sentences_per_chunk:
+                split_idx = pos + self.min_sentences_per_chunk
+
+            # Get the estimated token count
+            estimate = token_sums[split_idx] - token_sums[pos]
+
+            # Get candidate sentences and verify actual token count
+            chunk_sentences = sentences[pos:split_idx]
+            chunk_text = "".join(s.text for s in chunk_sentences)
+            actual = len(self._encode(chunk_text))
+
+            # Given the actual token_count and the estimate, get a feedback value for the next loop
+            feedback = self._get_feedback(estimate, actual)
+            # print(f"Estimate: {estimate} Actual: {actual} feedback: {feedback}")
+
+            # Back off one sentence at a time if we exceeded chunk size
+            while (
+                actual > self.chunk_size
+                and len(chunk_sentences) > self.min_sentences_per_chunk
+            ):
+                split_idx -= 1
+                chunk_sentences = sentences[pos:split_idx]
+                chunk_text = "".join(s.text for s in chunk_sentences)
+                actual = len(self._encode(chunk_text))
+
+            chunks.append(self._create_sentence_chunk(chunk_sentences, actual))
+            pos = split_idx
+
+        return chunks
+
+    def _get_chunks(self, text: str) -> List[LateChunk]:
+        """Get chunks from the text."""
+        if self.mode == 'token':
+            return self._token_chunk(text)
+        elif self.mode == 'sentence':
+            return self._sentence_chunk(text)
+        else:
+            raise ValueError(f"Unknown mode: {self.mode}")
+    
+    def _embedding_split(self, token_embeddings: "np.ndarray", token_counts: List[int]) -> List["np.ndarray"]:
+        """Split the embedding into chunks."""
+        embedding_splits = []
+        current_index = 0
+        for i, token_count in enumerate(token_counts):
+            if i != len(token_counts) - 1:
+                embedding_splits.append(token_embeddings[current_index:current_index+token_count])
+                current_index += token_count
+            else:
+                embedding_splits.append(token_embeddings[current_index:])
+        return embedding_splits
+        
+    def _mean_pool(self, embeddings: "np.ndarray") -> "np.ndarray":
+        """Mean pool the embeddings."""
+        # Assuming that numpy is installed and imported as np
+        # which is the case for the SentenceTransformerEmbeddings
+        return np.mean(embeddings, axis=0)
+
+    def chunk(self, text: str) -> List[LateChunk]:
+        """Chunk the text via Late Chunking."""
+        # Get the chunks first
+        chunks = self._get_chunks(text)
+        token_counts = [chunk.token_count for chunk in chunks]
+
+        # NOTE: A known issue with the SentenceTransformerEmbeddings is that it doesn't
+        # allow getting the token embeddings without adding special tokens. So the token
+        # embeddings are not exactly the same as the token embeddings of the text
+        # Additionally, token counts are not exactly the same as the token counts of the text
+        # because the tokenizer encodes the text differently if the text is split into chunks
+
+
+        # Get the token embeddings for the entire text
+        token_embeddings = self.embedding_model.embed_as_tokens(text)  # Shape: (n_tokens, embedding_dim)
+        chunk_token_embeddings = self._embedding_split(token_embeddings, token_counts)  # Shape: (n_chunks, n_tokens, embedding_dim)
+
+        # Get the chunk embeddings by averaging the token embeddings
+        chunk_embeddings = [self._mean_pool(token_emb) for token_emb in chunk_token_embeddings] # Shape: (n_chunks, embedding_dim)
+
+        # Add the chunk embeddings to the chunks
+        for chunk, embedding in zip(chunks, chunk_embeddings):
+            chunk.embedding = embedding
+
+        return chunks

--- a/src/chonkie/types.py
+++ b/src/chonkie/types.py
@@ -171,7 +171,7 @@ class SentenceChunk(Chunk):
 class SemanticSentence(Sentence):
     """Dataclass representing a semantic sentence with metadata.
 
-    All attributes are read-only via slots for performance reasons.
+    This class is used to represent a sentence with an embedding. 
 
     Attributes:
         text: The text content of the sentence
@@ -189,8 +189,6 @@ class SemanticSentence(Sentence):
 class SemanticChunk(SentenceChunk):
     """SemanticChunk dataclass representing a semantic chunk with metadata.
 
-    All attributes are read-only via slots for performance reasons.
-
     Attributes:
         text: The text content of the chunk
         start_index: The starting index of the chunk in the original text
@@ -201,3 +199,39 @@ class SemanticChunk(SentenceChunk):
     """
 
     sentences: List[SemanticSentence] = field(default_factory=list)
+
+@dataclass
+class LateSentence(Sentence):
+    """LateSentence dataclass representing a sentence with an embedding.
+
+    This class is used to represent a sentence with an embedding. 
+
+    Attributes:
+        text: The text content of the sentence
+        start_index: The starting index of the sentence in the original text
+        end_index: The ending index of the sentence in the original text
+        token_count: The number of tokens in the sentence
+        embedding: The sentence embedding
+
+    """
+
+    embedding: Optional["np.ndarray"] = field(default=None)
+
+
+@dataclass
+class LateChunk(Chunk):
+    """LateChunk dataclass representing a chunk with an embedding.
+
+    This class is used to represent a chunk with an embedding. 
+
+    Attributes:
+        text: The text content of the chunk
+        start_index: The starting index of the chunk in the original text
+        end_index: The ending index of the chunk in the original text
+        token_count: The number of tokens in the chunk
+        embedding: The chunk embedding
+
+    """
+
+    sentences: List[LateSentence] = field(default_factory=list)
+    embedding: Optional["np.ndarray"] = field(default=None)

--- a/tests/chunker/test_late_chunker.py
+++ b/tests/chunker/test_late_chunker.py
@@ -1,0 +1,143 @@
+"""Test cases for the LateChunker."""
+from typing import List
+
+import numpy as np
+import pytest
+
+from chonkie.chunker.late import LateChunker
+from chonkie.embeddings import SentenceTransformerEmbeddings
+from chonkie.types import LateChunk
+
+
+@pytest.fixture
+def embedding_model():
+    """Return a sentence transformer embedding model instance."""
+    return SentenceTransformerEmbeddings("all-minilm-l6-v2")
+
+
+@pytest.fixture
+def sample_text():
+    """Return a sample text."""
+    text = """# Chunking Strategies in Retrieval-Augmented Generation: A Comprehensive Analysis\n\nIn the rapidly evolving landscape of natural language processing, Retrieval-Augmented Generation (RAG) has emerged as a groundbreaking approach that bridges the gap between large language models and external knowledge bases. At the heart of these systems lies a crucial yet often overlooked process: chunking. This fundamental operation, which involves the systematic decomposition of large text documents into smaller, semantically meaningful units, plays a pivotal role in determining the overall effectiveness of RAG implementations.\n\nThe process of text chunking in RAG applications represents a delicate balance between competing requirements. On one side, we have the need for semantic coherence – ensuring that each chunk maintains meaningful context that can be understood and processed independently. On the other, we must optimize for information density, ensuring that each chunk carries sufficient signal without excessive noise that might impede retrieval accuracy. This balancing act becomes particularly crucial when we consider the downstream implications for vector databases and embedding models that form the backbone of modern RAG systems.\n\nThe selection of appropriate chunk size emerges as a fundamental consideration that significantly impacts system performance. Through extensive experimentation and real-world implementations, researchers have identified that chunks typically perform optimally in the range of 256 to 1024 tokens. However, this range should not be treated as a rigid constraint but rather as a starting point for optimization based on specific use cases and requirements. The implications of chunk size selection ripple throughout the entire RAG pipeline, affecting everything from storage requirements to retrieval accuracy and computational overhead.\n\nFixed-size chunking represents the most straightforward approach to document segmentation, offering predictable memory usage and consistent processing time. However, this apparent simplicity comes with significant drawbacks. By arbitrarily dividing text based on token or character count, fixed-size chunking risks fragmenting semantic units and disrupting the natural flow of information. Consider, for instance, a technical document where a complex concept is explained across several paragraphs – fixed-size chunking might split this explanation at critical junctures, potentially compromising the system's ability to retrieve and present this information coherently.\n\nIn response to these limitations, semantic chunking has gained prominence as a more sophisticated alternative. This approach leverages natural language understanding to identify meaningful boundaries within the text, respecting the natural structure of the document. Semantic chunking can operate at various levels of granularity, from simple sentence-based segmentation to more complex paragraph-level or topic-based approaches. The key advantage lies in its ability to preserve the inherent semantic relationships within the text, leading to more meaningful and contextually relevant retrieval results.\n\nRecent advances in the field have given rise to hybrid approaches that attempt to combine the best aspects of both fixed-size and semantic chunking. These methods typically begin with semantic segmentation but impose size constraints to prevent extreme variations in chunk length. Furthermore, the introduction of sliding window techniques with overlap has proved particularly effective in maintaining context across chunk boundaries. This overlap, typically ranging from 10% to 20% of the chunk size, helps ensure that no critical information is lost at segment boundaries, albeit at the cost of increased storage requirements.\n\nThe implementation of chunking strategies must also consider various technical factors that can significantly impact system performance. Vector database capabilities, embedding model constraints, and runtime performance requirements all play crucial roles in determining the optimal chunking approach. Moreover, content-specific factors such as document structure, language characteristics, and domain-specific requirements must be carefully considered. For instance, technical documentation might benefit from larger chunks that preserve detailed explanations, while news articles might perform better with smaller, more focused segments.\n\nThe future of chunking in RAG systems points toward increasingly sophisticated approaches. Current research explores the potential of neural chunking models that can learn optimal segmentation strategies from large-scale datasets. These models show promise in adapting to different content types and query patterns, potentially leading to more efficient and effective retrieval systems. Additionally, the emergence of cross-lingual chunking strategies addresses the growing need for multilingual RAG applications, while real-time adaptive chunking systems attempt to optimize segment boundaries based on user interaction patterns and retrieval performance metrics.\n\nThe effectiveness of RAG systems heavily depends on the thoughtful implementation of appropriate chunking strategies. While the field continues to evolve, practitioners must carefully consider their specific use cases and requirements when designing chunking solutions. Factors such as document characteristics, retrieval patterns, and performance requirements should guide the selection and optimization of chunking strategies. As we look to the future, the continued development of more sophisticated chunking approaches promises to further enhance the capabilities of RAG systems, enabling more accurate and efficient information retrieval and generation.\n\nThrough careful consideration of these various aspects and continued experimentation with different approaches, organizations can develop chunking strategies that effectively balance the competing demands of semantic coherence, computational efficiency, and retrieval accuracy. As the field continues to evolve, we can expect to see new innovations that further refine our ability to segment and process textual information in ways that enhance the capabilities of RAG systems while maintaining their practical utility in real-world applications."""
+    return text
+
+def test_late_chunker_initialization(embedding_model):
+    """Test that the LateChunker can be initialized properly."""
+    chunker = LateChunker(
+        embedding_model=embedding_model,
+        mode="sentence",
+        chunk_size=512
+    )
+
+    assert chunker is not None
+    assert isinstance(chunker.embedding_model, SentenceTransformerEmbeddings)
+    assert chunker.mode == "sentence"
+    assert chunker.chunk_size == 512
+    assert chunker.min_sentences_per_chunk == 1
+
+
+def test_late_chunker_invalid_mode(embedding_model):
+    """Test that the LateChunker raises error for invalid mode."""
+    with pytest.raises(ValueError):
+        LateChunker(embedding_model=embedding_model, mode="invalid")
+
+
+def test_late_chunker_sentence_mode(embedding_model, sample_text):
+    """Test that the LateChunker works in sentence mode."""
+    chunker = LateChunker(embedding_model=embedding_model, mode="sentence", chunk_size=512)
+    chunks = chunker.chunk(sample_text)
+
+    assert len(chunks) > 0
+    assert isinstance(chunks[0], LateChunk)
+    assert all(chunk.token_count <= 512 for chunk in chunks)
+    assert all(chunk.embedding is not None for chunk in chunks)
+    assert all(isinstance(chunk.embedding, np.ndarray) for chunk in chunks)
+
+
+def test_late_chunker_token_mode(embedding_model, sample_text):
+    """Test that the LateChunker works in token mode."""
+    chunker = LateChunker(embedding_model=embedding_model, mode="token", chunk_size=512)
+    chunks = chunker.chunk(sample_text)
+
+    assert len(chunks) > 0
+    assert isinstance(chunks[0], LateChunk)
+    assert all(chunk.token_count <= 512 for chunk in chunks)
+    assert all(chunk.embedding is not None for chunk in chunks)
+    assert all(isinstance(chunk.embedding, np.ndarray) for chunk in chunks)
+
+
+def test_late_chunker_empty_text(embedding_model):
+    """Test that the LateChunker can handle empty text input."""
+    chunker = LateChunker(embedding_model=embedding_model)
+    chunks = chunker.chunk("")
+
+    assert len(chunks) == 0
+
+
+def test_late_chunker_single_sentence(embedding_model):
+    """Test that the LateChunker can handle text with a single sentence."""
+    chunker = LateChunker(embedding_model=embedding_model)
+    text = "This is a single sentence."
+    chunks = chunker.chunk(text)
+
+    assert len(chunks) == 1
+    assert chunks[0].text == text
+    assert chunks[0].embedding is not None
+    assert isinstance(chunks[0].embedding, np.ndarray)
+
+
+def test_late_chunker_sentence_boundaries(embedding_model):
+    """Test that the LateChunker respects sentence boundaries."""
+    text = "First sentence. Second sentence. Third sentence."
+    chunker = LateChunker(
+        embedding_model=embedding_model,
+        mode="sentence",
+        chunk_size=512,
+        min_sentences_per_chunk=2
+    )
+    chunks = chunker.chunk(text)
+
+    for chunk in chunks:
+        # Count sentences by splitting on periods
+        sentence_count = len([s for s in chunk.text.split(".") if s.strip()])
+        assert sentence_count >= 2 or sentence_count == 1  # Last chunk might have fewer sentences
+
+
+def verify_chunk_indices(chunks: List[LateChunk], original_text: str):
+    """Verify that chunk indices correctly map to the original text."""
+    for i, chunk in enumerate(chunks):
+        # Extract text using the indices
+        extracted_text = original_text[chunk.start_index : chunk.end_index]
+        # Remove any leading/trailing whitespace from both texts for comparison
+        chunk_text = chunk.text.strip()
+        extracted_text = extracted_text.strip()
+
+        assert chunk_text == extracted_text, (
+            f"Chunk {i} text mismatch:\n"
+            f"Chunk text: '{chunk_text}'\n"
+            f"Extracted text: '{extracted_text}'\n"
+            f"Indices: [{chunk.start_index}:{chunk.end_index}]"
+        )
+
+
+def test_late_chunker_indices(embedding_model, sample_text):
+    """Test that the LateChunker correctly maps chunk indices to the original text."""
+    chunker = LateChunker(embedding_model=embedding_model)
+    chunks = chunker.chunk(sample_text)
+    verify_chunk_indices(chunks, sample_text)
+
+
+def test_late_chunker_embedding_dimensions(embedding_model, sample_text):
+    """Test that all chunk embeddings have consistent dimensions."""
+    chunker = LateChunker(embedding_model=embedding_model)
+    chunks = chunker.chunk(sample_text)
+    
+    # Get expected embedding dimension from the model
+    expected_dim = embedding_model.dimension
+    
+    for chunk in chunks:
+        assert chunk.embedding.shape == (expected_dim,)
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
This pull request introduces a new experimental chunker, `LateChunker`, and makes several enhancements to the embedding functionality. The most important changes include adding the `LateChunker` to the documentation, updating the `SentenceTransformer` embedding class to support token embeddings, and adding new data classes for `LateSentence` and `LateChunk`. Additionally, comprehensive test cases for the `LateChunker` have been added.

### New Features:
* **Documentation Update:**
  - Added `LateChunker (experimental)` to the list of chunkers in `README.md`.

* **Embedding Enhancements:**
  - Updated `SentenceTransformer` embedding class to import `numpy` and added methods to embed text as tokens and in batches. [[1]](diffhunk://#diff-a772f5d723fcdf86b61627ed9675d4441d0b7d3629ce7dbe9a355dab983f959bL44-R45) [[2]](diffhunk://#diff-a772f5d723fcdf86b61627ed9675d4441d0b7d3629ce7dbe9a355dab983f959bR67-R113)
  - Added `max_seq_length` property to the `SentenceTransformer` embedding class.

* **Data Classes:**
  - Added new data classes `LateSentence` and `LateChunk` to represent sentences and chunks with embeddings.

### Tests:
* **New Test Cases:**
  - Added comprehensive test cases for the `LateChunker` in `tests/chunker/test_late_chunker.py`.