### PR TITLE
Patch SemanticChunker._group_sentences_window() to add last sentence …

### DIFF
--- a/src/chonkie/chunker/semantic.py
+++ b/src/chonkie/chunker/semantic.py
@@ -419,6 +419,8 @@ class SemanticChunker(BaseChunker):
             sentences[split_indices[i] : split_indices[i + 1]]
             for i in range(len(split_indices) - 1)
         ]
+        # Add last sentence to the last group
+        groups[-1].append(sentences[-1])
         return groups
 
     def _group_sentences(self, sentences: List[Sentence]) -> List[List[Sentence]]:


### PR DESCRIPTION
A patch that addresses #106 by adding last sentence to last group in `SemanticChunker._group_sentences_window()`.

Unclear if this is adequate or if the fix should occur in the actual semantic splitting logic in `SemanticChunker._get_split_indices()`.