### PR TITLE
[fix] Add fix for #106: Reconstruction tests for SemanticChunker failing, missing last sentence

### DIFF
--- a/src/chonkie/refinery/base.py
+++ b/src/chonkie/refinery/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Union
 
 from chonkie.types import Chunk
 
@@ -23,6 +23,10 @@ class BaseRefinery(ABC):
     def refine(self, chunks: List[Chunk]) -> List[Chunk]:
         """Refine the given list of chunks and return the refined list."""
         pass
+    
+    def refine_batch(self, chunks_batch: List[List[Chunk]]) -> List[List[Chunk]]:
+        """Refine the given list of chunks and return the refined list."""
+        return [self.refine(chunks) for chunks in chunks_batch]
 
     @classmethod
     @abstractmethod
@@ -34,6 +38,29 @@ class BaseRefinery(ABC):
         """Representation of the Refinery."""
         return f"{self.__class__.__name__}(context_size={self.context_size})"
 
-    def __call__(self, chunks: List[Chunk]) -> List[Chunk]:
-        """Call the Refinery."""
-        return self.refine(chunks)
+    def __call__(self, chunks: Union[List[Chunk], List[List[Chunk]]]) -> Union[List[Chunk], List[List[Chunk]]]:
+        """Call the Refinery.
+        
+        Args:
+            chunks: Either a list of Chunks or a list of lists of Chunks
+            
+        Returns:
+            Refined chunks in the same format as input
+            
+        Raises:
+            ValueError: If input type is not a list of Chunks or list of lists of Chunks
+        
+        """
+        # If chunks is not a list or is empty, return chunks
+        if not isinstance(chunks, list) or not chunks:
+            return chunks
+        
+        # Check if it's a list of Chunks
+        if isinstance(chunks[0], Chunk):
+            return self.refine(chunks)
+        
+        # Check if it's a list of lists of Chunks
+        if isinstance(chunks[0], list) and chunks[0] and isinstance(chunks[0][0], Chunk):
+            return self.refine_batch(chunks)
+        
+        raise ValueError("Invalid input type for Refinery: must be List[Chunk] or List[List[Chunk]]")

--- a/src/chonkie/refinery/overlap.py
+++ b/src/chonkie/refinery/overlap.py
@@ -141,10 +141,10 @@ class OverlapRefinery(BaseRefinery):
         text_portion = chunk.text[-char_window:]
 
         # Get exact token boundaries
-        tokens = self.tokenizer.encode(text_portion)
+        tokens = self.tokenizer.encode(text_portion) #TODO: should be self._encode; need a unified tokenizer interface
         context_tokens = min(self.context_size, len(tokens))
         context_tokens_ids = tokens[-context_tokens:]
-        context_text = self.tokenizer.decode(context_tokens_ids)
+        context_text = self.tokenizer.decode(context_tokens_ids) #TODO: should be self._decode; need a unified tokenizer interface
 
         # Find where context text starts in chunk
         try:
@@ -408,7 +408,7 @@ class OverlapRefinery(BaseRefinery):
                 else:
                     # Otherwise use approximate by adding context tokens plus one for space
                     refined_chunks[i].token_count = (
-                        refined_chunks[i].token_count + context.token_count + 1
+                        refined_chunks[i].token_count + context.token_count
                     )
 
         return refined_chunks

--- a/src/chonkie/refinery/overlap.py
+++ b/src/chonkie/refinery/overlap.py
@@ -136,7 +136,7 @@ class OverlapRefinery(BaseRefinery):
         if not hasattr(self, "tokenizer"):
             return None
 
-        # Take 6x context_size characters to ensure enough tokens
+        # Take _AVG_CHAR_PER_TOKEN * context_size characters to ensure enough tokens
         char_window = min(len(chunk.text), int(self.context_size * self._AVG_CHAR_PER_TOKEN))
         text_portion = chunk.text[-char_window:]
 
@@ -170,7 +170,7 @@ class OverlapRefinery(BaseRefinery):
         if not hasattr(self, "tokenizer"):
             return None
 
-        # Take 6x context_size characters to ensure enough tokens
+        # Take _AVG_CHAR_PER_TOKEN * context_size characters to ensure enough tokens
         char_window = min(len(chunk.text), int(self.context_size * self._AVG_CHAR_PER_TOKEN))
         text_portion = chunk.text[:char_window]
 

--- a/src/chonkie/refinery/overlap.py
+++ b/src/chonkie/refinery/overlap.py
@@ -50,6 +50,9 @@ class OverlapRefinery(BaseRefinery):
         else:
             # Without tokenizer, must use approximate method
             self.approximate = True
