### PR TITLE
[FEAT] Add support for callable `token_counter` as input for rule-based Chunkers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Documentation](https://img.shields.io/badge/docs-chonkie.ai-blue.svg)](https://docs.chonkie.ai)
 ![Package size](https://img.shields.io/badge/size-11.2MB-blue)
 [![Downloads](https://static.pepy.tech/badge/chonkie)](https://pepy.tech/project/chonkie)
-[![Discord](https://dcbadge.limes.pink/api/server/https://discord.gg/nMYNVyuB5Y?style=flat)](https://discord.gg/rYYp6DC4cv)
+[![Discord](https://dcbadge.limes.pink/api/server/https://discord.gg/rYYp6DC4cv?style=flat)](https://discord.gg/rYYp6DC4cv)
 [![GitHub stars](https://img.shields.io/github/stars/bhavnicksm/chonkie.svg)](https://github.com/bhavnicksm/chonkie/stargazers)
 
 _The no-nonsense RAG chunking library that's lightweight, lightning-fast, and ready to CHONK your texts_

--- a/src/chonkie/chunker/recursive.py
+++ b/src/chonkie/chunker/recursive.py
@@ -2,7 +2,7 @@
 from bisect import bisect_left
 from functools import lru_cache
 from itertools import accumulate
-from typing import Any, List, Optional, Union, Literal
+from typing import Any, Callable, List, Optional, Union, Literal
 
 from chonkie.chunker.base import BaseChunker
 from chonkie.types import Chunk, RecursiveChunk, RecursiveLevel, RecursiveRules
@@ -18,26 +18,26 @@ class RecursiveChunker(BaseChunker):
     """
 
     def __init__(self,
-                 tokenizer: Union[str, Any] = "gpt2",
+                 tokenizer_or_token_counter: Union[str, Callable, Any] = "gpt2",
                  chunk_size: int = 512,
-                 rules: RecursiveRules = RecursiveRules(), 
                  min_characters_per_chunk: int = 12,
+                 rules: RecursiveRules = RecursiveRules(), 
                  return_type: Literal["chunks", "texts"] = "chunks"
                  ) -> None:
         """Initialize the recursive chunker.
 
         Args:
-            tokenizer: The tokenizer to use for encoding/decoding.
+            tokenizer_or_token_counter: The tokenizer or token counter to use for encoding/decoding.
             chunk_size: The size of the chunks to return.
-            rules: The rules to use for chunking.
             min_characters_per_chunk: The minimum number of characters per chunk.
+            rules: The rules to use for chunking.
             return_type: Whether to return chunks or texts.
         
         Raises:
             ValueError: If parameters are invalid.
 
         """
-        super().__init__(tokenizer)
+        super().__init__(tokenizer_or_token_counter=tokenizer_or_token_counter)
         
         if chunk_size <= 0:
             raise ValueError("chunk_size must be positive")

--- a/src/chonkie/chunker/word.py
+++ b/src/chonkie/chunker/word.py
@@ -1,6 +1,6 @@
 """Word-based chunker."""
 import re
-from typing import Any, List, Tuple, Union, Literal
+from typing import Any, Callable, List, Tuple, Union, Literal
 
 from chonkie.types import Chunk
 
@@ -22,7 +22,7 @@ class WordChunker(BaseChunker):
 
     def __init__(
         self,
-        tokenizer: Union[str, Any] = "gpt2",
+        tokenizer_or_token_counter: Union[str, Callable, Any] = "gpt2",
         chunk_size: int = 512,
         chunk_overlap: int = 128,
         return_type: Literal["chunks", "texts"] = "chunks"
@@ -30,7 +30,7 @@ class WordChunker(BaseChunker):
         """Initialize the WordChunker with configuration parameters.
 
         Args:
-            tokenizer: The tokenizer instance to use for encoding/decoding
+            tokenizer_or_token_counter: The tokenizer or token counter to use for encoding/decoding
             chunk_size: Maximum number of tokens per chunk
             chunk_overlap: Maximum number of tokens to overlap between chunks
             return_type: Whether to return chunks or texts
@@ -39,7 +39,7 @@ class WordChunker(BaseChunker):
             ValueError: If chunk_size <= 0 or chunk_overlap >= chunk_size or invalid return_type
 
         """
-        super().__init__(tokenizer)
+        super().__init__(tokenizer_or_token_counter=tokenizer_or_token_counter)
 
         if chunk_size <= 0:
             raise ValueError("chunk_size must be positive")
@@ -108,8 +108,7 @@ class WordChunker(BaseChunker):
         words = [
             word for word in words if word != ""
         ]  # Add space in the beginning because tokenizers usually split that differently
-        encodings = self._encode_batch(words)
-        return [len(encoding) for encoding in encodings]
+        return [self._count_tokens(word) for word in words]
 
     def chunk(self, text: str) -> List[Chunk]:
         """Split text into overlapping chunks based on words while respecting token limits.


### PR DESCRIPTION
This pull request includes several changes to the `chonkie` library, focusing primarily on modifying the chunker classes to support both tokenizers and token counters. Additionally, there are some minor updates to the README file.

### Enhancements to Chunker Classes:
* Updated `RecursiveChunker`, `SentenceChunker`, and `WordChunker` to accept either a tokenizer or a token counter by changing the `tokenizer` parameter to `tokenizer_or_token_counter` and updating the corresponding `super().__init__` calls. [[1]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L21-R40) [[2]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL29-R29) [[3]](diffhunk://#diff-37c569b0fda38e8c01d37b59e041720870686bd0348020e80790e21c07b4c1f9L25-R33)
* Removed the `_get_token_counts` method from `SentenceChunker` and replaced its usage with `_count_tokens_batch` to improve token counting accuracy. [[1]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL195-L208) [[2]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL251-R237)
* Replaced direct calls to `_encode` with `_count_tokens` in `SentenceChunker` to streamline token counting. [[1]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL368-R354) [[2]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL382-R368)
* Simplified token counting in `WordChunker` by using `_count_tokens` instead of `_encode_batch`.

### Minor Updates:
* Fixed the Discord badge URL in the `README.md` file.