### PR TITLE
Feature Implementation: Cohere Embeddings Support #118

### DIFF
--- a/.github/workflows/python-test-push.yml
+++ b/.github/workflows/python-test-push.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ model2vec = ["model2vec>=0.1.0", "numpy>=1.23.0, <2.2"]
 st = ["sentence-transformers>=3.0.0", "numpy>=1.23.0, <2.2"]
 openai = ["openai>=1.0.0", "numpy>=1.23.0, <2.2"]
 semantic = ["model2vec>=0.1.0", "numpy>=1.23.0, <2.2"]
-all = ["sentence-transformers>=3.0.0", "numpy>=1.23.0, <2.2", "openai>=1.0.0", "model2vec>=0.1.0"]
+cohere = ["cohere>=5.13.0", "numpy>=1.23.0, <2.2"]
+all = ["sentence-transformers>=3.0.0", "numpy>=1.23.0, <2.2", "openai>=1.0.0", "model2vec>=0.1.0", "cohere>=5.13.0"]
 dev = [
     "pytest>=6.2.0", 
     "pytest-cov>=4.0.0",

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -16,6 +16,7 @@ from .embeddings import (
     Model2VecEmbeddings,
     OpenAIEmbeddings,
     SentenceTransformerEmbeddings,
+    CohereEmbeddings,
 )
 from .refinery import (
     BaseRefinery,
@@ -77,6 +78,7 @@ __all__ += [
     "Model2VecEmbeddings",
     "SentenceTransformerEmbeddings",
     "OpenAIEmbeddings",
+    "CohereEmbeddings",
     "AutoEmbeddings",
 ]
 

--- a/src/chonkie/chunker/token.py
+++ b/src/chonkie/chunker/token.py
@@ -52,28 +52,27 @@ class TokenChunker(BaseChunker):
     
     def _create_chunks(
         self,
-        chunk_texts: List[str],
         token_counts: List[int],
-        decoded_text: str,
+        token_groups: List[List[int]]
     ) -> List[Chunk]:
         """Create chunks from a list of texts."""
         # package everything as Chunk objects and send out the result
+        chunk_texts = self._decode_batch(token_groups)
         chunks = []
         current_index = 0
-        for chunk_text, token_count in zip(chunk_texts, token_counts):
-            start_index = decoded_text.find(
-                chunk_text, current_index
-            )  # Find needs to be run every single time because of unknown overlap length
-            end_index = start_index + len(chunk_text)
+        for chunk_text, token_count, token_group in zip(chunk_texts, token_counts, token_groups):
+            end_index = current_index + len(chunk_text)
             chunks.append(
                 Chunk(
                     text=chunk_text,
-                    start_index=start_index,
+                    start_index=current_index,
                     end_index=end_index,
                     token_count=token_count,
                 )
             )
-            current_index = end_index
+            # we subtract the space taken by the overlapping text, that gives you the start_index for the next chunk
+            overlap_tokens = self.chunk_overlap - (self.chunk_size - len(token_group))
+            current_index = end_index - len("".join(self._decode_batch([token_group[-overlap_tokens:]])))
         return chunks
 
     def chunk(self, text: str) -> List[Chunk]:
@@ -92,9 +91,6 @@ class TokenChunker(BaseChunker):
         # Encode full text
         text_tokens = self._encode(text)
 
-        # We decode the text because the tokenizer might result in a different output than text
-        decoded_text = self._decode(text_tokens)
-
         # Calculate chunk positions
         token_groups = [
             text_tokens[
@@ -108,11 +104,7 @@ class TokenChunker(BaseChunker):
             len(toks) for toks in token_groups
         ]  # get the token counts; it's prolly chunk_size, but len doesn't take too long
 
-        chunk_texts = self._decode_batch(
-            token_groups
-        )  # decrease the time by decoding in one go (?)
-
-        chunks = self._create_chunks(chunk_texts, token_counts, decoded_text)
+        chunks = self._create_chunks(token_counts, token_groups)
 
         return chunks
 

--- a/src/chonkie/chunker/token.py
+++ b/src/chonkie/chunker/token.py
@@ -72,7 +72,7 @@ class TokenChunker(BaseChunker):
             )
             # we subtract the space taken by the overlapping text, that gives you the start_index for the next chunk
             overlap_tokens = self.chunk_overlap - (self.chunk_size - len(token_group))
-            current_index = end_index - len("".join(self._decode_batch([token_group[-overlap_tokens:]])))
+            current_index = end_index - len(self._decode(token_group[-overlap_tokens:]))
         return chunks
 
     def chunk(self, text: str) -> List[Chunk]:

--- a/src/chonkie/chunker/token.py
+++ b/src/chonkie/chunker/token.py
@@ -70,9 +70,11 @@ class TokenChunker(BaseChunker):
                     token_count=token_count,
                 )
             )