+        
+        # Average number of characters per token
+        self._AVG_CHAR_PER_TOKEN = 7
 
     def _get_refined_chunks(
         self, chunks: List[Chunk], inplace: bool = True
@@ -168,7 +171,7 @@ class OverlapRefinery(BaseRefinery):
             return None
 
         # Take 6x context_size characters to ensure enough tokens
-        char_window = min(len(chunk.text), self.context_size * 6)
+        char_window = min(len(chunk.text), self.context_size * self._AVG_CHAR_PER_TOKEN)
         text_portion = chunk.text[:char_window]
 
         # Get exact token boundaries

--- a/src/chonkie/refinery/overlap.py
+++ b/src/chonkie/refinery/overlap.py
@@ -171,7 +171,7 @@ class OverlapRefinery(BaseRefinery):
             return None
 
         # Take 6x context_size characters to ensure enough tokens
-        char_window = min(len(chunk.text), self.context_size * self._AVG_CHAR_PER_TOKEN)
+        char_window = min(len(chunk.text), int(self.context_size * self._AVG_CHAR_PER_TOKEN))
         text_portion = chunk.text[:char_window]
 
         # Get exact token boundaries

--- a/src/chonkie/refinery/overlap.py
+++ b/src/chonkie/refinery/overlap.py
@@ -137,7 +137,7 @@ class OverlapRefinery(BaseRefinery):
             return None
 
         # Take 6x context_size characters to ensure enough tokens
-        char_window = min(len(chunk.text), self.context_size * 6)
+        char_window = min(len(chunk.text), int(self.context_size * self._AVG_CHAR_PER_TOKEN))
         text_portion = chunk.text[-char_window:]
 
         # Get exact token boundaries

--- a/tests/chunker/test_token_chunker.py
+++ b/tests/chunker/test_token_chunker.py
@@ -331,5 +331,11 @@ def test_token_chunker_token_counts(tokenizer, sample_text):
     token_counts = [len(tokenizer.encode(chunk.text)) for chunk in chunks]
     assert all([chunk.token_count == token_count for chunk, token_count in zip(chunks, token_counts)]), "All chunks must have a token count equal to the length of the encoded text"
 
+def test_token_chunker_indices_batch(tokenizer, sample_text):
+    """Test that TokenChunker's indices correctly map to original text."""
+    chunker = TokenChunker(tokenizer=tokenizer, chunk_size=512, chunk_overlap=128)
+    chunks = chunker.chunk_batch([sample_text]*10)[-1]
+    verify_chunk_indices(chunks, sample_text)
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/refinery/test_overlap_refinery.py
+++ b/tests/refinery/test_overlap_refinery.py
@@ -5,6 +5,7 @@ from transformers import AutoTokenizer
 
 from chonkie.refinery import OverlapRefinery
 from chonkie.types import Chunk, Context, Sentence, SentenceChunk
+from chonkie import TokenChunker
 
 
 @pytest.fixture
@@ -66,6 +67,11 @@ def sentence_chunks() -> List[SentenceChunk]:
         ),
     ]
 
