### PR TITLE
[FEAT] Support `return_type` as `texts` for direct text handling

### DIFF
--- a/src/chonkie/chunker/sdpm.py
+++ b/src/chonkie/chunker/sdpm.py
@@ -1,6 +1,6 @@
 """Semantic Double Pass Merge chunking using sentence embeddings."""
 
-from typing import Any, List, Union
+from typing import Any, List, Union, Literal
 
 from chonkie.types import SemanticChunk, Sentence
 
@@ -17,15 +17,17 @@ class SDPMChunker(SemanticChunker):
 
     Args:
         embedding_model: Sentence embedding model to use
-        similarity_threshold: Minimum similarity score to consider sentences similar
-        similarity_percentile: Minimum similarity percentile to consider sentences similar
+        mode: Mode for grouping sentences, either "cumulative" or "window"
+        threshold: Threshold for semantic similarity (0-1) or percentile (1-100), defaults to "auto"
         chunk_size: Maximum token count for a chunk
-        initial_sentences: Number of sentences to consider for initial grouping
-        skip_window: Number of chunks to skip when looking for similarities
+        similarity_window: Number of sentences to consider for similarity threshold calculation
+        min_sentences: Minimum number of sentences per chunk
         min_chunk_size: Minimum number of tokens per sentence
-
-    Methods:
-        chunk: Split text into chunks using the SDPM approach.
+        min_characters_per_sentence: Minimum number of characters per sentence
+        threshold_step: Step size for similarity threshold calculation
+        delim: Delimiters to split sentences on
+        skip_window: Number of chunks to skip when looking for similarities
+        return_type: Whether to return chunks or texts
 
     """
 
@@ -42,6 +44,7 @@ class SDPMChunker(SemanticChunker):
         threshold_step: float = 0.01,
         delim: Union[str, List[str]] = [".", "!", "?", "\n"],
         skip_window: int = 1,
+        return_type: Literal["chunks", "texts"] = "chunks",
         **kwargs
     ):
         """Initialize the SDPMChunker.
@@ -58,6 +61,7 @@ class SDPMChunker(SemanticChunker):
             threshold_step: Step size for similarity threshold calculation
             delim: Delimiters to split sentences on
             skip_window: Number of chunks to skip when looking for similarities
+            return_type: Whether to return chunks or texts
             **kwargs: Additional keyword arguments
 
         """
@@ -72,6 +76,7 @@ class SDPMChunker(SemanticChunker):
             min_characters_per_sentence=min_characters_per_sentence,
             threshold_step=threshold_step,
             delim=delim,
+            return_type=return_type,
             **kwargs
         )
         self.skip_window = skip_window

--- a/src/chonkie/chunker/sentence.py
+++ b/src/chonkie/chunker/sentence.py
@@ -33,8 +33,7 @@ class SentenceChunker(BaseChunker):
         min_characters_per_sentence: int = 12,
         approximate: bool = True,
         delim: Union[str, List[str]] = [".", "!", "?", "\n"],
-        return_type: Literal["chunks", "texts"] = "chunks",
-        **kwargs
+        return_type: Literal["chunks", "texts"] = "chunks"
     ):
         """Initialize the SentenceChunker with configuration parameters.
 
@@ -303,13 +302,16 @@ class SentenceChunker(BaseChunker):
 
         """
         chunk_text = "".join([sentence.text for sentence in sentences])
-        return SentenceChunk(
-            text=chunk_text,
-            start_index=sentences[0].start_index,
-            end_index=sentences[-1].end_index,
-            token_count=token_count,
-            sentences=sentences,
-        )
+        if self.return_type == "texts":
+            return chunk_text
+        else:
+            return SentenceChunk(
+                text=chunk_text,
+                start_index=sentences[0].start_index,
+                end_index=sentences[-1].end_index,
+                token_count=token_count,
+                sentences=sentences,
+            )
 
     def chunk(self, text: str) -> List[Chunk]:
         """Split text into overlapping chunks based on sentences while respecting token limits.
@@ -379,12 +381,7 @@ class SentenceChunker(BaseChunker):
                 chunk_text = "".join(s.text for s in chunk_sentences)
                 actual = len(self._encode(chunk_text))
     
