### PR TITLE
[FIX] Handle edge case for RecursiveChunker (#131)

### DIFF
--- a/src/chonkie/chunker/recursive.py
+++ b/src/chonkie/chunker/recursive.py
@@ -53,9 +53,13 @@ class RecursiveChunker(BaseChunker):
             # Usually a good idea to check if there are any splits that are too short in characters
             # and then merge them
             merged_splits = []
-            for split in splits:
+            for i, split in enumerate(splits):
                 if len(split) < self.min_characters_per_chunk:
-                    merged_splits[-1] += split
+                    if merged_splits:
+                        merged_splits[-1] += split
+                    else:
+                        splits[i+1] = split + splits[i+1] # When merge splits is empty, we merge the current split with the next split
+                    continue
                 else:
                     merged_splits.append(split)
             splits = merged_splits


### PR DESCRIPTION
This pull request includes a change to the `_split_text` method in the `src/chonkie/chunker/recursive.py` file to enhance the handling of short text splits by merging them more effectively.

Enhancements to text splitting:

* [`src/chonkie/chunker/recursive.py`](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L56-R62): Modified the `_split_text` method to use an index-based loop and handle cases where `merged_splits` is empty by merging the current split with the next one.