+@pytest.fixture
+def sample_text():
+    """Return a sample text."""
+    text = """# Chunking Strategies in Retrieval-Augmented Generation: A Comprehensive Analysis\n\nIn the rapidly evolving landscape of natural language processing, Retrieval-Augmented Generation (RAG) has emerged as a groundbreaking approach that bridges the gap between large language models and external knowledge bases. At the heart of these systems lies a crucial yet often overlooked process: chunking. This fundamental operation, which involves the systematic decomposition of large text documents into smaller, semantically meaningful units, plays a pivotal role in determining the overall effectiveness of RAG implementations.\n\nThe process of text chunking in RAG applications represents a delicate balance between competing requirements. On one side, we have the need for semantic coherence – ensuring that each chunk maintains meaningful context that can be understood and processed independently. On the other, we must optimize for information density, ensuring that each chunk carries sufficient signal without excessive noise that might impede retrieval accuracy. This balancing act becomes particularly crucial when we consider the downstream implications for vector databases and embedding models that form the backbone of modern RAG systems.\n\nThe selection of appropriate chunk size emerges as a fundamental consideration that significantly impacts system performance. Through extensive experimentation and real-world implementations, researchers have identified that chunks typically perform optimally in the range of 256 to 1024 tokens. However, this range should not be treated as a rigid constraint but rather as a starting point for optimization based on specific use cases and requirements. The implications of chunk size selection ripple throughout the entire RAG pipeline, affecting everything from storage requirements to retrieval accuracy and computational overhead.\n\nFixed-size chunking represents the most straightforward approach to document segmentation, offering predictable memory usage and consistent processing time. However, this apparent simplicity comes with significant drawbacks. By arbitrarily dividing text based on token or character count, fixed-size chunking risks fragmenting semantic units and disrupting the natural flow of information. Consider, for instance, a technical document where a complex concept is explained across several paragraphs – fixed-size chunking might split this explanation at critical junctures, potentially compromising the system's ability to retrieve and present this information coherently.\n\nIn response to these limitations, semantic chunking has gained prominence as a more sophisticated alternative. This approach leverages natural language understanding to identify meaningful boundaries within the text, respecting the natural structure of the document. Semantic chunking can operate at various levels of granularity, from simple sentence-based segmentation to more complex paragraph-level or topic-based approaches. The key advantage lies in its ability to preserve the inherent semantic relationships within the text, leading to more meaningful and contextually relevant retrieval results.\n\nRecent advances in the field have given rise to hybrid approaches that attempt to combine the best aspects of both fixed-size and semantic chunking. These methods typically begin with semantic segmentation but impose size constraints to prevent extreme variations in chunk length. Furthermore, the introduction of sliding window techniques with overlap has proved particularly effective in maintaining context across chunk boundaries. This overlap, typically ranging from 10% to 20% of the chunk size, helps ensure that no critical information is lost at segment boundaries, albeit at the cost of increased storage requirements.\n\nThe implementation of chunking strategies must also consider various technical factors that can significantly impact system performance. Vector database capabilities, embedding model constraints, and runtime performance requirements all play crucial roles in determining the optimal chunking approach. Moreover, content-specific factors such as document structure, language characteristics, and domain-specific requirements must be carefully considered. For instance, technical documentation might benefit from larger chunks that preserve detailed explanations, while news articles might perform better with smaller, more focused segments.\n\nThe future of chunking in RAG systems points toward increasingly sophisticated approaches. Current research explores the potential of neural chunking models that can learn optimal segmentation strategies from large-scale datasets. These models show promise in adapting to different content types and query patterns, potentially leading to more efficient and effective retrieval systems. Additionally, the emergence of cross-lingual chunking strategies addresses the growing need for multilingual RAG applications, while real-time adaptive chunking systems attempt to optimize segment boundaries based on user interaction patterns and retrieval performance metrics.\n\nThe effectiveness of RAG systems heavily depends on the thoughtful implementation of appropriate chunking strategies. While the field continues to evolve, practitioners must carefully consider their specific use cases and requirements when designing chunking solutions. Factors such as document characteristics, retrieval patterns, and performance requirements should guide the selection and optimization of chunking strategies. As we look to the future, the continued development of more sophisticated chunking approaches promises to further enhance the capabilities of RAG systems, enabling more accurate and efficient information retrieval and generation.\n\nThrough careful consideration of these various aspects and continued experimentation with different approaches, organizations can develop chunking strategies that effectively balance the competing demands of semantic coherence, computational efficiency, and retrieval accuracy. As the field continues to evolve, we can expect to see new innovations that further refine our ability to segment and process textual information in ways that enhance the capabilities of RAG systems while maintaining their practical utility in real-world applications."""
+    return text
 
 def test_overlap_refinery_initialization():
     """Test that OverlapRefinery initializes correctly with different parameters."""
@@ -258,6 +264,64 @@ def test_overlap_refinery_prefix_mode_with_merge(basic_chunks, tokenizer):
         ), f"{refined[i].text} {basic_chunks[i].text}"
         # Verify start index is from context
         assert refined[i].start_index == refined[i].context.start_index
