### PR TITLE
[FEAT] Support Ollama Embeddings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,9 @@ Documentation = "https://docs.chonkie.ai"
 model2vec = ["model2vec>=0.3.0", "numpy>=1.23.0, <2.2"]
 st = ["sentence-transformers>=3.0.0", "numpy>=1.23.0, <2.2"]
 openai = ["openai>=1.0.0", "numpy>=1.23.0, <2.2"]
+ollama = ["ollama>=0.4.0", "numpy>=1.23.0, <2.2", "requests>=2.32.0"]
 semantic = ["model2vec>=0.3.0", "numpy>=1.23.0, <2.2"]
-all = ["sentence-transformers>=3.0.0", "numpy>=1.23.0, <2.2", "openai>=1.0.0", "model2vec>=0.3.0"]
+all = ["sentence-transformers>=3.0.0", "numpy>=1.23.0, <2.2", "openai>=1.0.0", "model2vec>=0.3.0", "ollama>=0.4.0", "numpy>=1.23.0, <2.2", "requests>=2.32.0"]
 dev = [
     "pytest>=6.2.0", 
     "pytest-cov>=4.0.0",

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -15,6 +15,7 @@ from .embeddings import (
     BaseEmbeddings,
     Model2VecEmbeddings,
     OpenAIEmbeddings,
+    OllamaEmbeddings,
     SentenceTransformerEmbeddings,
 )
 from .refinery import (
@@ -77,6 +78,7 @@ __all__ += [
     "Model2VecEmbeddings",
     "SentenceTransformerEmbeddings",
     "OpenAIEmbeddings",
+    "OllamaEmbeddings",
     "AutoEmbeddings",
 ]
 

--- a/src/chonkie/embeddings/__init__.py
+++ b/src/chonkie/embeddings/__init__.py
@@ -3,6 +3,7 @@ from .base import BaseEmbeddings
 from .model2vec import Model2VecEmbeddings
 from .openai import OpenAIEmbeddings
 from .sentence_transformer import SentenceTransformerEmbeddings
+from .ollama import OllamaEmbeddings
 
 # Add all embeddings classes to __all__
 __all__ = [
@@ -11,4 +12,5 @@ __all__ = [
     "SentenceTransformerEmbeddings",
     "OpenAIEmbeddings",
     "AutoEmbeddings",
+    "OllamaEmbeddings"
 ]

--- a/src/chonkie/embeddings/auto.py
+++ b/src/chonkie/embeddings/auto.py
@@ -24,6 +24,9 @@ class AutoEmbeddings:
         # Get Anthropic embeddings
         embeddings = AutoEmbeddings.get_embeddings("anthropic://claude-v1", api_key="...")
 
+        # Get Ollama embeddings
+        embeddings = AutoEmbeddings.get_embeddings("ollama://all-minilm")
+
     """
 
     @classmethod
@@ -52,6 +55,9 @@ class AutoEmbeddings:
             # Get Anthropic embeddings
             embeddings = AutoEmbeddings.get_embeddings("anthropic://claude-v1", api_key="...")
 
+             # Get Ollama embeddings
+            embeddings = AutoEmbeddings.get_embeddings("ollama://all-minilm")
+
         """
         # Load embeddings instance if already provided
         if isinstance(model, BaseEmbeddings):
@@ -72,9 +78,14 @@ class AutoEmbeddings:
                 try:
                     return SentenceTransformerEmbeddings(model, **kwargs)
                 except Exception as e:
-                    raise ValueError(
-                        f"Failed to load embeddings via SentenceTransformerEmbeddings: {e}"
-                    )
+                    # try with ollama - as any gguf model can be loaded through ollama
+                    from .ollama import OllamaEmbeddings
+                    try:
+                        return OllamaEmbeddings(model, **kwargs)
+                    except Exception as e:
+                        raise ValueError(
+                            f"Failed to load embeddings via SentenceTransformerEmbeddings & Ollama: {e}"
+                        )
         else:
             # get the wrapped embeddings instance
             try:

--- a/src/chonkie/embeddings/ollama.py
+++ b/src/chonkie/embeddings/ollama.py
@@ -1,0 +1,226 @@
+import importlib
+import os
+import warnings
+from typing import List, Optional
+
+import numpy as np
+
+from .base import BaseEmbeddings
+
+
+class OllamaEmbeddings(BaseEmbeddings):
+    """Ollama embeddings implementation for the local ollama serve."""
+
+    DEFAULT_MODEL = "all-minilm"                # a light-weight model
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL,
+        endpoint: Optional[str] = None,
+        max_retries: int = 3,
+        timeout: float = 60.0,
+        batch_size: int = 128,
+        show_warnings: bool = True
+    ):
+        """Initialize Ollama Embeddings.
+        
+        Args:
+            model: Name of the embedding model available through Ollama to use
+            max_retries: Maximum number of retries for failed requests,
+            timeout: Timeout in seconds for API requests
+            batch_size: Maximum number of texts to embed in one API call
+            show_warnings: Whether to show warnings about token usage
+
+        """
+        super().__init__()
+        if not self.is_available():
+            raise ImportError(
+                "Ollama package is not available. Please install it via pip."
+            )
+        else:
+            if endpoint is None: endpoint = os.getenv("OLLAMA_ENDPOINT")
+            self.is_ollama_running(endpoint)
+            from ollama import Client
+
+        # initialize the client
+        self.client = Client(
+            host=endpoint,
+            timeout=timeout
+        )
+        self.model = model
+        self._show_warnings = show_warnings
+        self._batch_size = batch_size
+        self._max_retries = max_retries
+
+        model_parameters = self.fetch_model()   # pull and get the model parameters
+        self._dimension = model_parameters["dimensions"]
+        self._context_length = model_parameters["context_length"]
+        self._num_ctx = model_parameters["num_ctx"]
+        self._tokenizer = self.count_tokens
+
+    def embed(self, text: str) -> np.ndarray:
+        """Get embeddings for a single text."""
+        token_count = self.count_tokens(text)
+        if token_count > self._context_length and self._show_warnings:
+            warnings.warn(
+                f"Text has {token_count} tokens which exceeds the maximum context window of {self._context_length}. "
+                "It will be truncated."
+            )
+        for _ in range(self._max_retries):
+            try:
+                response = self.client.embed(
+                    model=self.model,
+                    input=text,
+                    truncate=True,  # ensures input stays in the context window
+                    options={"num_ctx": max(self._num_ctx, token_count + 100)} 
+                )
+                # adding a buffer of 100 tokens here as token count is estimated.
+
+                return np.array(response.embeddings[0], dtype=np.float32)
+            except Exception as e:
+                if self._show_warnings:
+                    warnings.warn(
+                        f"There was an exception while generating embeddings. Exception: {str(e)}. Retrying..."
+                    )
+
+        raise RuntimeError(
+            "Unable to generate embeddings through Ollama."
+        )
+
+    def embed_batch(self, texts: List[str]) -> List[np.ndarray]:
+        """Get embeddings for multiple texts using batched calls"""
+        if not texts:
+            return []
+        
+        all_embeddings = []
+
+        # process in batches 
+        for i in range(0, len(texts), self._batch_size):
+            batch = texts[i : i + self._batch_size]
+
+            # check token counts and warn if necessary
+            token_counts = self.count_tokens_batch(batch)
+            if self._show_warnings:
+                for _, count in zip(batch, token_counts):
+                    if count > self._context_length:
+                        warnings.warn(
+                            f"Text has {count} tokens which exceeds the model's context length of {self._context_length}. "
+                            "It will be truncated."
+                        )
+            try:
+                for _ in range(self._max_retries):
+                    try:
+                        response = self.client.embed(
+                            model=self.model,
+                            input=batch,
+                            truncate=True,  # ensures input stays in the context window
+                            options={"num_ctx": max(self._num_ctx, count + 100)} 
+                        )
+
+                        embeddings = [
+                            np.array(e, dtype=np.float32) for e in response.embeddings
+                        ]
+
+                        all_embeddings.extend(embeddings)
+                        break
+                    except Exception as e:
+                        if self._show_warnings:
+                            warnings.warn(
+                                f"There was an exception while generating embeddings. Exception: {str(e)}. Retrying..."
+                            )
+            except Exception as e:
+                # if the batch processing fails, try one by one
+                if len(batch) > 1:
+                    warnings.warn(
+                        f"Batch embedding failed: {str(e)}. Trying one by one."
+                    )
+                    individual_embeddings = [self.embed(text) for text in batch]
+                    all_embeddings.extend(individual_embeddings)
+                else:
+                    raise e
+                
+        return all_embeddings
+
+    def count_tokens(self, text: str) -> int:
+        """Count tokens in text using the model's tokenizer."""
+        # using token estimation
+        # refer: sentence.py -> _estimate_token_counts
+        CHARS_PER_TOKEN = 6.0  # Avg. char per token for llama3 is b/w 6-7
+        return max(1, len(text) // CHARS_PER_TOKEN)
+    
+    def count_tokens_batch(self, texts: List[str]) -> List[int]:
+        """Count tokens in multiple texts."""
+        return [self.count_tokens(text) for text in texts] 
+
+    def similarity(self, u: np.ndarray, v: np.ndarray) -> float:
+        """Compute cosine similarity between two embeddings."""
+        return np.divide(
+            np.dot(u, v), np.linalg.norm(u) * np.linalg.norm(v), dtype=float
+        )
+    
+    @property
+    def dimension(self) -> int:
+        """Return the embedding dimension."""
+        return self._dimension
+    
+    def get_tokenizer_or_token_counter(self):
+        """Returns None till the tokenization part is updated."""
+        return self._tokenizer
+
+    def fetch_model(self) -> dict:
+        """
+        Pull the model from the ollama library and return the required parameters.
+        Raises a ValueError if the model is neither present in the ollama hub nor loaded manually.
+        """
+        try:
+            import ollama
+            ollama.show(self.model)
+        except Exception:
+            if self._show_warnings:
+                warnings.warn(
+                    f"{self.model} is not available locally. Downloading from the Ollama hub. This may take a while."
+                )
+            try:
+                ollama.pull(self.model)    # pull the model from the hub
+            except Exception:
+                raise ValueError(
+                    f"Ollama doesn't provide the given model in the hub. Please make sure the model's ID is correct or load the model manually."
+                )
+
+        model_file = self.client.show(self.model)
+        model_architecture = model_file.modelinfo["general.architecture"]
+        
+        context_length = model_file.modelinfo[f"{model_architecture}.context_length"]
+        dimensions = model_file.modelinfo[f"{model_architecture}.embedding_length"]
+        for param in model_file.parameters.split("\n"):
+            key, value = param.split()
+            if key == "num_ctx": num_ctx = float(value)
+            break
+
+    
+        return {
+            "context_length": context_length,
+            "num_ctx": num_ctx,
+            "dimensions": dimensions
+        }
+
+        
+    @classmethod
+    def is_available(cls):
+        """Check if the Ollama package is available."""
+        return importlib.util.find_spec("ollama") is not None
+
+    @classmethod
+    def is_ollama_running(cls, url: str) -> bool:
+        """Check if the Ollama server is up and running"""
+        try:
+            import requests
+            response = requests.get(url)
+        except requests.ConnectionError:
+            raise ConnectionError(
+                f"Ollama is not running at {url}. Please provide a valid endpoint or make sure the Ollama is up and running at the default/given endpoint. Refer https://github.com/ollama/ollama."
+            )
+        return response.status_code == 200 and response.text == "Ollama is running"
+    
+    def __repr__(self) -> str:
+        return f"OllamaEmbeddings(model={self.model})"

--- a/src/chonkie/embeddings/registry.py
+++ b/src/chonkie/embeddings/registry.py
@@ -6,7 +6,7 @@ from .base import BaseEmbeddings
 from .model2vec import Model2VecEmbeddings
 from .openai import OpenAIEmbeddings
 from .sentence_transformer import SentenceTransformerEmbeddings
-
+from .ollama import OllamaEmbeddings
 
 @dataclass
 class RegistryEntry:
@@ -159,3 +159,13 @@ EmbeddingsRegistry.register(
     pattern=r"^minishlab/|^minishlab/potion-base-|^minishlab/potion-|^potion-",
     supported_types=["Model2Vec", "model2vec"],
 )
+
+# Register Ollama embeddings
+EmbeddingsRegistry.register(
+    "ollama",
+    OllamaEmbeddings,
+    pattern=r"^ollama|^snowflake-arctic-embed|^bge-|^granite-embedding"
+)
+EmbeddingsRegistry.register("nomic-embed-text", OllamaEmbeddings)
+EmbeddingsRegistry.register("mxbai-embed-large", OllamaEmbeddings)
+EmbeddingsRegistry.register("paraphrase-multilingual", OllamaEmbeddings)

--- a/tests/embeddings/test_auto_embeddings.py
+++ b/tests/embeddings/test_auto_embeddings.py
@@ -1,11 +1,13 @@
 """Tests for the AutoEmbeddings class."""
 
 import pytest
+import os
 
 from chonkie import AutoEmbeddings
 from chonkie.embeddings.model2vec import Model2VecEmbeddings
 from chonkie.embeddings.openai import OpenAIEmbeddings
 from chonkie.embeddings.sentence_transformer import SentenceTransformerEmbeddings
+from chonkie.embeddings.ollama import OllamaEmbeddings
 
 
 @pytest.fixture
@@ -30,6 +32,12 @@ def sentence_transformer_identifier_small():
 def openai_identifier():
     """Fixture providing an OpenAI identifier."""
     return "text-embedding-3-small"
+
+
+@pytest.fixture
+def ollama_identifier():
+    """Fixture providing an Ollama identifier."""
+    return "all-minilm"
 
 
 @pytest.fixture
@@ -68,6 +76,19 @@ def test_auto_embeddings_openai(openai_identifier):
     )
     assert isinstance(embeddings, OpenAIEmbeddings)
     assert embeddings.model == openai_identifier
+
+
+@pytest.mark.skipif(
+    "OLLAMA_ENDPOINT" not in os.environ,
+    reason="Skipping test because OLLAMA_ENDPOINT is not defined",
+)
+def test_auto_embeddings_ollama(ollama_identifier):
+    """Test that the AutoEmbeddings class can get Ollama embeddings."""
+    embeddings = AutoEmbeddings.get_embeddings(
+        ollama_identifier
+    )
+    assert isinstance(embeddings, OllamaEmbeddings)
+    assert embeddings.model == ollama_identifier 
 
 
 def test_auto_embeddings_invalid_identifier(invalid_identifier):

--- a/tests/embeddings/test_ollama_embeddings.py
+++ b/tests/embeddings/test_ollama_embeddings.py
@@ -1,0 +1,117 @@
+import numpy as np
+import pytest
+import os
+
+from chonkie.embeddings.ollama import OllamaEmbeddings
+
+@pytest.fixture
+def embedding_model():
+    return OllamaEmbeddings(model="all-minilm", endpoint=os.getenv("OLLAMA_ENDPOINT"))
+
+
+@pytest.fixture
+def sample_text():
+    return "This is a sample text for testing."
+
+
+@pytest.fixture
+def sample_texts():
+    return [
+        "This is the first sample text.",
+        "Here is another example sentence.",
+        "Testing embeddings with multiple sentences.",
+    ]
+
+
+@pytest.mark.skipif(
+    "OLLAMA_ENDPOINT" not in os.environ,
+    reason="Skipping test because OLLAMA_ENDPOINT is not defined",
+)
+def test_initialization_with_model_name():
+    embeddings = OllamaEmbeddings("all-minilm")
+    assert embeddings.model == "all-minilm"
+    assert embeddings.model is not None
+
+
+@pytest.mark.skipif(
+    "OLLAMA_ENDPOINT" not in os.environ,
+    reason="Skipping test because OLLAMA_ENDPOINT is not defined",
+)
+def test_embed_single_text(embedding_model, sample_text):
+    embedding = embedding_model.embed(sample_text)
+    assert isinstance(embedding, np.ndarray)
+    assert embedding.shape == (embedding_model.dimension,)
+
+
+@pytest.mark.skipif(
+    "OLLAMA_ENDPOINT" not in os.environ,
+    reason="Skipping test because OLLAMA_ENDPOINT is not defined",
+)
+def test_embed_batch_texts(embedding_model, sample_texts):
+    embeddings = embedding_model.embed_batch(sample_texts)
+    assert isinstance(embeddings, list)
+    assert len(embeddings) == len(sample_texts)
+    assert all(isinstance(embedding, np.ndarray) for embedding in embeddings)
+    assert all(
+        embedding.shape == (embedding_model.dimension,) for embedding in embeddings
+    )
+
+
+@pytest.mark.skipif(
+    "OLLAMA_ENDPOINT" not in os.environ,
+    reason="Skipping test because OLLAMA_ENDPOINT is not defined",
+)
+def test_count_tokens_single_text(embedding_model, sample_text):
+    token_count = embedding_model.count_tokens(sample_text)
+    assert isinstance(token_count, float)
+    assert token_count > 0
+
+
+@pytest.mark.skipif(
+    "OLLAMA_ENDPOINT" not in os.environ,
+    reason="Skipping test because OLLAMA_ENDPOINT is not defined",
+)
+def test_count_tokens_batch_texts(embedding_model, sample_texts):
+    token_counts = embedding_model.count_tokens_batch(sample_texts)
+    assert isinstance(token_counts, list)
+    assert len(token_counts) == len(sample_texts)
+    assert all(isinstance(count, float) for count in token_counts)
+    assert all(count > 0 for count in token_counts)
+
+
+@pytest.mark.skipif(
+    "OLLAMA_ENDPOINT" not in os.environ,
+    reason="Skipping test because OLLAMA_ENDPOINT is not defined",
+)
+def test_similarity(embedding_model, sample_texts):
+    embeddings = embedding_model.embed_batch(sample_texts)
+    similarity_score = embedding_model.similarity(embeddings[0], embeddings[1])
+    assert isinstance(similarity_score, float)
+    assert 0.0 <= similarity_score <= 1.0
+
+
+@pytest.mark.skipif(
+    "OLLAMA_ENDPOINT" not in os.environ,
+    reason="Skipping test because OLLAMA_ENDPOINT is not defined",
+)
+def test_dimension_property(embedding_model):
+    assert isinstance(embedding_model.dimension, int)
+    assert embedding_model.dimension > 0
+
+
+def test_is_available():
+    assert OllamaEmbeddings.is_available() is True
+
+
+@pytest.mark.skipif(
+    "OLLAMA_ENDPOINT" not in os.environ,
+    reason="Skipping test because OLLAMA_ENDPOINT is not defined",
+)
+def test_repr(embedding_model):
+    repr_str = repr(embedding_model)
+    assert isinstance(repr_str, str)
+    assert repr_str.startswith("OllamaEmbeddings")
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
- added support for Ollama Embeddings
- added the same to the registry to support AutoEmbeddings.
- added tests for the same.

Key things to notice:
1. Ollama doesn't provide a tokenizer internally. So, currently using token estimation as an alternative instead of mapping every tokenizer from HF to the model. This may raise inaccuracy in increasing the window, added a buffer of 100 tokens as there is nothing to lose because `num_ctx` caps at the context length anyway. Did not go for mapping each tokenizer with the model (which works partially) because Ollama will expose the tokenizer API anytime soon. Refer [here](https://github.com/ollama/ollama/pull/8106).
2. An added dependency `requests` for checking whether the Ollama is running at the provided endpoint or not. To remove the dependency, please suggest anything else that works. 
3. Pulling a model that did not yet exist may take a while and the flow stalls there. Need a suggestion for a better workaround.
4. In AutoEmbeddings, has some intersection with the sentence_transformers models. Did not know whether it is correct or wrong to proceed with this. It doesn't raise an issue in any manner though. 