### PR TITLE
[FIX] Minor fixes + Stylistic enhancements for TQDM and Multiprocessing

### DIFF
--- a/src/chonkie/chunker/base.py
+++ b/src/chonkie/chunker/base.py
@@ -248,7 +248,7 @@ class BaseChunker(ABC):
                     texts,
                     desc="🦛 CHONKING",
                     disable=not show_progress_bar,
-                    unit="texts",
+                    unit="text",
                     bar_format="{desc}: [{bar:20}] {percentage:3.0f}% • {n_fmt}/{total_fmt} texts chunked [{elapsed}<{remaining}, {rate_fmt}] 🌱", 
                     ascii=' >=')
         ]

--- a/src/chonkie/chunker/base.py
+++ b/src/chonkie/chunker/base.py
@@ -269,7 +269,7 @@ class BaseChunker(ABC):
                      unit="texts",
                      bar_format="{desc}: [{bar:20}] {percentage:3.0f}% • {n_fmt}/{total_fmt} texts chunked [{elapsed}<{remaining}, {rate_fmt}] 🌱",
                      ascii=' >=') as pbar:
-                for result in pool.imap_unordered(self.chunk, texts, chunksize=chunksize):
+                for result in pool.imap(self.chunk, texts, chunksize=chunksize):
                     results.append(result)
                     pbar.update()
             return results

--- a/src/chonkie/chunker/base.py
+++ b/src/chonkie/chunker/base.py
@@ -7,9 +7,11 @@ from abc import ABC, abstractmethod
 from multiprocessing import Pool, cpu_count
 from typing import Any, Callable, List, Union
 
+from tqdm import tqdm
+
 from chonkie.types import Chunk
 
-from tqdm import tqdm
+
 class BaseChunker(ABC):
     """Abstract base class for all chunker implementations.
 

--- a/src/chonkie/chunker/base.py
+++ b/src/chonkie/chunker/base.py
@@ -246,11 +246,11 @@ class BaseChunker(ABC):
         return [
                 self.chunk(t) for t in tqdm(
                     texts,
-                    desc="🦛 CHONKING",
+                    desc="🦛",
                     disable=not show_progress_bar,
-                    unit="text",
-                    bar_format="{desc}: [{bar:20}] {percentage:3.0f}% • {n_fmt}/{total_fmt} texts chunked [{elapsed}<{remaining}, {rate_fmt}] 🌱", 
-                    ascii=' >=')
+                        unit="doc",
+                    bar_format="{desc} ch{bar:20}nk {percentage:3.0f}% • {n_fmt}/{total_fmt} docs chunked [{elapsed}<{remaining}, {rate_fmt}] 🌱", 
+                    ascii=' o')
         ]
     
     def _process_batch_multiprocessing(self,
@@ -264,11 +264,11 @@ class BaseChunker(ABC):
         with Pool(processes=num_workers) as pool:
             results = []
             with tqdm(total=total,
-                     desc="🦛 CHONKING",
+                     desc="🦛",
                      disable=not show_progress_bar,
-                     unit="texts",
-                     bar_format="{desc}: [{bar:20}] {percentage:3.0f}% • {n_fmt}/{total_fmt} texts chunked [{elapsed}<{remaining}, {rate_fmt}] 🌱",
-                     ascii=' >=') as pbar:
+                     unit="doc",
+                     bar_format="{desc} ch{bar:20}nk {percentage:3.0f}% • {n_fmt}/{total_fmt} docs chunked [{elapsed}<{remaining}, {rate_fmt}] 🌱",
+                     ascii=' o') as pbar:
                 for result in pool.imap(self.chunk, texts, chunksize=chunksize):
                     results.append(result)
                     pbar.update()

--- a/src/chonkie/chunker/semantic.py
+++ b/src/chonkie/chunker/semantic.py
@@ -115,13 +115,13 @@ class SemanticChunker(BaseChunker):
             self.embedding_model = AutoEmbeddings.get_embeddings(embedding_model, **kwargs)
         else:
             raise ValueError(
-                "embedding_model must be a string or BaseEmbeddings instance"
+                f"{embedding_model} is not a valid embedding model"
             )
 
         # Probably the dependency is not installed
         if self.embedding_model is None:
             raise ImportError(
-                "embedding_model is not a valid embedding model",
+                f"{embedding_model} is not a valid embedding model",
                 "Please install the `semantic` extra to use this feature",
             )
 

--- a/src/chonkie/chunker/token.py
+++ b/src/chonkie/chunker/token.py
@@ -193,7 +193,7 @@ class TokenChunker(BaseChunker):
                         batch_size,
                         desc="🦛 CHONKING",
                         disable=not show_progress_bar, 
-                        unit="batches",
+                        unit="batch",
                         bar_format="{desc}: [{bar:20}] {percentage:3.0f}% • {n_fmt}/{total_fmt} batches chunked [{elapsed}<{remaining}, {rate_fmt}] 🌱",
                         ascii=' >='):
             batch_texts = texts[i : min(i + batch_size, len(texts))]

--- a/src/chonkie/chunker/token.py
+++ b/src/chonkie/chunker/token.py
@@ -2,11 +2,13 @@
 
 from typing import Any, Generator, List, Tuple, Union
 
+from tqdm import trange
+
 from chonkie.types import Chunk
 
 from .base import BaseChunker
 
-from tqdm import trange
+
 class TokenChunker(BaseChunker):
     """Chunker that splits text into chunks of a specified token size.
 