+
+
+def test_overlap_refinery_sample_text_suffix(sample_text):
+    """Test that OverlapRefinery works correctly with a sample text in suffix mode."""
+    # Get chunks from sample text
+    chunker = TokenChunker(chunk_size=384, chunk_overlap=0)
+    tokenizer = chunker.tokenizer
+    chunks = chunker.chunk(sample_text)
+    # Initialize refinery and refine chunks
+    refinery = OverlapRefinery(context_size=128,
+                               tokenizer=tokenizer,
+                               mode="suffix",
+                               merge_context=True, 
+                               approximate=False)
+    refined = refinery.refine(chunks)
+
+    # Check the size of the refined chunks
+    assert len(refined) == len(chunks)
+    for i, chunk in enumerate(refined):
+        if i != len(refined) - 1:
+            assert chunker._count_tokens(chunk.text) == 512, \
+                f"Chunk {i} has {chunker._count_tokens(chunk.text)} tokens"
+        else:
+            assert chunker._count_tokens(chunk.text) == chunk.token_count, \
+                f"Chunk {i} has {chunker._count_tokens(chunk.text)} tokens"
+
+
+def test_overlap_refinery_sample_text_prefix(sample_text):
+    """Test that OverlapRefinery works correctly with a sample text in prefix mode."""
+    # Get chunks from sample text
+    chunker = TokenChunker(chunk_size=384, chunk_overlap=0)
+    tokenizer = chunker.tokenizer
+    chunks = chunker.chunk(sample_text)
+    original_token_count = [chunker._count_tokens(chunk.text) for chunk in chunks]
+
+    # Initialize refinery and refine chunks
+    refinery = OverlapRefinery(context_size=128,
+                               tokenizer=tokenizer,
+                               mode="prefix",
+                               merge_context=True, 
+                               approximate=False)
+    refined = refinery.refine(chunks)
+
+    # Check the size of the refined chunks
+    assert len(refined) == len(chunks)
+    
+    actual_token_count = []
+    predicted_token_count = []
+    for i, chunk in enumerate(refined):
+        if i != 0:
+            actual_token_count.append(chunker._count_tokens(chunk.text))
+            predicted_token_count.append(original_token_count[i] + 128)
+        else:
+            actual_token_count.append(chunk.token_count)
+            predicted_token_count.append(chunk.token_count)
+
+    assert actual_token_count == predicted_token_count, \
+        f"Actual token count: {actual_token_count} does not match predicted token count: {predicted_token_count}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request includes several changes to the `semantic.py` file in the `src/chonkie/chunker` directory, as well as updates to the test files in the `tests/chunker` and `tests/embeddings` directories. The main focus of these changes is to improve the semantic chunking logic and update the test cases accordingly.

Improvements to semantic chunking logic:

* [`src/chonkie/chunker/semantic.py`](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L92-R92): Modified the `__init__` method to set `similarity_window` based on the mode.
* [`src/chonkie/chunker/semantic.py`](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7R250-R281): Replaced the `_compute_pairwise_similarities` method with `_compute_window_similarities` to handle window-based similarity calculations. [[1]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7R250-R281) [[2]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L299-R320) [[3]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L360-R381)
* [`src/chonkie/chunker/semantic.py`](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L385-R409): Updated the `_group_sentences_cumulative` and `_group_sentences_window` methods to use the new similarity calculation. [[1]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L385-R409) [[2]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L416-R437)
* [`src/chonkie/chunker/semantic.py`](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L440-R461): Removed the additional space count in the `_create_chunk` method's `token_count` calculation.

Updates to test cases:

* [`tests/chunker/test_sdpm_chunker.py`](diffhunk://#diff-59e9fe8582c533f68b49ed2e26c270a165492bde3e4d52a1903b6c409e6dbcd7L172-R175): Updated the `test_spdm_chunker_token_counts` test to use the `chunker._count_tokens` method.
* [`tests/chunker/test_semantic_chunker.py`](diffhunk://#diff-b834fd599ae2641f495d6dbff207bd7ff21246a210980770725cc92cf800fdd1L261-R288): Added new tests for the `SemanticChunker` to verify token counts and text reconstruction.
* [`tests/embeddings/test_model2vec_embeddings.py`](diffhunk://#diff-f247db3d250f49ed8a4b8baf2f0cc6acab60d97bfb6c4a1e9d6cf852ed5b15e7R1): Added docstrings to test functions and improved the assertions for better clarity. [[1]](diffhunk://#diff-f247db3d250f49ed8a4b8baf2f0cc6acab60d97bfb6c4a1e9d6cf852ed5b15e7R1) [[2]](diffhunk://#diff-f247db3d250f49ed8a4b8baf2f0cc6acab60d97bfb6c4a1e9d6cf852ed5b15e7R11-R23) [[3]](diffhunk://#diff-f247db3d250f49ed8a4b8baf2f0cc6acab60d97bfb6c4a1e9d6cf852ed5b15e7R32) [[4]](diffhunk://#diff-f247db3d250f49ed8a4b8baf2f0cc6acab60d97bfb6c4a1e9d6cf852ed5b15e7R41-R56) [[5]](diffhunk://#diff-f247db3d250f49ed8a4b8baf2f0cc6acab60d97bfb6c4a1e9d6cf852ed5b15e7R65-R87)