-            if self.return_type == "chunks":
-                chunks.append(self._create_chunk(chunk_sentences, actual))
-            elif self.return_type == "texts":
-                chunks.append("".join(chunk_sentences))
-            else:
-                raise ValueError("Invalid return_type. Must be either 'chunks' or 'texts'.")
+            chunks.append(self._create_chunk(chunk_sentences, actual))
 
             # Calculate next position with overlap
             if self.chunk_overlap > 0 and split_idx < len(sentences):

--- a/src/chonkie/chunker/word.py
+++ b/src/chonkie/chunker/word.py
@@ -1,6 +1,6 @@
 """Word-based chunker."""
 import re
-from typing import Any, List, Tuple, Union
+from typing import Any, List, Tuple, Union, Literal
 
 from chonkie.types import Chunk
 
@@ -25,6 +25,7 @@ class WordChunker(BaseChunker):
         tokenizer: Union[str, Any] = "gpt2",
         chunk_size: int = 512,
         chunk_overlap: int = 128,
+        return_type: Literal["chunks", "texts"] = "chunks"
     ):
         """Initialize the WordChunker with configuration parameters.
 
@@ -32,10 +33,10 @@ class WordChunker(BaseChunker):
             tokenizer: The tokenizer instance to use for encoding/decoding
             chunk_size: Maximum number of tokens per chunk
             chunk_overlap: Maximum number of tokens to overlap between chunks
-            mode: Tokenization mode - "heuristic" (space-based) or "advanced" (handles punctuation)
+            return_type: Whether to return chunks or texts
 
         Raises:
-            ValueError: If chunk_size <= 0 or chunk_overlap >= chunk_size or invalid mode
+            ValueError: If chunk_size <= 0 or chunk_overlap >= chunk_size or invalid return_type
 
         """
         super().__init__(tokenizer)
@@ -44,9 +45,12 @@ class WordChunker(BaseChunker):
             raise ValueError("chunk_size must be positive")
         if chunk_overlap >= chunk_size:
             raise ValueError("chunk_overlap must be less than chunk_size")
+        if return_type not in ["chunks", "texts"]:
+            raise ValueError("Invalid return_type. Must be either 'chunks' or 'texts'.")    
 
         self.chunk_size = chunk_size
         self.chunk_overlap = chunk_overlap
+        self.return_type = return_type
 
     def _split_into_words(self, text: str) -> List[str]:
         """Split text into words while preserving whitespace."""
@@ -135,13 +139,18 @@ class WordChunker(BaseChunker):
                 current_chunk.append(word)
                 current_chunk_length += length
             else:
-                chunk = self._create_chunk(
-                    current_chunk,
-                    text,
-                    current_chunk_length,
-                    current_index,
-                )
-                chunks.append(chunk)
+                if self.return_type == "chunks":
+                    chunk = self._create_chunk(
+                        current_chunk,
+                        text,
+                        current_chunk_length,
+                        current_index,
+                    )
+                    chunks.append(chunk)
+                elif self.return_type == "texts":
+                    chunks.append("".join(current_chunk))
+                
+                
                 # update the current_chunk and previous chunk
                 previous_chunk_length = current_chunk_length
                 current_index = chunk.end_index
@@ -167,8 +176,11 @@ class WordChunker(BaseChunker):
 
         # Add the final chunk if it has any words
         if current_chunk:
-            chunk = self._create_chunk(current_chunk, text, current_chunk_length)
-            chunks.append(chunk)
+            if self.return_type == "chunks":
+                chunk = self._create_chunk(current_chunk, text, current_chunk_length)
+                chunks.append(chunk)
+            elif self.return_type == "texts":
+                chunks.append("".join(current_chunk))
         return chunks
 
     def __repr__(self) -> str:

--- a/tests/chunker/test_sdpm_chunker.py
+++ b/tests/chunker/test_sdpm_chunker.py
@@ -179,8 +179,9 @@ def test_sdpm_chunker_return_type(embedding_model, sample_text):
     """Test that SDPMChunker's return type is correctly set."""
     chunker = SDPMChunker(embedding_model=embedding_model, chunk_size=512, threshold=0.5, return_type="texts")
     chunks = chunker.chunk(sample_text)
+    tokenizer = embedding_model.get_tokenizer_or_token_counter()
     assert all([type(chunk) is str for chunk in chunks])
