### PR TITLE
LiteLLM Integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,9 @@ model2vec = ["model2vec>=0.1.0", "numpy>=1.23.0, <2.2"]
 st = ["sentence-transformers>=3.0.0", "numpy>=1.23.0, <2.2"]
 openai = ["openai>=1.0.0", "numpy>=1.23.0, <2.2"]
 semantic = ["model2vec>=0.1.0", "numpy>=1.23.0, <2.2"]
-all = ["sentence-transformers>=3.0.0", "numpy>=1.23.0, <2.2", "openai>=1.0.0", "model2vec>=0.1.0"]
+litellm = ["litellm>=1.57.10", "numpy>=1.23.0, <2.2"]
+
+all = ["sentence-transformers>=3.0.0", "numpy>=1.23.0, <2.2", "openai>=1.0.0", "model2vec>=0.1.0", "litellm>=1.57.10"]
 dev = [
     "pytest>=6.2.0", 
     "pytest-cov>=4.0.0",

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -16,6 +16,7 @@ from .embeddings import (
     Model2VecEmbeddings,
     OpenAIEmbeddings,
     SentenceTransformerEmbeddings,
+    LiteLLMEmbeddings,
 )
 from .refinery import (
     BaseRefinery,
@@ -78,6 +79,7 @@ __all__ += [
     "SentenceTransformerEmbeddings",
     "OpenAIEmbeddings",
     "AutoEmbeddings",
+    "LiteLLMEmbeddings",
 ]
 
 # Add all refinery classes to __all__

--- a/src/chonkie/embeddings/__init__.py
+++ b/src/chonkie/embeddings/__init__.py
@@ -3,6 +3,7 @@ from .base import BaseEmbeddings
 from .model2vec import Model2VecEmbeddings
 from .openai import OpenAIEmbeddings
 from .sentence_transformer import SentenceTransformerEmbeddings
+from .litellm import LiteLLMEmbeddings
 
 # Add all embeddings classes to __all__
 __all__ = [
@@ -11,4 +12,5 @@ __all__ = [
     "SentenceTransformerEmbeddings",
     "OpenAIEmbeddings",
     "AutoEmbeddings",
+    "LiteLLMEmbeddings",
 ]

--- a/src/chonkie/embeddings/auto.py
+++ b/src/chonkie/embeddings/auto.py
@@ -23,6 +23,9 @@ class AutoEmbeddings:
         # Get Anthropic embeddings
         embeddings = AutoEmbeddings.get_embeddings("anthropic://claude-v1", api_key="...")
 
+        # Get LiteLLM embeddings
+        embeddings = AutoEmbeddings.get_embeddings("huggingface/microsoft/codebert-base", api_key="...")
+
     """
 
     @classmethod
@@ -50,6 +53,9 @@ class AutoEmbeddings:
 
             # Get Anthropic embeddings
             embeddings = AutoEmbeddings.get_embeddings("anthropic://claude-v1", api_key="...")
+
+            # Get LiteLLM embeddings
+            embeddings = AutoEmbeddings.get_embeddings("huggingface/microsoft/codebert-base", api_key="...")
 
         """
         # Load embeddings instance if already provided

--- a/src/chonkie/embeddings/litellm.py
+++ b/src/chonkie/embeddings/litellm.py
@@ -1,0 +1,148 @@
+import importlib
+from litellm import embedding
+from litellm import token_counter
+from typing import Callable, List, Optional
+import os
+import time
+import numpy as np
+
+from .base import BaseEmbeddings
+
+
+class LiteLLMEmbeddings(BaseEmbeddings):
+
+    def __init__(
+        self,
+        model: str = 'huggingface/microsoft/codebert-base',
+        input: List[str] = "Hello, my dog is cute",
+        user: str = None,
+        dimensions: Optional[int] = None,
+        api_key: Optional[str] = None,
+        api_type: Optional[str] = None,
+        api_version: Optional[str] = None,
+        api_base: Optional[str] = None,
+        encoding_format: Optional[str] = None,
+        timeout: Optional[int] = 300,
+        input_type: Optional[str] = "feature-extraction",
+    ):
+        """Initialize LiteLLM embeddings.
+
+        Args:
+            model: Name of the LiteLLM embedding model to use
+            input: Text to embed
+            user: User ID for API requests
+            dimensions: Number of dimensions for the embedding model
+            api_key: API key for the model
+            api_type: Type of API to use
+            api_version: Version of the API to use
+            api_base: Base URL for the API
+            encoding_format: Encoding format for the input text
+            timeout: Timeout in seconds for API requests
+
+        """
+        super().__init__()
+        if not self.is_available():
+            raise ImportError(
+                "LiteLLM package is not available. Please install it via pip."
+            )
+        else:
+            # Check if LiteLLM works with given parameters
+            try:
+                api_key = api_key if api_key is not None else os.environ.get("HUGGINGFACE_API_KEY")
+                my_list = []
+                my_list.append(input)
+                response = embedding(model=model, input=my_list, user=user, dimensions=dimensions, api_key=api_key, api_type=api_type, api_version=api_version, api_base=api_base, encoding_format=encoding_format, timeout=timeout)
+            except Exception as e:
+                raise ValueError(f"LiteLLM failed to initialize with the given parameters: {e}")
+            else:
+                self.kwargs = {
+                    "user": user,
+                    "dimensions": dimensions,
+                    "api_key": api_key,
+                    "api_type": api_type,
+                    "api_version": api_version,
+                    "api_base": api_base,
+                    "encoding_format": encoding_format,
+                    "timeout": timeout,
+                }
+                self.model = model
+                if dimensions is None:
+                    self._dimension = len(response.data[0]['embedding'])
+                else: 
+                    self._dimension = dimensions
+   
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+        
+    
+    def embed(self, text: str) -> "np.ndarray":
+        if isinstance(text, str):
+            text = [text]
+        retries = 5  # Number of retries
+        wait_time = 10  # Wait time between retries
+        for i in range(retries):
+            try:
+                response = embedding(model=self.model, input=text, **self.kwargs)
+            except Exception as e:
+                print(f"Attempt {i+1}/{retries}: Model is still loading, retrying in {wait_time} seconds...")
+                time.sleep(wait_time)
+            else:
+                break
+        embeddings = response.data[0]['embedding']
+        return np.array(embeddings)
+
+    def embed_batch(self, texts: List[str]) -> List["np.ndarray"]:
+        if isinstance(texts, str):
+            texts = [texts]
+        retries = 5  # Number of retries
+        wait_time = 10  # Wait time between retries
+        for i in range(retries):
+            try:
+                responses = embedding(
+                    model=self.model,
+                    input=texts,
+                    **self.kwargs 
+                )
+                # Exit the loop if successful
+            except Exception as e:
+                print(f"Attempt {i+1}/{retries}: Model is still loading, retrying in {wait_time} seconds...")
+                time.sleep(wait_time)
+            else:
+                break
+
+        # response = embedding(model=self.model_name, input=texts, **self.kwargs)
+        np_embeddings = []
+        # np_embeddings.append([entry['embedding'] for entry in responses.data])
+        np_embeddings.extend(np.array(entry['embedding']) for entry in responses["data"])
+        return np_embeddings
+
+    def count_tokens(self, text: str) -> int:
+        return token_counter(model=self.model, text=text)
+
+    def count_tokens_batch(self, texts: List[str]) -> List[int]:
+        token_list = []
+        for i in texts:
+            token_list.append(token_counter(model=self.model, text=i))
+        return token_list
+    
+    def _tokenizer_helper(self, string: str) -> int:
+        return token_counter(model=self.model, text=str)
+
+    def get_tokenizer_or_token_counter(self) -> "Callable[[str], int]":
+        return self._tokenizer_helper
+        
+
+    def similarity(self, u: np.ndarray, v: np.ndarray) -> float:
+        """Compute cosine similarity between two embeddings."""
+        return np.divide(
+            np.dot(u, v), np.linalg.norm(u) * np.linalg.norm(v), dtype=float
+        )
+        
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return importlib.util.find_spec("litellm") is not None
+
+    def __repr__(self) -> str:
+        return f"LiteLLMEmbeddings(model={self.model})"

--- a/src/chonkie/embeddings/registry.py
+++ b/src/chonkie/embeddings/registry.py
@@ -6,7 +6,7 @@ from .base import BaseEmbeddings
 from .model2vec import Model2VecEmbeddings
 from .openai import OpenAIEmbeddings
 from .sentence_transformer import SentenceTransformerEmbeddings
-
+from .litellm import LiteLLMEmbeddings
 
 @dataclass
 class RegistryEntry:
@@ -158,4 +158,11 @@ EmbeddingsRegistry.register(
     Model2VecEmbeddings,
     pattern=r"^minishlab/|^minishlab/potion-base-|^minishlab/potion-|^potion-",
     supported_types=["Model2Vec", "model2vec"],
+)
+
+# Register LiteLLM embeddings
+EmbeddingsRegistry.register(
+    "litellm",
+    LiteLLMEmbeddings,
+    pattern=r"^litellm/|^huggingface/"
 )

--- a/tests/embeddings/test_auto_embeddings.py
+++ b/tests/embeddings/test_auto_embeddings.py
@@ -7,6 +7,7 @@ from chonkie.embeddings.model2vec import Model2VecEmbeddings
 from chonkie.embeddings.openai import OpenAIEmbeddings
 from chonkie.embeddings.sentence_transformer import SentenceTransformerEmbeddings
 
+from chonkie.embeddings.litellm import LiteLLMEmbeddings
 
 @pytest.fixture
 def model2vec_identifier():
@@ -31,6 +32,10 @@ def openai_identifier():
     """Fixture providing an OpenAI identifier."""
     return "text-embedding-3-small"
 
+@pytest.fixture
+def litellm_identifier():
+    """Fixture providing an LiteLLM identifier."""
+    return "huggingface/microsoft/codebert-base"
 
 @pytest.fixture
 def invalid_identifier():
@@ -68,6 +73,14 @@ def test_auto_embeddings_openai(openai_identifier):
     )
     assert isinstance(embeddings, OpenAIEmbeddings)
     assert embeddings.model == openai_identifier
+
+def test_auto_embeddings_litellm(litellm_identifier):
+    """Test that the AutoEmbeddings class can get LiteLLM embeddings."""
+    embeddings = AutoEmbeddings.get_embeddings(
+        litellm_identifier, api_key="your_litellm_api_key"
+    )
+    assert isinstance(embeddings, LiteLLMEmbeddings)
+    assert embeddings.model == litellm_identifier
 
 
 def test_auto_embeddings_invalid_identifier(invalid_identifier):

--- a/tests/embeddings/test_litellm_embeddings.py
+++ b/tests/embeddings/test_litellm_embeddings.py
@@ -1,0 +1,119 @@
+import os
+
+import numpy as np
+import pytest
+
+from chonkie.embeddings.litellm import LiteLLMEmbeddings
+
+@pytest.mark.timeout(60)
+@pytest.fixture
+def embedding_model():
+    api_key = os.environ.get("HUGGINGFACE_API_KEY")
+    return LiteLLMEmbeddings(api_key=api_key)
+
+
+@pytest.fixture
+def sample_text():
+    return "This is a sample text for testing."
+
+
+@pytest.fixture
+def sample_texts():
+    return [
+        "This is the first sample text.",
+        "Here is another example sentence.",
+        "Testing embeddings with multiple sentences.",
+    ]
+
+@pytest.mark.timeout(60)
+@pytest.mark.skipif(
+    "HUGGINGFACE_API_KEY" not in os.environ,
+    reason="Skipping test because HUGGINGFACE_API_KEY is not defined",
+)
+def test_initialization_with_model_name():
+    embeddings = LiteLLMEmbeddings()
+    assert embeddings.model == 'huggingface/microsoft/codebert-base'
+
+@pytest.mark.timeout(60)
+@pytest.mark.skipif(
+    "HUGGINGFACE_API_KEY" not in os.environ,
+    reason="Skipping test because HUGGINGFACE_API_KEY is not defined",
+)
+def test_embed_single_text(embedding_model, sample_text):
+    embedding = embedding_model.embed(sample_text)
+    assert isinstance(embedding, np.ndarray)
+    assert embedding.shape == (embedding_model.dimension,)
+
+@pytest.mark.timeout(60)
+@pytest.mark.skipif(
+    "HUGGINGFACE_API_KEY" not in os.environ,
+    reason="Skipping test because HUGGINGFACE_API_KEY is not defined",
+)
+def test_embed_batch_texts(embedding_model, sample_texts):
+    embeddings = embedding_model.embed_batch(sample_texts)
+    assert isinstance(embeddings, list)
+    assert len(embeddings) == len(sample_texts)
+    assert all(isinstance(embedding, np.ndarray) for embedding in embeddings)
+    assert all(
+        embedding.shape == (embedding_model.dimension,) for embedding in embeddings
+    )
+
+@pytest.mark.timeout(60)
+@pytest.mark.skipif(
+    "HUGGINGFACE_API_KEY" not in os.environ,
+    reason="Skipping test because HUGGINGFACE_API_KEY is not defined",
+)
+def test_count_tokens_single_text(embedding_model, sample_text):
+    token_count = embedding_model.count_tokens(sample_text)
+    assert isinstance(token_count, int)
+    assert token_count > 0
+
+@pytest.mark.timeout(60)
+@pytest.mark.skipif(
+    "HUGGINGFACE_API_KEY" not in os.environ,
+    reason="Skipping test because HUGGINGFACE_API_KEY is not defined",
+)
+def test_count_tokens_batch_texts(embedding_model, sample_texts):
+    token_counts = embedding_model.count_tokens_batch(sample_texts)
+    assert isinstance(token_counts, list)
+    assert len(token_counts) == len(sample_texts)
+    assert all(isinstance(count, int) for count in token_counts)
+    assert all(count > 0 for count in token_counts)
+
+@pytest.mark.timeout(60)
+@pytest.mark.skipif(
+    "HUGGINGFACE_API_KEY" not in os.environ,
+    reason="Skipping test because HUGGINGFACE_API_KEY is not defined",
+)
+def test_similarity(embedding_model, sample_texts):
+    embeddings = embedding_model.embed_batch(sample_texts)
+    similarity_score = embedding_model.similarity(embeddings[0], embeddings[1])
+    assert isinstance(similarity_score, float)
+    assert 0.0 <= similarity_score <= 1.0
+
+@pytest.mark.timeout(60)
+@pytest.mark.skipif(
+    "HUGGINGFACE_API_KEY" not in os.environ,
+    reason="Skipping test because HUGGINGFACE_API_KEY is not defined",
+)
+def test_dimension_property(embedding_model):
+    assert isinstance(embedding_model.dimension, int)
+    assert embedding_model.dimension > 0
+
+
+def test_is_available():
+    assert LiteLLMEmbeddings.is_available() is True
+
+@pytest.mark.timeout(60)
+@pytest.mark.skipif(
+    "HUGGINGFACE_API_KEY" not in os.environ,
+    reason="Skipping test because HUGGINGFACE_API_KEY is not defined",
+)
+def test_repr(embedding_model):
+    repr_str = repr(embedding_model)
+    assert isinstance(repr_str, str)
+    assert repr_str.startswith("LiteLLMEmbeddings")
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
added litellm support to identify and embed with any Huggingface embedding model that has feature extraction
added the same to the registry to support AutoEmbeddings.
added tests for the same.
key things to notice:

timeout is dependent on model size, since the model needs to be loaded onto the local hardware first.
context length, dimensions, and such measures are dependent on the model
token_counter is a callable from litellm, which would also need time to load. 
currently only supports huggingface models. Litellm can support more models such as voyage, mistral, etc, but the API keys should be given in parameters. 
