### PR TITLE
[fix] Add LateChunker support to chunker and module exports

### DIFF
--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -7,6 +7,7 @@ from .chunker import (
     SentenceChunker,
     TokenChunker,
     WordChunker,
+    LateChunker,
 )
 from .embeddings import (
     AutoEmbeddings,
@@ -26,6 +27,7 @@ from .types import (
     SemanticSentence,
     Sentence,
     SentenceChunk,
+    LateChunk,
 )
 
 __version__ = "0.3.0"
@@ -47,6 +49,7 @@ __all__ += [
     "SemanticChunk",
     "Sentence",
     "SemanticSentence",
+    "LateChunk",
 ]
 
 # Add all chunker classes to __all__
@@ -57,6 +60,7 @@ __all__ += [
     "SentenceChunker",
     "SemanticChunker",
     "SDPMChunker",
+    "LateChunker",
 ]
 
 # Add all embeddings classes to __all__

--- a/src/chonkie/chunker/__init__.py
+++ b/src/chonkie/chunker/__init__.py
@@ -6,6 +6,7 @@ from .semantic import SemanticChunker
 from .sentence import SentenceChunker
 from .token import TokenChunker
 from .word import WordChunker
+from .late import LateChunker
 
 __all__ = [
     "BaseChunker",
@@ -14,4 +15,5 @@ __all__ = [
     "SentenceChunker",
     "SemanticChunker",
     "SDPMChunker",
+    "LateChunker",
 ]


### PR DESCRIPTION
- Introduced LateChunker to the chunking module and updated the __init__.py files to include it in the public API.
- Enhanced the chunking capabilities by integrating LateChunker, following recent improvements in its functionality.

This commit builds on the previous work done for LateChunking, ensuring it is accessible for users of the chonkie library.