-    assert all([len(embedding_model.encode(chunk)) <= 512 for chunk in chunks])
+    assert all([len(tokenizer.encode(chunk)) <= 512 for chunk in chunks])
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/chunker/test_sdpm_chunker.py
+++ b/tests/chunker/test_sdpm_chunker.py
@@ -175,5 +175,12 @@ def test_spdm_chunker_token_counts(embedding_model, sample_text):
     token_counts = [chunker._count_tokens(chunk.text) for chunk in chunks]
     assert all([chunk.token_count == token_count for chunk, token_count in zip(chunks, token_counts)]), "All chunks must have a token count equal to the length of the encoded text"
 
+def test_sdpm_chunker_return_type(embedding_model, sample_text):
+    """Test that SDPMChunker's return type is correctly set."""
+    chunker = SDPMChunker(embedding_model=embedding_model, chunk_size=512, threshold=0.5, return_type="texts")
+    chunks = chunker.chunk(sample_text)
+    assert all([type(chunk) is str for chunk in chunks])
+    assert all([len(embedding_model.encode(chunk)) <= 512 for chunk in chunks])
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/chunker/test_semantic_chunker.py
+++ b/tests/chunker/test_semantic_chunker.py
@@ -287,6 +287,12 @@ def test_semantic_chunker_reconstruction_batch(embedding_model, sample_text):
     chunks = chunker.chunk_batch([sample_text]*10)[-1]
     assert sample_text == "".join([chunk.text for chunk in chunks])
 
+def test_semantic_chunker_return_type(embedding_model, sample_text):
+    """Test that SemanticChunker's return type is correctly set."""
+    chunker = SemanticChunker(embedding_model=embedding_model, chunk_size=512, threshold=0.5, return_type="texts")
+    chunks = chunker.chunk(sample_text)
+    assert all([type(chunk) is str for chunk in chunks])
+    assert all([len(embedding_model.encode(chunk)) <= 512 for chunk in chunks])
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/chunker/test_semantic_chunker.py
+++ b/tests/chunker/test_semantic_chunker.py
@@ -291,8 +291,9 @@ def test_semantic_chunker_return_type(embedding_model, sample_text):
     """Test that SemanticChunker's return type is correctly set."""
     chunker = SemanticChunker(embedding_model=embedding_model, chunk_size=512, threshold=0.5, return_type="texts")
     chunks = chunker.chunk(sample_text)
+    tokenizer = embedding_model.get_tokenizer_or_token_counter()
     assert all([type(chunk) is str for chunk in chunks])
-    assert all([len(embedding_model.encode(chunk)) <= 512 for chunk in chunks])
+    assert all([len(tokenizer.encode(chunk)) <= 512 for chunk in chunks])
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/chunker/test_sentence_chunker.py
+++ b/tests/chunker/test_sentence_chunker.py
@@ -171,6 +171,12 @@ def test_sentence_chunker_token_counts(tokenizer, sample_text):
     token_counts = [len(tokenizer.encode(chunk.text)) for chunk in chunks]
     assert all([chunk.token_count == token_count for chunk, token_count in zip(chunks, token_counts)]), "All chunks must have a token count equal to the length of the encoded text"
 
+def test_sentence_chunker_return_type(tokenizer, sample_text):
+    """Test that SentenceChunker's return type is correctly set."""
+    chunker = SentenceChunker(tokenizer=tokenizer, chunk_size=512, chunk_overlap=128, return_type="texts")
+    chunks = chunker.chunk(sample_text)
+    assert all([type(chunk) is str for chunk in chunks])
+    assert all([len(tokenizer.encode(chunk)) <= 512 for chunk in chunks])
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/chunker/test_token_chunker.py
+++ b/tests/chunker/test_token_chunker.py
@@ -337,5 +337,12 @@ def test_token_chunker_indices_batch(tiktokenizer, sample_text):
     chunks = chunker.chunk_batch([sample_text]*10)[-1]
     verify_chunk_indices(chunks, sample_text)
 
+def test_token_chunker_return_type(tiktokenizer, sample_text):
+    """Test that TokenChunker's return type is correctly set."""
+    chunker = TokenChunker(tokenizer=tiktokenizer, chunk_size=512, chunk_overlap=128, return_type="texts")
+    chunks = chunker.chunk(sample_text)
+    assert all([type(chunk) is str for chunk in chunks])
+    assert all([len(tiktokenizer.encode(chunk)) <= 512 for chunk in chunks])
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/chunker/test_word_chunker.py
+++ b/tests/chunker/test_word_chunker.py
@@ -214,5 +214,12 @@ def test_word_chunker_token_counts(tokenizer, sample_text):
     token_counts = [len(tokenizer.encode(chunk.text)) for chunk in chunks]
     assert all([chunk.token_count == token_count for chunk, token_count in zip(chunks, token_counts)]), "All chunks must have a token count equal to the length of the encoded text"
 
