### PR TITLE
[FIX] Update outdated package versions + set max limit to numpy to v2.2 (buggy)

### DIFF
--- a/.github/workflows/python-test-push.yml
+++ b/.github/workflows/python-test-push.yml
@@ -10,8 +10,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v4
         with:
+          version: latest
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,11 @@ dependencies = [
 Homepage = "https://github.com/bhavnicksm/chonkie"
 Documentation = "https://docs.chonkie.ai"
 [project.optional-dependencies]
-model2vec = ["model2vec>=0.1.0", "numpy>=1.23.0"]
-st = ["sentence-transformers>=2.3.0", "numpy>=1.23.0"]
-openai = ["openai>=1.0.0", "numpy>=1.23.0"]
-semantic = ["model2vec>=0.1.0", "numpy>=1.23.0"]
-all = ["sentence-transformers>=2.3.0", "numpy>=1.23.0", "openai>=1.0.0", "model2vec>=0.1.0"]
+model2vec = ["model2vec>=0.1.0", "numpy>=1.23.0, <2.2"]
+st = ["sentence-transformers>=3.0.0", "numpy>=1.23.0, <2.2"]
+openai = ["openai>=1.0.0", "numpy>=1.23.0, <2.2"]
+semantic = ["model2vec>=0.1.0", "numpy>=1.23.0, <2.2"]
+all = ["sentence-transformers>=3.0.0", "numpy>=1.23.0, <2.2", "openai>=1.0.0", "model2vec>=0.1.0"]
 dev = [
     "pytest>=6.2.0", 
     "datasets>=1.14.0",


### PR DESCRIPTION
This pull request includes updates to the CI workflow and dependency versions to ensure compatibility and improve performance.

CI workflow update:

* [`.github/workflows/python-test-push.yml`](diffhunk://#diff-d6a8b1b38b2e521ccb0c938537c1a7d3f3ac92ce99c0ad84b849a2631f1f5662L13-R15): Updated the `astral-sh/setup-uv` action from version 3 to version 4 and added the `version: latest` parameter to ensure the latest version of `uv` is installed.

Dependency version updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L40-R44): Updated the `numpy` dependency to specify an upper version limit of `<2.2` for all optional dependencies and increased the `sentence-transformers` dependency to version `3.0.0`.