--- a/src/chonkie/chunker/token.py
+++ b/src/chonkie/chunker/token.py
@@ -191,11 +191,11 @@ class TokenChunker(BaseChunker):
         for i in trange(0,
                         len(texts),
                         batch_size,
-                        desc="🦛 CHONKING",
+                        desc="🦛",
                         disable=not show_progress_bar, 
                         unit="batch",
-                        bar_format="{desc}: [{bar:20}] {percentage:3.0f}% • {n_fmt}/{total_fmt} batches chunked [{elapsed}<{remaining}, {rate_fmt}] 🌱",
-                        ascii=' >='):
+                        bar_format="{desc} ch{bar:20}nk {percentage:3.0f}% • {n_fmt}/{total_fmt} batches chunked [{elapsed}<{remaining}, {rate_fmt}] 🌱",
+                        ascii=' o'):
             batch_texts = texts[i : min(i + batch_size, len(texts))]
             chunks.extend(self._process_text_batch(batch_texts))
         return chunks

--- a/src/chonkie/embeddings/auto.py
+++ b/src/chonkie/embeddings/auto.py
@@ -1,6 +1,5 @@
 """AutoEmbeddings is a factory class for automatically loading embeddings."""
 
-import warnings
 from typing import Any, Union
 
 from .base import BaseEmbeddings

--- a/src/chonkie/embeddings/auto.py
+++ b/src/chonkie/embeddings/auto.py
@@ -1,3 +1,5 @@
+"""AutoEmbeddings is a factory class for automatically loading embeddings."""
+
 import warnings
 from typing import Any, Union
 
@@ -63,7 +65,7 @@ class AutoEmbeddings:
                     try:
                         return embeddings_cls(model, **kwargs)
                     except Exception as e:
-                        warnings.warn(f"Failed to load {embeddings_cls.__name__}: {e}")
+                        raise ValueError(f"Failed to load {embeddings_cls.__name__}: {e}")
             except Exception:
                 # Fall back to SentenceTransformerEmbeddings if no matching implementation is found
                 from .sentence_transformer import SentenceTransformerEmbeddings

--- a/src/chonkie/embeddings/base.py
+++ b/src/chonkie/embeddings/base.py
@@ -1,5 +1,8 @@
+"""Base class for all embeddings implementations."""
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Callable, List, Union
+
+import numpy as np
 
 # for type checking
 if TYPE_CHECKING:


### PR DESCRIPTION
This pull request includes several changes to the `chonkie` package, focusing on updating progress bar descriptions, improving error messages, and adding docstrings for better code clarity. The most important changes include modifications to progress bar descriptions in multiple files, updates to error messages in `semantic.py`, and the addition of docstrings in `auto.py` and `base.py`.

### Progress bar description updates:
* [`src/chonkie/chunker/base.py`](diffhunk://#diff-10846354259652bb75e491a4bbce39e3909b204c82e70145936f910655ad97a0L249-R253): Updated progress bar descriptions in `_process_batch_sequential` and `_process_batch_multiprocessing` methods to use "doc" instead of "texts" and changed the bar format and ASCII style. [[1]](diffhunk://#diff-10846354259652bb75e491a4bbce39e3909b204c82e70145936f910655ad97a0L249-R253) [[2]](diffhunk://#diff-10846354259652bb75e491a4bbce39e3909b204c82e70145936f910655ad97a0L267-R272)
* [`src/chonkie/chunker/token.py`](diffhunk://#diff-dc86e456384b2f6c8c9a959fa1aad45eecc4923ec151319f037f5e0a17cd5099L194-R198): Updated progress bar description in `chunk_batch` method to use "batch" instead of "batches" and changed the bar format and ASCII style.

### Error message improvements:
* [`src/chonkie/chunker/semantic.py`](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L118-R124): Improved error messages in the `__init__` method to provide more specific information about invalid embedding models.
* [`src/chonkie/embeddings/auto.py`](diffhunk://#diff-0e95a5656987bd1c00cac6f2cf536710a6262257c5a3a91a4a4f04608988b5cdL66-R68): Changed the error handling in `get_embeddings` method to raise a `ValueError` instead of issuing a warning when an embedding class fails to load.

### Code clarity enhancements:
* [`src/chonkie/embeddings/auto.py`](diffhunk://#diff-0e95a5656987bd1c00cac6f2cf536710a6262257c5a3a91a4a4f04608988b5cdR1-R2): Added a docstring to describe the `AutoEmbeddings` class.
* [`src/chonkie/embeddings/base.py`](diffhunk://#diff-849579bb6030628505c4ee859c8913bd4e9d3aa3bc681e1323c23c66b010ad84R1-R6): Added a docstring to describe the base class for all embeddings implementations.