### PR TITLE
[FIX] #116: Incorrect`start_index` when `chunk_overlap` is not 0

### DIFF
--- a/src/chonkie/chunker/token.py
+++ b/src/chonkie/chunker/token.py
@@ -52,28 +52,27 @@ class TokenChunker(BaseChunker):
     
     def _create_chunks(
         self,
-        chunk_texts: List[str],
         token_counts: List[int],
-        decoded_text: str,
+        token_groups: List[List[int]]
     ) -> List[Chunk]:
         """Create chunks from a list of texts."""
         # package everything as Chunk objects and send out the result
+        chunk_texts = self._decode_batch(token_groups)
         chunks = []
         current_index = 0
-        for chunk_text, token_count in zip(chunk_texts, token_counts):
-            start_index = decoded_text.find(
-                chunk_text, current_index
-            )  # Find needs to be run every single time because of unknown overlap length
-            end_index = start_index + len(chunk_text)
+        for chunk_text, token_count, token_group in zip(chunk_texts, token_counts, token_groups):
+            end_index = current_index + len(chunk_text)
             chunks.append(
                 Chunk(
                     text=chunk_text,
-                    start_index=start_index,
+                    start_index=current_index,
                     end_index=end_index,
                     token_count=token_count,
                 )
             )
-            current_index = end_index
+            # we subtract the space taken by the overlapping text, that gives you the start_index for the next chunk
+            overlap_tokens = self.chunk_overlap - (self.chunk_size - len(token_group))
+            current_index = end_index - len("".join(self._decode_batch([token_group[-overlap_tokens:]])))
         return chunks
 
     def chunk(self, text: str) -> List[Chunk]:
@@ -92,9 +91,6 @@ class TokenChunker(BaseChunker):
         # Encode full text
         text_tokens = self._encode(text)
 
-        # We decode the text because the tokenizer might result in a different output than text
-        decoded_text = self._decode(text_tokens)
-
         # Calculate chunk positions
         token_groups = [
             text_tokens[
@@ -108,11 +104,7 @@ class TokenChunker(BaseChunker):
             len(toks) for toks in token_groups
         ]  # get the token counts; it's prolly chunk_size, but len doesn't take too long
 
-        chunk_texts = self._decode_batch(
-            token_groups
-        )  # decrease the time by decoding in one go (?)
-
-        chunks = self._create_chunks(chunk_texts, token_counts, decoded_text)
+        chunks = self._create_chunks(token_counts, token_groups)
 
         return chunks
 

--- a/src/chonkie/chunker/token.py
+++ b/src/chonkie/chunker/token.py
@@ -72,7 +72,7 @@ class TokenChunker(BaseChunker):
             )
             # we subtract the space taken by the overlapping text, that gives you the start_index for the next chunk
             overlap_tokens = self.chunk_overlap - (self.chunk_size - len(token_group))
-            current_index = end_index - len("".join(self._decode_batch([token_group[-overlap_tokens:]])))
+            current_index = end_index - len(self._decode(token_group[-overlap_tokens:]))
         return chunks
 
     def chunk(self, text: str) -> List[Chunk]:

--- a/src/chonkie/chunker/token.py
+++ b/src/chonkie/chunker/token.py
@@ -70,9 +70,11 @@ class TokenChunker(BaseChunker):
                     token_count=token_count,
                 )
             )
+            
             # we subtract the space taken by the overlapping text, that gives you the start_index for the next chunk
             overlap_tokens = self.chunk_overlap - (self.chunk_size - len(token_group))
-            current_index = end_index - len(self._decode(token_group[-overlap_tokens:]))
+            current_index = end_index - len(self._decode(token_group[-overlap_tokens:] if overlap_tokens > 0 else []))
+        
         return chunks
 
     def chunk(self, text: str) -> List[Chunk]:


### PR DESCRIPTION
I decoded each time the trailing `overlap_tokens` and then subtracted their space from the `end_index` so that I will get the `start_index` for the next chunk. Hence, we need not find the `chunk_text` in the `decoded_text`. Both the find() and `decoded_text` are not needed anymore. 

We have to subtract `chunk_size - current_token_count` because the last chunk may have lesser tokens than the `chunk_size`.

I timed the fixed old and the new method, here are the results:

`new valid approach`:
- 189 μs ± 5.38 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
- 195 μs ± 6.38 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
- 198 μs ± 2 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
- 188 μs ± 2.98 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
- 187 μs ± 3.07 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)


`old approach`:
- 181 μs ± 4.73 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
- 181 μs ± 5.67 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
- 189 μs ± 4.53 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
- 183 μs ± 2.93 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
- 182 μs ± 2.35 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)