### PR TITLE
[Feat] Add `include_delim='next'` as an optional argument in SentenceChunker and RecursiveChunker

### DIFF
--- a/src/chonkie/chunker/recursive.py
+++ b/src/chonkie/chunker/recursive.py
@@ -59,7 +59,12 @@ class RecursiveChunker(BaseChunker):
         # At every delimiter, replace it with the sep   
         if rule.delimiters:
             for delimiter in rule.delimiters:
-                text = text.replace(delimiter, delimiter + sep)
+                if rule.include_delim == "prev":
+                    text = text.replace(delimiter, delimiter + sep)
+                elif rule.include_delim == "next":
+                    text = text.replace(delimiter, sep + delimiter)
+                else:
+                    text = text.replace(delimiter, sep)
 
             # Split the text at the sep
             splits = [s for s in text.split(sep) if s != ""]

--- a/src/chonkie/types.py
+++ b/src/chonkie/types.py
@@ -1,7 +1,7 @@
 """Dataclasses for Chonkie."""
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union, Literal
 
 if TYPE_CHECKING:
     import numpy as np
@@ -248,6 +248,7 @@ class RecursiveLevel:
 
     delimiters: Union[List[str], str, None] = None
     whitespace: bool = False
+    include_delim: Union[Literal["prev", "next", None], None] = "prev"
 
     def __post_init__(self):
         """Post-initialize the recursive level."""
@@ -270,11 +271,9 @@ class RecursiveLevel:
                 
     def __repr__(self) -> str:
         """Get a string representation of the recursive level."""
-        return f"RecursiveLevel(delimiters={self.delimiters}, whitespace={self.whitespace})"
-    
-    def __str__(self) -> str:
-        """Get a string representation of the recursive level."""
-        return f"RecursiveLevel(delimiters={self.delimiters}, whitespace={self.whitespace})"
+        return (f"RecursiveLevel(delimiters={self.delimiters}, "
+                f"whitespace={self.whitespace}, "
+                f"include_delim={self.include_delim})")
 
 @dataclass
 class RecursiveRules: 
@@ -349,11 +348,6 @@ class RecursiveRules:
     def __repr__(self) -> str:
         """Get a string representation of the recursive rules."""
         return f"RecursiveRules(levels={self.levels})"
-    
-    def __str__(self) -> str:
-        """Get a string representation of the recursive rules."""
-        return f"RecursiveRules(levels={self.levels})"
-
 
 @dataclass
 class RecursiveChunk(Chunk):


### PR DESCRIPTION
This pull request includes several changes to improve the documentation, update type hints, and enhance chunking functionality. The most important changes include updating the benchmarks in the `README.md`, adding type hints, and modifying chunking logic to handle delimiters more flexibly.

Documentation updates:
* [`benchmarks/README.md`](diffhunk://#diff-576c27794bae284efc278336a16d0649aaf599973a64d4b65dc67bc99bb7f000L7-R152): Updated the benchmarks to include more detailed speed and size comparisons across different datasets and chunking methods.

Type hints and imports:
* [`src/chonkie/chunker/recursive.py`](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L5-R5): Updated type hints for consistency and clarity. [[1]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7L5-R5) [[2]](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7R62-R67)
* [`src/chonkie/chunker/sdpm.py`](diffhunk://#diff-359202635006b02c57f41dbefe88292468e723829ac8579c6086b8b54b082037L3-R3): Adjusted the order of type hints for better readability.
* [`src/chonkie/chunker/semantic.py`](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7R3-R12): Added conditional imports for `numpy` to avoid unnecessary dependencies. [[1]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7R3-R12) [[2]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L253-R261)
* [`src/chonkie/chunker/sentence.py`](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL4-R4): Updated type hints and added new parameters for delimiter handling. [[1]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL4-R4) [[2]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL15-R23) [[3]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL31-R55) [[4]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cR71-R74) [[5]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cR84-L157) [[6]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cR102-R116) [[7]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cR125)
* [`src/chonkie/chunker/token.py`](diffhunk://#diff-dc86e456384b2f6c8c9a959fa1aad45eecc4923ec151319f037f5e0a17cd5099L3-R3): Adjusted the order of type hints for better readability.
* [`src/chonkie/chunker/word.py`](diffhunk://#diff-37c569b0fda38e8c01d37b59e041720870686bd0348020e80790e21c07b4c1f9L3-R3): Adjusted the order of type hints for better readability.
* [`src/chonkie/embeddings/base.py`](diffhunk://#diff-849579bb6030628505c4ee859c8913bd4e9d3aa3bc681e1323c23c66b010ad84R2-R11): Added conditional imports for `numpy` to avoid unnecessary dependencies.
* [`src/chonkie/embeddings/model2vec.py`](diffhunk://#diff-7567a68d2e120b898523d55da2af93d790a3030646dedf36d2914d9d2c5b2c31L1-R14): Added conditional imports for `numpy` and `model2vec` to avoid unnecessary dependencies. [[1]](diffhunk://#diff-7567a68d2e120b898523d55da2af93d790a3030646dedf36d2914d9d2c5b2c31L1-R14) [[2]](diffhunk://#diff-7567a68d2e120b898523d55da2af93d790a3030646dedf36d2914d9d2c5b2c31L28-R35)

Chunking enhancements:
* [`src/chonkie/chunker/recursive.py`](diffhunk://#diff-8bbe8a372641303a22785a4d84abd72a02d9cad7afe7d7055d0f9581cae268b7R62-R67): Improved delimiter handling by adding logic to include delimiters in the previous or next chunk.
* [`src/chonkie/chunker/sentence.py`](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL15-R23): Enhanced sentence splitting logic to handle delimiters more flexibly and added validation for new parameters. [[1]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL15-R23) [[2]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL31-R55) [[3]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cR71-R74) [[4]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cR84-L157) [[5]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cR102-R116) [[6]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cR125)