### PR TITLE
[chore] Bump version to "v0.4.0" + minor change

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Bhavnick Minhas
+Copyright (c) 2024 Chonkie AI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chonkie"
-version = "0.3.0"
+version = "0.4.0"
 description = "🦛 CHONK your texts with Chonkie ✨ - The no-nonsense RAG chunking library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -34,7 +34,7 @@ from .types import (
     SentenceChunk,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __name__ = "chonkie"
 __author__ = "Bhavnick Minhas"
 


### PR DESCRIPTION
This pull request includes updates to the project metadata and licensing information. The most important changes include updating the project version and changing the copyright information.

Project metadata updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the project version from `0.3.0` to `0.4.0`.
* [`src/chonkie/__init__.py`](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408L37-R37): Updated the `__version__` attribute from `0.3.0` to `0.4.0`.

Licensing information update:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated the copyright holder from "Bhavnick Minhas" to "Chonkie AI".