### PR TITLE
[FEAT] Add support for RecursiveChunking + minor fixes

### DIFF
--- a/.github/workflows/python-test-push.yml
+++ b/.github/workflows/python-test-push.yml
@@ -10,8 +10,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v4
         with:
+          version: latest
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To install chonkie, simply run:
 pip install chonkie
 ```
 
-Chonkie follows the rule to have minimal defualt installs, read the [DOCS](https://docs.chonkie.ai) to know the installation for your required chunker, or simply install `all` if you don't want to think about it (not recommended).
+Chonkie follows the rule to have minimal default installs, read the [DOCS](https://docs.chonkie.ai) to know the installation for your required chunker, or simply install `all` if you don't want to think about it (not recommended).
 
 ```bash
 pip install chonkie[all]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Documentation](https://img.shields.io/badge/docs-chonkie.ai-blue.svg)](https://docs.chonkie.ai)
 ![Package size](https://img.shields.io/badge/size-9.7MB-blue)
 [![Downloads](https://static.pepy.tech/badge/chonkie)](https://pepy.tech/project/chonkie)
+[![Discord](https://dcbadge.limes.pink/api/server/https://discord.gg/nMYNVyuB5Y?style=flat)](https://discord.gg/nMYNVyuB5Y)
 [![GitHub stars](https://img.shields.io/github/stars/bhavnicksm/chonkie.svg)](https://github.com/bhavnicksm/chonkie/stargazers)
 
 _The no-nonsense RAG chunking library that's lightweight, lightning-fast, and ready to CHONK your texts_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,11 @@ dependencies = [
 Homepage = "https://github.com/bhavnicksm/chonkie"
 Documentation = "https://docs.chonkie.ai"
 [project.optional-dependencies]
-model2vec = ["model2vec>=0.1.0", "numpy>=1.23.0"]
-st = ["sentence-transformers>=2.3.0", "numpy>=1.23.0"]
-openai = ["openai>=1.0.0", "numpy>=1.23.0"]
-semantic = ["model2vec>=0.1.0", "numpy>=1.23.0"]
-all = ["sentence-transformers>=2.3.0", "numpy>=1.23.0", "openai>=1.0.0", "model2vec>=0.1.0"]
+model2vec = ["model2vec>=0.1.0", "numpy>=1.23.0, <2.2"]
+st = ["sentence-transformers>=3.0.0", "numpy>=1.23.0, <2.2"]
+openai = ["openai>=1.0.0", "numpy>=1.23.0, <2.2"]
+semantic = ["model2vec>=0.1.0", "numpy>=1.23.0, <2.2"]
+all = ["sentence-transformers>=3.0.0", "numpy>=1.23.0, <2.2", "openai>=1.0.0", "model2vec>=0.1.0"]
 dev = [
     "pytest>=6.2.0", 
     "datasets>=1.14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chonkie"
-version = "0.2.2"
+version = "0.3.0"
 description = "🦛 CHONK your texts with Chonkie ✨ - The no-nonsense RAG chunking library"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -28,7 +28,7 @@ from .types import (
     SentenceChunk,
 )
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 __name__ = "chonkie"
 __author__ = "Bhavnick Minhas"
 

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -7,6 +7,7 @@ from .chunker import (
     SentenceChunker,
     TokenChunker,
     WordChunker,
+    LateChunker,
 )
 from .embeddings import (
     AutoEmbeddings,
@@ -26,6 +27,7 @@ from .types import (
     SemanticSentence,
     Sentence,
     SentenceChunk,
+    LateChunk,
 )
 
 __version__ = "0.3.0"
@@ -47,6 +49,7 @@ __all__ += [
     "SemanticChunk",
     "Sentence",
     "SemanticSentence",
+    "LateChunk",
 ]
 
 # Add all chunker classes to __all__
@@ -57,6 +60,7 @@ __all__ += [
     "SentenceChunker",
     "SemanticChunker",
     "SDPMChunker",
+    "LateChunker",
 ]
 
 # Add all embeddings classes to __all__

--- a/src/chonkie/chunker/__init__.py
+++ b/src/chonkie/chunker/__init__.py
@@ -6,6 +6,7 @@ from .semantic import SemanticChunker
 from .sentence import SentenceChunker
 from .token import TokenChunker
 from .word import WordChunker
+from .late import LateChunker
 
 __all__ = [
     "BaseChunker",
@@ -14,4 +15,5 @@ __all__ = [
     "SentenceChunker",
     "SemanticChunker",
     "SDPMChunker",
+    "LateChunker",
 ]

--- a/src/chonkie/chunker/sdpm.py
+++ b/src/chonkie/chunker/sdpm.py
@@ -58,6 +58,7 @@ class SDPMChunker(SemanticChunker):
             threshold_step: Step size for similarity threshold calculation
             delim: Delimiters to split sentences on
             skip_window: Number of chunks to skip when looking for similarities
+            **kwargs: Additional keyword arguments
 
         """
         super().__init__(

--- a/src/chonkie/chunker/semantic.py
+++ b/src/chonkie/chunker/semantic.py
@@ -56,6 +56,7 @@ class SemanticChunker(BaseChunker):
             min_chunk_size: Minimum number of tokens per chunk (and sentence, defaults to 2)
             threshold_step: Step size for similarity threshold calculation
             delim: Delimiters to split sentences on
+            **kwargs: Additional keyword arguments
 
         Raises:
             ValueError: If parameters are invalid

--- a/src/chonkie/embeddings/registry.py
+++ b/src/chonkie/embeddings/registry.py
@@ -36,17 +36,7 @@ class EmbeddingsRegistry:
             name: Unique identifier for this implementation
             embedding_cls: The embeddings class to register
             pattern: Optional regex pattern string or compiled pattern
-
-        Examples:
-            # Register with exact name
-            EmbeddingsRegistry.register("sentence-transformers", SentenceTransformerEmbeddings)
-
-            # Register with pattern for OpenAI
-            EmbeddingsRegistry.register(
-                "openai",
-                OpenAIEmbeddings,
-                pattern=r"^openai://.+|^text-embedding-ada-\d+$"
-            )
+            supported_types: Optional list of types that the embeddings class supports
 
         """
         if not issubclass(embedding_cls, BaseEmbeddings):

--- a/src/chonkie/refinery/base.py
+++ b/src/chonkie/refinery/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Union
 
 from chonkie.types import Chunk
 
@@ -23,6 +23,10 @@ class BaseRefinery(ABC):
     def refine(self, chunks: List[Chunk]) -> List[Chunk]:
         """Refine the given list of chunks and return the refined list."""
         pass
+    
+    def refine_batch(self, chunks_batch: List[List[Chunk]]) -> List[List[Chunk]]:
+        """Refine the given list of chunks and return the refined list."""
+        return [self.refine(chunks) for chunks in chunks_batch]
 
     @classmethod
     @abstractmethod
@@ -34,6 +38,29 @@ class BaseRefinery(ABC):
         """Representation of the Refinery."""
         return f"{self.__class__.__name__}(context_size={self.context_size})"
 
-    def __call__(self, chunks: List[Chunk]) -> List[Chunk]:
-        """Call the Refinery."""
-        return self.refine(chunks)
+    def __call__(self, chunks: Union[List[Chunk], List[List[Chunk]]]) -> Union[List[Chunk], List[List[Chunk]]]:
+        """Call the Refinery.
+        
+        Args:
+            chunks: Either a list of Chunks or a list of lists of Chunks
+            
+        Returns:
+            Refined chunks in the same format as input
+            
+        Raises:
+            ValueError: If input type is not a list of Chunks or list of lists of Chunks
+        
+        """
+        # If chunks is not a list or is empty, return chunks
+        if not isinstance(chunks, list) or not chunks:
+            return chunks
+        
+        # Check if it's a list of Chunks
+        if isinstance(chunks[0], Chunk):
+            return self.refine(chunks)
+        
+        # Check if it's a list of lists of Chunks
+        if isinstance(chunks[0], list) and chunks[0] and isinstance(chunks[0][0], Chunk):
+            return self.refine_batch(chunks)
+        
+        raise ValueError("Invalid input type for Refinery: must be List[Chunk] or List[List[Chunk]]")

--- a/src/chonkie/refinery/overlap.py
+++ b/src/chonkie/refinery/overlap.py
@@ -141,10 +141,10 @@ class OverlapRefinery(BaseRefinery):
         text_portion = chunk.text[-char_window:]
 
         # Get exact token boundaries
-        tokens = self.tokenizer.encode(text_portion)
+        tokens = self.tokenizer.encode(text_portion) #TODO: should be self._encode; need a unified tokenizer interface
         context_tokens = min(self.context_size, len(tokens))
         context_tokens_ids = tokens[-context_tokens:]
-        context_text = self.tokenizer.decode(context_tokens_ids)
+        context_text = self.tokenizer.decode(context_tokens_ids) #TODO: should be self._decode; need a unified tokenizer interface
 
         # Find where context text starts in chunk
         try:
@@ -408,7 +408,7 @@ class OverlapRefinery(BaseRefinery):
                 else:
                     # Otherwise use approximate by adding context tokens plus one for space
                     refined_chunks[i].token_count = (
-                        refined_chunks[i].token_count + context.token_count + 1
+                        refined_chunks[i].token_count + context.token_count
                     )
 
         return refined_chunks

--- a/src/chonkie/refinery/overlap.py
+++ b/src/chonkie/refinery/overlap.py
@@ -136,7 +136,7 @@ class OverlapRefinery(BaseRefinery):
         if not hasattr(self, "tokenizer"):
             return None
 
-        # Take 6x context_size characters to ensure enough tokens
+        # Take _AVG_CHAR_PER_TOKEN * context_size characters to ensure enough tokens
         char_window = min(len(chunk.text), int(self.context_size * self._AVG_CHAR_PER_TOKEN))
         text_portion = chunk.text[-char_window:]
 
@@ -170,7 +170,7 @@ class OverlapRefinery(BaseRefinery):
         if not hasattr(self, "tokenizer"):
             return None
 
-        # Take 6x context_size characters to ensure enough tokens
+        # Take _AVG_CHAR_PER_TOKEN * context_size characters to ensure enough tokens
         char_window = min(len(chunk.text), int(self.context_size * self._AVG_CHAR_PER_TOKEN))
         text_portion = chunk.text[:char_window]
 

--- a/src/chonkie/refinery/overlap.py
+++ b/src/chonkie/refinery/overlap.py
@@ -50,6 +50,9 @@ class OverlapRefinery(BaseRefinery):
         else:
             # Without tokenizer, must use approximate method
             self.approximate = True
+        
+        # Average number of characters per token
+        self._AVG_CHAR_PER_TOKEN = 7
 
     def _get_refined_chunks(
         self, chunks: List[Chunk], inplace: bool = True
@@ -168,7 +171,7 @@ class OverlapRefinery(BaseRefinery):
             return None
 
         # Take 6x context_size characters to ensure enough tokens
-        char_window = min(len(chunk.text), self.context_size * 6)
+        char_window = min(len(chunk.text), self.context_size * self._AVG_CHAR_PER_TOKEN)
         text_portion = chunk.text[:char_window]
 
         # Get exact token boundaries

--- a/src/chonkie/refinery/overlap.py
+++ b/src/chonkie/refinery/overlap.py
@@ -171,7 +171,7 @@ class OverlapRefinery(BaseRefinery):
             return None
 
         # Take 6x context_size characters to ensure enough tokens
-        char_window = min(len(chunk.text), self.context_size * self._AVG_CHAR_PER_TOKEN)
+        char_window = min(len(chunk.text), int(self.context_size * self._AVG_CHAR_PER_TOKEN))
         text_portion = chunk.text[:char_window]
 
         # Get exact token boundaries

--- a/src/chonkie/refinery/overlap.py
+++ b/src/chonkie/refinery/overlap.py
@@ -137,7 +137,7 @@ class OverlapRefinery(BaseRefinery):
             return None
 
         # Take 6x context_size characters to ensure enough tokens
-        char_window = min(len(chunk.text), self.context_size * 6)
+        char_window = min(len(chunk.text), int(self.context_size * self._AVG_CHAR_PER_TOKEN))
         text_portion = chunk.text[-char_window:]
 
         # Get exact token boundaries

--- a/tests/refinery/test_overlap_refinery.py
+++ b/tests/refinery/test_overlap_refinery.py
@@ -5,6 +5,7 @@ from transformers import AutoTokenizer
 
 from chonkie.refinery import OverlapRefinery
 from chonkie.types import Chunk, Context, Sentence, SentenceChunk
+from chonkie import TokenChunker
 
 
 @pytest.fixture
@@ -66,6 +67,11 @@ def sentence_chunks() -> List[SentenceChunk]:
         ),
     ]
 
+@pytest.fixture
+def sample_text():
+    """Return a sample text."""
+    text = """# Chunking Strategies in Retrieval-Augmented Generation: A Comprehensive Analysis\n\nIn the rapidly evolving landscape of natural language processing, Retrieval-Augmented Generation (RAG) has emerged as a groundbreaking approach that bridges the gap between large language models and external knowledge bases. At the heart of these systems lies a crucial yet often overlooked process: chunking. This fundamental operation, which involves the systematic decomposition of large text documents into smaller, semantically meaningful units, plays a pivotal role in determining the overall effectiveness of RAG implementations.\n\nThe process of text chunking in RAG applications represents a delicate balance between competing requirements. On one side, we have the need for semantic coherence – ensuring that each chunk maintains meaningful context that can be understood and processed independently. On the other, we must optimize for information density, ensuring that each chunk carries sufficient signal without excessive noise that might impede retrieval accuracy. This balancing act becomes particularly crucial when we consider the downstream implications for vector databases and embedding models that form the backbone of modern RAG systems.\n\nThe selection of appropriate chunk size emerges as a fundamental consideration that significantly impacts system performance. Through extensive experimentation and real-world implementations, researchers have identified that chunks typically perform optimally in the range of 256 to 1024 tokens. However, this range should not be treated as a rigid constraint but rather as a starting point for optimization based on specific use cases and requirements. The implications of chunk size selection ripple throughout the entire RAG pipeline, affecting everything from storage requirements to retrieval accuracy and computational overhead.\n\nFixed-size chunking represents the most straightforward approach to document segmentation, offering predictable memory usage and consistent processing time. However, this apparent simplicity comes with significant drawbacks. By arbitrarily dividing text based on token or character count, fixed-size chunking risks fragmenting semantic units and disrupting the natural flow of information. Consider, for instance, a technical document where a complex concept is explained across several paragraphs – fixed-size chunking might split this explanation at critical junctures, potentially compromising the system's ability to retrieve and present this information coherently.\n\nIn response to these limitations, semantic chunking has gained prominence as a more sophisticated alternative. This approach leverages natural language understanding to identify meaningful boundaries within the text, respecting the natural structure of the document. Semantic chunking can operate at various levels of granularity, from simple sentence-based segmentation to more complex paragraph-level or topic-based approaches. The key advantage lies in its ability to preserve the inherent semantic relationships within the text, leading to more meaningful and contextually relevant retrieval results.\n\nRecent advances in the field have given rise to hybrid approaches that attempt to combine the best aspects of both fixed-size and semantic chunking. These methods typically begin with semantic segmentation but impose size constraints to prevent extreme variations in chunk length. Furthermore, the introduction of sliding window techniques with overlap has proved particularly effective in maintaining context across chunk boundaries. This overlap, typically ranging from 10% to 20% of the chunk size, helps ensure that no critical information is lost at segment boundaries, albeit at the cost of increased storage requirements.\n\nThe implementation of chunking strategies must also consider various technical factors that can significantly impact system performance. Vector database capabilities, embedding model constraints, and runtime performance requirements all play crucial roles in determining the optimal chunking approach. Moreover, content-specific factors such as document structure, language characteristics, and domain-specific requirements must be carefully considered. For instance, technical documentation might benefit from larger chunks that preserve detailed explanations, while news articles might perform better with smaller, more focused segments.\n\nThe future of chunking in RAG systems points toward increasingly sophisticated approaches. Current research explores the potential of neural chunking models that can learn optimal segmentation strategies from large-scale datasets. These models show promise in adapting to different content types and query patterns, potentially leading to more efficient and effective retrieval systems. Additionally, the emergence of cross-lingual chunking strategies addresses the growing need for multilingual RAG applications, while real-time adaptive chunking systems attempt to optimize segment boundaries based on user interaction patterns and retrieval performance metrics.\n\nThe effectiveness of RAG systems heavily depends on the thoughtful implementation of appropriate chunking strategies. While the field continues to evolve, practitioners must carefully consider their specific use cases and requirements when designing chunking solutions. Factors such as document characteristics, retrieval patterns, and performance requirements should guide the selection and optimization of chunking strategies. As we look to the future, the continued development of more sophisticated chunking approaches promises to further enhance the capabilities of RAG systems, enabling more accurate and efficient information retrieval and generation.\n\nThrough careful consideration of these various aspects and continued experimentation with different approaches, organizations can develop chunking strategies that effectively balance the competing demands of semantic coherence, computational efficiency, and retrieval accuracy. As the field continues to evolve, we can expect to see new innovations that further refine our ability to segment and process textual information in ways that enhance the capabilities of RAG systems while maintaining their practical utility in real-world applications."""
+    return text
 
 def test_overlap_refinery_initialization():
     """Test that OverlapRefinery initializes correctly with different parameters."""
@@ -258,6 +264,64 @@ def test_overlap_refinery_prefix_mode_with_merge(basic_chunks, tokenizer):
         ), f"{refined[i].text} {basic_chunks[i].text}"
         # Verify start index is from context
         assert refined[i].start_index == refined[i].context.start_index
+
+
+def test_overlap_refinery_sample_text_suffix(sample_text):
+    """Test that OverlapRefinery works correctly with a sample text in suffix mode."""
+    # Get chunks from sample text
+    chunker = TokenChunker(chunk_size=384, chunk_overlap=0)
+    tokenizer = chunker.tokenizer
+    chunks = chunker.chunk(sample_text)
+    # Initialize refinery and refine chunks
+    refinery = OverlapRefinery(context_size=128,
+                               tokenizer=tokenizer,
+                               mode="suffix",
+                               merge_context=True, 
+                               approximate=False)
+    refined = refinery.refine(chunks)
+
+    # Check the size of the refined chunks
+    assert len(refined) == len(chunks)
+    for i, chunk in enumerate(refined):
+        if i != len(refined) - 1:
+            assert chunker._count_tokens(chunk.text) == 512, \
+                f"Chunk {i} has {chunker._count_tokens(chunk.text)} tokens"
+        else:
+            assert chunker._count_tokens(chunk.text) == chunk.token_count, \
+                f"Chunk {i} has {chunker._count_tokens(chunk.text)} tokens"
+
+
+def test_overlap_refinery_sample_text_prefix(sample_text):
+    """Test that OverlapRefinery works correctly with a sample text in prefix mode."""
+    # Get chunks from sample text
+    chunker = TokenChunker(chunk_size=384, chunk_overlap=0)
+    tokenizer = chunker.tokenizer
+    chunks = chunker.chunk(sample_text)
+    original_token_count = [chunker._count_tokens(chunk.text) for chunk in chunks]
+
+    # Initialize refinery and refine chunks
+    refinery = OverlapRefinery(context_size=128,
+                               tokenizer=tokenizer,
+                               mode="prefix",
+                               merge_context=True, 
+                               approximate=False)
+    refined = refinery.refine(chunks)
+
+    # Check the size of the refined chunks
+    assert len(refined) == len(chunks)
+    
+    actual_token_count = []
+    predicted_token_count = []
+    for i, chunk in enumerate(refined):
+        if i != 0:
+            actual_token_count.append(chunker._count_tokens(chunk.text))
+            predicted_token_count.append(original_token_count[i] + 128)
+        else:
+            actual_token_count.append(chunk.token_count)
+            predicted_token_count.append(chunk.token_count)
+
+    assert actual_token_count == predicted_token_count, \
+        f"Actual token count: {actual_token_count} does not match predicted token count: {predicted_token_count}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces a new `RecursiveChunker` class and makes several updates to the `chonkie` library to support this new functionality. The most important changes include adding the `RecursiveChunker` class, updating the `README.md` to document the new chunker, and modifying various files to integrate the new chunker into the library.

### New Feature:
* Added `RecursiveChunker` class to `src/chonkie/chunker/recursive.py`, which provides hierarchical text chunking using customizable rules.

### Documentation Updates:
* Updated `README.md` to include the `RecursiveChunker` in the list of available chunkers and changed the citation format to `bibtex`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R90) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L128-R129)

### Integration:
* Updated `src/chonkie/__init__.py` to include the `RecursiveChunker` and related types in the module exports. [[1]](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408R5-L10) [[2]](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408R27-L30) [[3]](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408R52-R54) [[4]](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408R71)
* Updated `src/chonkie/chunker/__init__.py` to import and export the `RecursiveChunker`.

### Refinery Enhancements:
* Enhanced `Refinery` base class in `src/chonkie/refinery/base.py` to support batch refinement and handle both single and batch inputs. [[1]](diffhunk://#diff-a5a88fae3f19bf2c546e2b29f82765c4348c09db3362d1b0edab8eea8bf92d3fR27-R30) [[2]](diffhunk://#diff-a5a88fae3f19bf2c546e2b29f82765c4348c09db3362d1b0edab8eea8bf92d3fL37-R66)

### Miscellaneous:
* Modified `src/chonkie/refinery/overlap.py` to use a more accurate character-to-token ratio for context size calculations. [[1]](diffhunk://#diff-80725268365cb5d6bae898943f18604b84bce3021014d1406a3db4d9bfa4723bR54-R56) [[2]](diffhunk://#diff-80725268365cb5d6bae898943f18604b84bce3021014d1406a3db4d9bfa4723bL136-R147) [[3]](diffhunk://#diff-80725268365cb5d6bae898943f18604b84bce3021014d1406a3db4d9bfa4723bL170-R174) [[4]](diffhunk://#diff-80725268365cb5d6bae898943f18604b84bce3021014d1406a3db4d9bfa4723bL408-R411)