+            
             # we subtract the space taken by the overlapping text, that gives you the start_index for the next chunk
             overlap_tokens = self.chunk_overlap - (self.chunk_size - len(token_group))
-            current_index = end_index - len(self._decode(token_group[-overlap_tokens:]))
+            current_index = end_index - len(self._decode(token_group[-overlap_tokens:] if overlap_tokens > 0 else []))
+        
         return chunks
 
     def chunk(self, text: str) -> List[Chunk]:

--- a/src/chonkie/embeddings/__init__.py
+++ b/src/chonkie/embeddings/__init__.py
@@ -3,6 +3,7 @@ from .base import BaseEmbeddings
 from .model2vec import Model2VecEmbeddings
 from .openai import OpenAIEmbeddings
 from .sentence_transformer import SentenceTransformerEmbeddings
+from .cohere import CohereEmbeddings
 
 # Add all embeddings classes to __all__
 __all__ = [
@@ -10,5 +11,6 @@ __all__ = [
     "Model2VecEmbeddings",
     "SentenceTransformerEmbeddings",
     "OpenAIEmbeddings",
+    "CohereEmbeddings",
     "AutoEmbeddings",
 ]

--- a/src/chonkie/embeddings/auto.py
+++ b/src/chonkie/embeddings/auto.py
@@ -23,6 +23,9 @@ class AutoEmbeddings:
         # Get Anthropic embeddings
         embeddings = AutoEmbeddings.get_embeddings("anthropic://claude-v1", api_key="...")
 
+         # Get Cohere embeddings
+        embeddings = AutoEmbeddings.get_embeddings("cohere://embed-english-light-v3.0", api_key="...")
+
     """
 
     @classmethod
@@ -50,6 +53,9 @@ class AutoEmbeddings:
 
             # Get Anthropic embeddings
             embeddings = AutoEmbeddings.get_embeddings("anthropic://claude-v1", api_key="...")
+
+            # Get Cohere embeddings
+            embeddings = AutoEmbeddings.get_embeddings("cohere://embed-english-light-v3.0", api_key="...")
 
         """
         # Load embeddings instance if already provided

--- a/src/chonkie/embeddings/cohere.py
+++ b/src/chonkie/embeddings/cohere.py
@@ -1,0 +1,203 @@
+import importlib
+import os
+import warnings
+from typing import List, Optional
+
+import numpy as np
+
+from .base import BaseEmbeddings
+
+class CohereEmbeddings(BaseEmbeddings):
+    """Cohere embeddings implementation using their API"""
+
+    AVAILABLE_MODELS = {
+        # cohere v3.0 models
+        "embed-english-v3.0": (True, 1024),                 # tokenizer from tokenizers
+        "embed-multilingual-v3.0": (False, 1024),           # not listed in the cohere models api list
+        "embed-english-light-v3.0": (True, 384),            # from tokenizers
+        "embed-multilingual-light-v3.0": (False, 384),      # not listed in the cohere models api list
+        # cohere v2.0 models
+        "embed-english-v2.0": (False, 4096),                # url is not available in the cohere models api list
+        "embed-english-light-v2.0": (False, 1024),          # not listed in the models list
+        "embed-multilingual-v2.0": (True, 768)              # from tokenizers
+    }
+
+    DEFAULT_MODEL = "embed-english-light-v3.0"
+    TOKENIZER_BASE_URL = "https://storage.googleapis.com/cohere-public/tokenizers/"
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL,
+        api_key: Optional[str] = None,
+        client_name: Optional[str] = None,
+        max_retries: int = 3,
+        timeout: float = 60.0,
+        batch_size: int = 128,
+        show_warnings: bool = True
+    ):
+        """Initialize Cohere embeddings.
+        
+        Args:
+            model: name of the Cohere embedding model to use
+            api_key: (optional) Cohere API key (if not provided, looks for COHERE_API_KEY environment variable)
+            organization: (optional) client name for API requests
+            max_retries: maximum number of retries for failed requests
+            timeout: timeout in seconds for API requests
+            batch_size: maximum number of texts to embed in one API call (maximum allowed by Cohere is 96)
+            show_warnings: whether to show warnings about token usage and truncation
+        """
+
+        super().__init__()
+        if not self.is_available():
+            raise ImportError(
+                "Cohere package is not available. Please install it via pip."
+            )
+        else:
+            global cohere
+            import tokenizers
+            import requests
+            from cohere import ClientV2 # using v2
+
+        if model not in self.AVAILABLE_MODELS:
+            raise ValueError(
+                f"Model {model} is not available. Choose from: {list(self.AVAILABLE_MODELS.keys())}"
+            )
+        
+        self.model = model
+        self._dimension = self.AVAILABLE_MODELS[model][1]
+        tokenizer_url = self.TOKENIZER_BASE_URL + (model if self.AVAILABLE_MODELS[model][0] else self.DEFAULT_MODEL) + ".json"
+        response = requests.get(tokenizer_url)
+        self._tokenizer = tokenizers.Tokenizer.from_str(response.text)
+        self._batch_size = min(batch_size, 96)  # max batch size for cohere is 96
+        self._show_warnings = show_warnings
+        self._max_retries = max_retries
+        self._api_key = api_key or os.getenv("COHERE_API_KEY")
+
+        if self._api_key is None:
+            raise ValueError(
+                "Cohere API key not found. Either pass it as api_key or set COHERE_API_KEY environment variable."
+            )
+        
+        # setup Cohere client
+        self.client = ClientV2(
+            api_key=api_key or os.getenv("COHERE_API_KEY"),
+            client_name=client_name,
+            timeout=timeout
+        )
+
+
+    def embed(self, text: str) -> np.ndarray:
+        """Generate embeddings for a single text"""
+        token_count = self.count_tokens(text)
+        if token_count > 512 and self._show_warnings:   # Cohere models max_context_length
+            warnings.warn(
+                f"Text has {token_count} tokens which exceeds the model's context length of 512."
+                "Generation may not be optimal"
+            )
+
+        for _ in range(self._max_retries):
+            try:
+                response = self.client.embed(
+                    model=self.model,
+                    input_type="search_document",
+                    embedding_types=["float"],
+                    texts=[text]
+                )
+
+                return np.array(response.embeddings.float_[0], dtype=np.float32)
+            except Exception as e:
+                if self._show_warnings:
+                    warnings.warn(
+                        f"There was an exception while generating embeddings. Exception: {str(e)}. Retrying..."
+                    )
+
+        raise RuntimeError(
+            "Unable to generate embeddings through Cohere."
+        )
+
+    def embed_batch(self, texts: List[str]) -> List[np.ndarray]:
+        """Get embeddings for multiple texts using batched API calls."""
+        if not texts:
+            return []
+        
+        all_embeddings = []
+
+        # process in batches
+        for i in range(0, len(texts), self._batch_size):
+            batch = texts[i: i + self._batch_size]
+
+            # check token_counts and warn if necessary
+            token_counts = self.count_tokens_batch(batch)
+            if self._show_warnings:
+                for _, count in zip(batch, token_counts):
+                    if count > 512:
+                        warnings.warn(
+                            f"Text has {count} tokens which exceeds the model's context length of 512."
+                            "Generation may not be optimal."
+                        ) 
+
+            try:
+                for _ in range(self._max_retries):
+                    try:
+                        response = self.client.embed(
+                            model=self.model,
+                            input_type="search_document",
+                            embedding_types=["float"],
+                            texts=batch
+                        )
+
+                        embeddings = [
+                            np.array(e, dtype=np.float32) for e in response.embeddings.float_
+                        ]
+                        all_embeddings.extend(embeddings)
+                        break
+                    except Exception as e:
+                        if self._show_warnings:
+                            warnings.warn(
+                                f"There was an exception while generating embeddings. Exception: {str(e)}. Retrying..."
+                            )
+
+            except Exception as e:
+                # If the batch fails, try one by one
+                if len(batch) > 1:
+                    warnings.warn(
+                        f"Batch embedding failed: {str(e)}. Trying one by one."
+                    )
+                    individual_embeddings = [self.embed(text) for text in batch]
+                    all_embeddings.extend(individual_embeddings)
+                else:
+                    raise e
+                
+        return all_embeddings
+
+    def count_tokens(self, text: str) -> int:
+        """Count tokens in text using the model's tokenizer."""
+        return len(self._tokenizer.encode(text, add_special_tokens=False))
+    
+    def count_tokens_batch(self, texts: List[str]) -> List[int]:
+        """Count tokens in multiple texts"""
+        tokens = self._tokenizer.encode_batch(texts, add_special_tokens=False)
+        return [len(t) for t in tokens]
+    
+    def similarity(self, u: np.ndarray, v: np.ndarray) -> float:
+        """Compute cosine similarity between two embeddings."""
+        return np.divide(
+            np.dot(u, v), np.linalg.norm(u) * np.linalg.norm(v), dtype=float
+        )
+
+    @property
+    def dimension(self) -> int:
+        """Return the embedding dimension"""
+        return self._dimension
+    
+    def get_tokenizer_or_token_counter(self):
+        """Return a tokenizers tokenizer object of the current model"""
+        return self._tokenizer
+    
+    @classmethod
+    def is_available(cls) -> bool:
+        """Check if the Cohere package is available."""
+        return importlib.util.find_spec("cohere") is not None
+    
+    def __repr__(self) -> str:
+        return f"CohereEmbeddings(model={self.model})"