+def test_word_chunker_return_type(tokenizer, sample_text):
+    """Test that WordChunker's return type is correctly set."""
+    chunker = WordChunker(tokenizer=tokenizer, chunk_size=512, chunk_overlap=128, return_type="texts")
+    chunks = chunker.chunk(sample_text)
+    assert all([type(chunk) is str for chunk in chunks])
+    assert all([len(tokenizer.encode(chunk)) <= 512 for chunk in chunks])
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
This pull request introduces a new feature to the chunking modules, allowing them to return either chunks or raw texts based on a new parameter `return_type`. Additionally, it includes validation checks for the new parameter and updates to the chunk creation logic to accommodate this change.

### New Feature: Return Type Parameter

* [`src/chonkie/chunker/recursive.py`](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L5-R5): Added `return_type` parameter to the `__init__` method and included validation checks. Updated `_recursive_chunk` method to handle both "chunks" and "texts" return types. [[1]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L5-R5) [[2]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L24-R25) [[3]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7R34-R49) [[4]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7R211-R214) [[5]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7R247-R275)
* [`src/chonkie/chunker/sdpm.py`](diffhunk://#diff-359202635006b02c57f41dbefe88292468e723829ac8579c6086b8b54b082037L3-R3): Added `return_type` parameter to the `__init__` method and included validation checks. Updated `_create_chunk` method to handle both "chunks" and "texts" return types. [[1]](diffhunk://#diff-359202635006b02c57f41dbefe88292468e723829ac8579c6086b8b54b082037L3-R3) [[2]](diffhunk://#diff-359202635006b02c57f41dbefe88292468e723829ac8579c6086b8b54b082037L20-R30) [[3]](diffhunk://#diff-359202635006b02c57f41dbefe88292468e723829ac8579c6086b8b54b082037R47) [[4]](diffhunk://#diff-359202635006b02c57f41dbefe88292468e723829ac8579c6086b8b54b082037R64) [[5]](diffhunk://#diff-359202635006b02c57f41dbefe88292468e723829ac8579c6086b8b54b082037R79)
* [`src/chonkie/chunker/semantic.py`](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L4-R4): Added `return_type` parameter to the `__init__` method and included validation checks. Updated `_create_chunk` method to handle both "chunks" and "texts" return types. [[1]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L4-R4) [[2]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7R27-R30) [[3]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7R45) [[4]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7R63) [[5]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7R93-R94) [[6]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7R106) [[7]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L456-R483)
* [`src/chonkie/chunker/sentence.py`](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL4-R4): Added `return_type` parameter to the `__init__` method and included validation checks. Updated `_create_chunk` method to handle both "chunks" and "texts" return types. [[1]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL4-R4) [[2]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL36-R36) [[3]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cR51-R52) [[4]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cR67-R68) [[5]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cR77) [[6]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cR305-R307)
* [`src/chonkie/chunker/token.py`](diffhunk://#diff-dc86e456384b2f6c8c9a959fa1aad45eecc4923ec151319f037f5e0a17cd5099L3-R3): Added `return_type` parameter to the `__init__` method and included validation checks. Updated `chunk` method to handle both "chunks" and "texts" return types. [[1]](diffhunk://#diff-dc86e456384b2f6c8c9a959fa1aad45eecc4923ec151319f037f5e0a17cd5099L3-R3) [[2]](diffhunk://#diff-dc86e456384b2f6c8c9a959fa1aad45eecc4923ec151319f037f5e0a17cd5099R27-R35) [[3]](diffhunk://#diff-dc86e456384b2f6c8c9a959fa1aad45eecc4923ec151319f037f5e0a17cd5099R48-R51) [[4]](diffhunk://#diff-dc86e456384b2f6c8c9a959fa1aad45eecc4923ec151319f037f5e0a17cd5099R124-R126) [[5]](diffhunk://#diff-dc86e456384b2f6c8c9a959fa1aad45eecc4923ec151319f037f5e0a17cd5099R136-R141) [[6]](diffhunk://#diff-dc86e456384b2f6c8c9a959fa1aad45eecc4923ec151319f037f5e0a17cd5099R155)