--- a/src/chonkie/embeddings/registry.py
+++ b/src/chonkie/embeddings/registry.py
@@ -6,6 +6,7 @@ from .base import BaseEmbeddings
 from .model2vec import Model2VecEmbeddings
 from .openai import OpenAIEmbeddings
 from .sentence_transformer import SentenceTransformerEmbeddings
+from .cohere import CohereEmbeddings
 
 
 @dataclass
@@ -159,3 +160,15 @@ EmbeddingsRegistry.register(
     pattern=r"^minishlab/|^minishlab/potion-base-|^minishlab/potion-|^potion-",
     supported_types=["Model2Vec", "model2vec"],
 )
+
+# Register Cohere embeddings with pattern
+EmbeddingsRegistry.register(
+    "cohere", CohereEmbeddings, pattern=r"^cohere|^embed-"
+)
+EmbeddingsRegistry.register("embed-english-v3.0", CohereEmbeddings)
+EmbeddingsRegistry.register("embed-multilingual-v3.0", CohereEmbeddings)
+EmbeddingsRegistry.register("embed-english-light-v3.0", CohereEmbeddings)
+EmbeddingsRegistry.register("embed-multilingual-light-v3.0", CohereEmbeddings)
+EmbeddingsRegistry.register("embed-english-v2.0", CohereEmbeddings)
+EmbeddingsRegistry.register("embed-english-light-v2.0", CohereEmbeddings)
+EmbeddingsRegistry.register("embed-multilingual-v2.0", CohereEmbeddings)

--- a/tests/chunker/test_semantic_chunker.py
+++ b/tests/chunker/test_semantic_chunker.py
@@ -4,7 +4,7 @@ from typing import List
 import pytest
 
 from chonkie import SemanticChunker
-from chonkie.embeddings import Model2VecEmbeddings, OpenAIEmbeddings
+from chonkie.embeddings import Model2VecEmbeddings, OpenAIEmbeddings, CohereEmbeddings
 from chonkie.types import Chunk, SemanticChunk
 
 
@@ -42,6 +42,19 @@ def openai_embedding_model():
     """
     api_key = os.environ.get("OPENAI_API_KEY")
     return OpenAIEmbeddings(model="text-embedding-3-small", api_key=api_key)
+
+
+@pytest.fixture
+def cohere_embedding_model():
+    """Fixture that returns an Cohere embedding model for testing.
+    
+    Returns:
+        CohereEmbeddings: An Cohere model initialized with 'embed-english-light-v3.0'
+            and the API key from environment variables.
+            
+    """
+    api_key = os.environ.get("COHERE_API_KEY")
+    return CohereEmbeddings(model="embed-english-light-v3.0", api_key=api_key)
 
 
 @pytest.fixture
@@ -114,6 +127,27 @@ def test_semantic_chunker_initialization_sentence_transformer():
     """Test that the SemanticChunker can be initialized with SentenceTransformer model."""
     chunker = SemanticChunker(
         embedding_model="all-MiniLM-L6-v2",
+        chunk_size=512,
+        threshold=0.5,
+    )
+
+    assert chunker is not None
+    assert chunker.chunk_size == 512
+    assert chunker.threshold == 0.5
+    assert chunker.mode == "window"
+    assert chunker.similarity_window == 1
+    assert chunker.min_sentences == 1
+    assert chunker.min_chunk_size == 2
+
+
+@pytest.mark.skipif(
+    "COHERE_API_KEY" not in os.environ,
+    reason="Skipping test because COHERE_API_KEY is not defined",
+)
+def test_semantic_chunker_initialization_cohere(cohere_embedding_model):
+    """Test that the SemanticChunker can be initialized with required parameters."""
+    chunker = SemanticChunker(
+        embedding_model=cohere_embedding_model,
         chunk_size=512,
         threshold=0.5,
     )

--- a/tests/embeddings/test_auto_embeddings.py
+++ b/tests/embeddings/test_auto_embeddings.py
@@ -6,6 +6,7 @@ from chonkie import AutoEmbeddings
 from chonkie.embeddings.model2vec import Model2VecEmbeddings
 from chonkie.embeddings.openai import OpenAIEmbeddings
 from chonkie.embeddings.sentence_transformer import SentenceTransformerEmbeddings
+from chonkie.embeddings.cohere import CohereEmbeddings
 
 
 @pytest.fixture
@@ -30,6 +31,12 @@ def sentence_transformer_identifier_small():
 def openai_identifier():
     """Fixture providing an OpenAI identifier."""
     return "text-embedding-3-small"
+
+
+@pytest.fixture
+def cohere_identifier():
+    """Fixture providing an Cohere identifier."""
+    return "embed-english-light-v3.0"
 
 
 @pytest.fixture
@@ -68,6 +75,15 @@ def test_auto_embeddings_openai(openai_identifier):
     )
     assert isinstance(embeddings, OpenAIEmbeddings)
     assert embeddings.model == openai_identifier
+
+
+def test_auto_embeddings_cohere(cohere_identifier):
+    """Test that the AutoEmbeddings class can get Cohere embeddings."""
+    embeddings = AutoEmbeddings.get_embeddings(
+        cohere_identifier, api_key="your_cohere_api_key"
+    )
+    assert isinstance(embeddings, CohereEmbeddings)
+    assert embeddings.model == cohere_identifier
 
 
 def test_auto_embeddings_invalid_identifier(invalid_identifier):

--- a/tests/embeddings/test_cohere_embeddings.py
+++ b/tests/embeddings/test_cohere_embeddings.py
@@ -1,0 +1,119 @@
+import os
+
+import numpy as np
+import pytest
+
+from chonkie.embeddings.cohere import CohereEmbeddings 
+
+@pytest.fixture
+def embedding_model():
+    api_key = os.environ.get("COHERE_API_KEY")
+    return CohereEmbeddings(model="embed-english-light-v3.0", api_key=api_key)
+
+
+@pytest.fixture
+def sample_text():
+    return "This is a sample text for testing."
+
+
+@pytest.fixture
+def sample_texts():
+    return [
+        "This is the first sample text.",
+        "Here is another example sentence.",
+        "Testing embeddings with multiple sentences.",
+    ]
+
+
+@pytest.mark.skipif(
+    "COHERE_API_KEY" not in os.environ,
+    reason="Skipping test because COHERE_API_KEY is not defined",
+)
+def test_initialization_with_model_name():
+    embeddings = CohereEmbeddings(model="embed-english-light-v3.0")
+    assert embeddings.model == "embed-english-light-v3.0"
+    assert embeddings.client is not None
+
+
+@pytest.mark.skipif(
+    "COHERE_API_KEY" not in os.environ,
+    reason="Skipping test because COHERE_API_KEY is not defined",
+)
+def test_embed_single_text(embedding_model, sample_text):
+    embedding = embedding_model.embed(sample_text)
+    assert isinstance(embedding, np.ndarray)
+    assert embedding.shape == (embedding_model.dimension,)
+
+
+@pytest.mark.skipif(
+    "COHERE_API_KEY" not in os.environ,
+    reason="Skipping test because COHERE_API_KEY is not defined",
+)
+def test_embed_batch_texts(embedding_model, sample_texts):
+    embeddings = embedding_model.embed_batch(sample_texts)
+    assert isinstance(embeddings, list)
+    assert len(embeddings) == len(sample_texts)
+    assert all(isinstance(embedding, np.ndarray) for embedding in embeddings)
+    assert all(
+        embedding.shape == (embedding_model.dimension,) for embedding in embeddings
+    )
+
+
+@pytest.mark.skipif(
+    "COHERE_API_KEY" not in os.environ,
+    reason="Skipping test because COHERE_API_KEY is not defined",
+)
+def test_count_tokens_single_text(embedding_model, sample_text):
+    token_count = embedding_model.count_tokens(sample_text)
+    assert isinstance(token_count, int)
+    assert token_count > 0
+
+
+@pytest.mark.skipif(
+    "COHERE_API_KEY" not in os.environ,
+    reason="Skipping test because COHERE_API_KEY is not defined",
+)
+def test_count_tokens_batch_texts(embedding_model, sample_texts):
+    token_counts = embedding_model.count_tokens_batch(sample_texts)
+    assert isinstance(token_counts, list)
+    assert len(token_counts) == len(sample_texts)
+    assert all(isinstance(count, int) for count in token_counts)
+    assert all(count > 0 for count in token_counts)
+
+
+@pytest.mark.skipif(
+    "COHERE_API_KEY" not in os.environ,
+    reason="Skipping test because COHERE_API_KEY is not defined",
+)
+def test_similarity(embedding_model, sample_texts):
+    embeddings = embedding_model.embed_batch(sample_texts)
+    similarity_score = embedding_model.similarity(embeddings[0], embeddings[1])
+    assert isinstance(similarity_score, float)
+    assert 0.0 <= similarity_score <= 1.0
+
+
+@pytest.mark.skipif(
+    "COHERE_API_KEY" not in os.environ,
+    reason="Skipping test because COHERE_API_KEY is not defined",
+)
+def test_dimension_property(embedding_model):
+    assert isinstance(embedding_model.dimension, int)
+    assert embedding_model.dimension > 0
+
+
+def test_is_available():
+    assert CohereEmbeddings.is_available() is True
+
+
+@pytest.mark.skipif(
+    "COHERE_API_KEY" not in os.environ,
+    reason="Skipping test because COHERE_API_KEY is not defined",
+)
+def test_repr(embedding_model):
+    repr_str = repr(embedding_model)
+    assert isinstance(repr_str, str)
+    assert repr_str.startswith("CohereEmbeddings")
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
- added every model support for Cohere embeddings.
- added the same to the registry to support AutoEmbeddings.
- added tests for the same. 

key things to notice:
1. some models do not have tokenizers available. used the default "embed-english-light-v3.0" for those. (please review yourself and conclude)
2. there is a limit of 96 on the number of documents in a single API call. 
3. the model context length mentioned in the Cohere documentation is 512. but, they did not mention anywhere that it will be truncated in the case of larger texts, rather mentioned that it is not optimal. reflected the same in the code. 
4. used `tokenizers` for the complete tokenizing via Cohere official urls as I faced some issues while loading the same through hf via `autotiktoken`. 