### PR TITLE
[Feat] Add `mode="recursive"` in `OverlapRefinery` for all methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-__pycache__/
-chonkie.egg-info/
 .DS_Store
 
 build/*
 notebooks/*
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@
 build/*
 notebooks/*
 *.pyc
+src/chonkie.egg-info/*
+src/chonkie/__pycache__/*
+chonkie.egg-info/dependency_links.txt
+chonkie.egg-info/PKG-INFO
+chonkie.egg-info/requires.txt
+chonkie.egg-info/SOURCES.txt
+chonkie.egg-info/top_level.txt

--- a/cookbook/tutorials/recursive_chunking_pdf.ipynb
+++ b/cookbook/tutorials/recursive_chunking_pdf.ipynb
@@ -1,3569 +1,3569 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "gpuType": "T4"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU",
-    "widgets": {
-      "application/vnd.jupyter.widget-state+json": {
-        "f3f468050cb5486589c68d273fa859a6": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_a54f3fbe457c4eb180aaeebb3d849ba0",
-              "IPY_MODEL_ebbfe03efc654c08a13ad2d14b7b5c31",
-              "IPY_MODEL_5a912a0e334d4ccfb9df57b27a22f38a"
-            ],
-            "layout": "IPY_MODEL_e3203d311565460d894ee217af5b5f42"
-          }
-        },
-        "a54f3fbe457c4eb180aaeebb3d849ba0": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_d36682aa48f04f3dbc1c9c67ec6b12f9",
-            "placeholder": "​",
-            "style": "IPY_MODEL_adcd55623850471eb401625e37094039",
-            "value": "model.safetensors: 100%"
-          }
-        },
-        "ebbfe03efc654c08a13ad2d14b7b5c31": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_97c14d92f1314350a869fa597b5de66c",
-            "max": 129210456,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_12b10bf1df0542899733ea423889ddce",
-            "value": 129210456
-          }
-        },
-        "5a912a0e334d4ccfb9df57b27a22f38a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_5727087483534a61a3a68ce3a8763cd6",
-            "placeholder": "​",
-            "style": "IPY_MODEL_509b942cf9e64a0c9f4ae2579a986639",
-            "value": " 129M/129M [00:03&lt;00:00, 43.2MB/s]"
-          }
-        },
-        "e3203d311565460d894ee217af5b5f42": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "d36682aa48f04f3dbc1c9c67ec6b12f9": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "adcd55623850471eb401625e37094039": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "97c14d92f1314350a869fa597b5de66c": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "12b10bf1df0542899733ea423889ddce": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "5727087483534a61a3a68ce3a8763cd6": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "509b942cf9e64a0c9f4ae2579a986639": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "8b00bb6eca4b4b68b61fae4dcaafe949": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_d2badcdaf80e4c759aa829f450c1807b",
-              "IPY_MODEL_6be572d089be4626ab684e4721416488",
-              "IPY_MODEL_66a7d89614e94d8491302a797a4c12e5"
-            ],
-            "layout": "IPY_MODEL_13e1bdf79aff423c9624874cb9c9a870"
-          }
-        },
-        "d2badcdaf80e4c759aa829f450c1807b": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_5a3fd46acb0c447790c980a98f62e361",
-            "placeholder": "​",
-            "style": "IPY_MODEL_97112c2b170148e5b937afc4da6ab1c4",
-            "value": "README.md: 100%"
-          }
-        },
-        "6be572d089be4626ab684e4721416488": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_87a26b89a5cb4d518cd9bf2b330bd498",
-            "max": 16673,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_9fc9f9eaec244b0eb4c92c20301c6e63",
-            "value": 16673
-          }
-        },
-        "66a7d89614e94d8491302a797a4c12e5": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_b1a1836c316342109ee8718629380efe",
-            "placeholder": "​",
-            "style": "IPY_MODEL_f67a93d013984b40b3055eb5c546fec4",
-            "value": " 16.7k/16.7k [00:00&lt;00:00, 588kB/s]"
-          }
-        },
-        "13e1bdf79aff423c9624874cb9c9a870": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "5a3fd46acb0c447790c980a98f62e361": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "97112c2b170148e5b937afc4da6ab1c4": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "87a26b89a5cb4d518cd9bf2b330bd498": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "9fc9f9eaec244b0eb4c92c20301c6e63": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "b1a1836c316342109ee8718629380efe": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "f67a93d013984b40b3055eb5c546fec4": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "9aec040202fb4a58973ede6f4d760707": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_a8bc59e034fe4daeaa00bfeadd2635f6",
-              "IPY_MODEL_8d15667d78bc400080d7b4c6bdb396b2",
-              "IPY_MODEL_0e10ceb014ed428891a8cf05c2a2251e"
-            ],
-            "layout": "IPY_MODEL_6be64614024c438daaea95a47b144c04"
-          }
-        },
-        "a8bc59e034fe4daeaa00bfeadd2635f6": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_708454183e4b460f90f7fa3f430bc332",
-            "placeholder": "​",
-            "style": "IPY_MODEL_cbcec8f8093c4a92b211ea0fb8885a3a",
-            "value": "config.json: 100%"
-          }
-        },
-        "8d15667d78bc400080d7b4c6bdb396b2": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_20d7b3de1705424c9e61db230c43fd95",
-            "max": 202,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_8698fbf252024bea85051703f9aacbf7",
-            "value": 202
-          }
-        },
-        "0e10ceb014ed428891a8cf05c2a2251e": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_34e293cc15484477b940eb870743dcdc",
-            "placeholder": "​",
-            "style": "IPY_MODEL_f39f8a5a039a4b4e8b9ca06cc874a465",
-            "value": " 202/202 [00:00&lt;00:00, 4.22kB/s]"
-          }
-        },
-        "6be64614024c438daaea95a47b144c04": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "708454183e4b460f90f7fa3f430bc332": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "cbcec8f8093c4a92b211ea0fb8885a3a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "20d7b3de1705424c9e61db230c43fd95": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "8698fbf252024bea85051703f9aacbf7": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "34e293cc15484477b940eb870743dcdc": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "f39f8a5a039a4b4e8b9ca06cc874a465": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "a3eacad2d39449d0be3ba3e606dc5cf7": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_ac5ee023c9c943a0a5ed531fea511b1a",
-              "IPY_MODEL_e44835492ff645f8a588a7d7ec1f04b5",
-              "IPY_MODEL_d2610ed202794ec2918482e18ca457fc"
-            ],
-            "layout": "IPY_MODEL_6c1da5303cad44098dafd87763b609f7"
-          }
-        },
-        "ac5ee023c9c943a0a5ed531fea511b1a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_4b6bd295aba748bd9670cd06a69682a9",
-            "placeholder": "​",
-            "style": "IPY_MODEL_dec5a689253f41acaf392d1ef20f494b",
-            "value": "tokenizer.json: 100%"
-          }
-        },
-        "e44835492ff645f8a588a7d7ec1f04b5": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_7d0bf8146d2747f2b518ddb43f203c88",
-            "max": 1493150,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_de9b6916a9ec4d788ba0c07b4d397480",
-            "value": 1493150
-          }
-        },
-        "d2610ed202794ec2918482e18ca457fc": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_8d0b2d93f67c4ff2a633660782125131",
-            "placeholder": "​",
-            "style": "IPY_MODEL_b568a2f59a154ddeafb78710e1518604",
-            "value": " 1.49M/1.49M [00:00&lt;00:00, 1.79MB/s]"
-          }
-        },
-        "6c1da5303cad44098dafd87763b609f7": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "4b6bd295aba748bd9670cd06a69682a9": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "dec5a689253f41acaf392d1ef20f494b": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "7d0bf8146d2747f2b518ddb43f203c88": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "de9b6916a9ec4d788ba0c07b4d397480": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "8d0b2d93f67c4ff2a633660782125131": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "b568a2f59a154ddeafb78710e1518604": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "d3f68b3fb7b4494294922e06de7dbe53": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_c49defa1fcea4d30bdec9435d651e2b1",
-              "IPY_MODEL_90d2e938d0c1476588c088acf1b86685",
-              "IPY_MODEL_30c134be926948b3959ce7a723c0ae8a"
-            ],
-            "layout": "IPY_MODEL_9cbcc6b7d1354e5ea98eebf487d2a94f"
-          }
-        },
-        "c49defa1fcea4d30bdec9435d651e2b1": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_ebed0e46009745ae9818d16a9dade7ef",
-            "placeholder": "​",
-            "style": "IPY_MODEL_755799f1e6b14b2f91f19edf06964436",
-            "value": "tokenizer_config.json: 100%"
-          }
-        },
-        "90d2e938d0c1476588c088acf1b86685": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_0937dafccc1547069a553c0421028172",
-            "max": 3584,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_4003e08660c64d10a18d74bd47f19275",
-            "value": 3584
-          }
-        },
-        "30c134be926948b3959ce7a723c0ae8a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_5de1ff0789f547e7a6147888e08aca64",
-            "placeholder": "​",
-            "style": "IPY_MODEL_985458e3563244c9b94525d831fd90dc",
-            "value": " 3.58k/3.58k [00:00&lt;00:00, 52.6kB/s]"
-          }
-        },
-        "9cbcc6b7d1354e5ea98eebf487d2a94f": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "ebed0e46009745ae9818d16a9dade7ef": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "755799f1e6b14b2f91f19edf06964436": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "0937dafccc1547069a553c0421028172": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "4003e08660c64d10a18d74bd47f19275": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "5de1ff0789f547e7a6147888e08aca64": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "985458e3563244c9b94525d831fd90dc": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "ca28c121e84e425185a4d801c3930b69": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_dc7fdda7a5354621978c17ec22ed0330",
-              "IPY_MODEL_7ae08b4d31924479809eb7d3f2fb38fb",
-              "IPY_MODEL_ce4b6e104d7b433da4eb1ee3a7278182"
-            ],
-            "layout": "IPY_MODEL_2d74a3e80b9646be88ed4bc5158ff8a2"
-          }
-        },
-        "dc7fdda7a5354621978c17ec22ed0330": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_3e30645b7a384ed48129e7afa471a982",
-            "placeholder": "​",
-            "style": "IPY_MODEL_9324441028b1496e87c7059bcd1b371b",
-            "value": "tokenizer.json: 100%"
-          }
-        },
-        "7ae08b4d31924479809eb7d3f2fb38fb": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_8a3bb9d63ba640c6a0c63c7bd08d50cf",
-            "max": 7847602,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_a0f4ea3ee6f04fd4ba0e5cb37f24b343",
-            "value": 7847602
-          }
-        },
-        "ce4b6e104d7b433da4eb1ee3a7278182": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_853eb421b8364fe0a7e3a2e91be79aaf",
-            "placeholder": "​",
-            "style": "IPY_MODEL_51be8798d9b8426081c9cb8955624b9c",
-            "value": " 7.85M/7.85M [00:01&lt;00:00, 5.71MB/s]"
-          }
-        },
-        "2d74a3e80b9646be88ed4bc5158ff8a2": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "3e30645b7a384ed48129e7afa471a982": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "9324441028b1496e87c7059bcd1b371b": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "8a3bb9d63ba640c6a0c63c7bd08d50cf": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "a0f4ea3ee6f04fd4ba0e5cb37f24b343": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "853eb421b8364fe0a7e3a2e91be79aaf": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "51be8798d9b8426081c9cb8955624b9c": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        }
-      }
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gcVXWGG6MopX"
+   },
+   "source": [
+    "# 🦛 Chonkie: An example of RecursiveChunker for PDF/Markdown Chunking\n",
+    "\n",
+    "![chonkie_logo_white_bg.png](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA8AAAAIcCAIAAAC2P1AsAACAAElEQVR4Xuzd91dUZ7v4/88/cM46JxGmVzoW7FETY2IF6b3asMTeGzCVoUqZBihYqdKmUe0mpmnUqLGAFHtDep2y9x6+ew+aGMyT55kn33OCZ12vda1ZEyIziPzw5l73vvf/GwYAAAAAAAD8y/7f6A8AAAAAAAAA/jEIaAAAAAAAAKwAAQ0AAAAAAIAVIKABAAAAAACwAgQ0AAAAAAAAVoCABgAAAAAAwAoQ0AAAAAAAAFgBAhoAAAAAAAArQEADAAAAAABgBQhoAAAAAAAArAABDQAAAAAAgBUgoAEAAAAAALACBDQAAAAAAABWgIAGAAAAAADAChDQAAAAAAAAWAECGgAAAAAAACtAQAMAAAAAAGAFCGgAAAAAAACsAAENAAAAAACAFSCgAQAAAAAAsAIENAAAAAAAAFaAgAYAAAAAAMAKENAAAAAAAABYAQIaAAAAAAAAK0BAAwAAAAAAYAUIaAAAAAAAAKwAAQ0AAAAAAIAVIKABAAAAAACwAgQ0AAAAAAAAVoCABgAAAAAAwAoQ0AAAAAAAAFgBAhoAAAAAAAArQEADAAAAAABgBQhoAAAAAAAArAABDQAAAAAAgBUgoAEAAAAAALACBDQAAAAAAABWgIAGAAAAAADAChDQAAAAAAAAWAECGgAAAAAAACtAQAMAAAAAAGAFCGgAAAAAAACsAAENAAAAAACAFSCgAQAAAAAAsAIENAAAAAAAAFaAgAYAAAAAAMAKENAAAAAAAABYAQIaAAAAAAAAK0BAAwAAAAAAYAUIaAAAAAAAAKwAAQ0AAAAAAIAVIKABAAAAAACwAgQ0AAAAAAAAVoCABgAAAAAAwAoQ0AAAAAAAAFgBAhoAAAAAAAArQEADAAAAAABgBQhoAAAAAAAArAABDQAAAAAAgBUgoAEAAAAAALACBDQAAAAAAABWgIAGAAAAAADAChDQAAAAAAAAWAECGgAAAAAAACtAQAMAAAAAAGAFCGgAAAAAAACsAAENAAAAAACAFSCgAQAAAAAAsAIENAAAAAAAAFaAgAYAAAAAAMAKENAAAAAAAABYAQIaAAAAAAAAK0BAAwAAAAAAYAUIaAAAAAAAAKwAAQ0AAAAAAIAVIKABAAAAAACwAgQ0AAAAAAAAVoCABgAAAAAAwAoQ0AAAAAAAAFgBAhoAAAAAAAArQEADAAAAAABgBQhoAAAAAAAArAABDQAAAAAAgBUgoAEAAAAAALACBDQAAAAAAABWgIAGAAAAAADAChDQAAAAAAAAWAECGgAAAAAAACtAQAMAAAAAAGAFCGgAAAAAAACsAAENAAAAAACAFSCgAQAAAAAAsAIENAAAAAAAAFaAgAYAAAAAAMAKENAAAAAAAABYAQIaAAAAAAAAK0BAAwAAAAAAYAUIaAAAAAAAAKwAAQ0A+D/CjKGIUW8YGtAP9pkMQxhqGjabR/8hAAAA4C+DgAYAfLjMJqOh8+WLO5e/qzuRJ92+LiZw6S7P+bu8Fu72cxdHRxSkJV4+W/vi8QOjQY//4dGfDQAAAPxbIKABAB8kDDU9bb5XpkwTrwhdOXNCmAsnkE0JYVOCmZRgBiWQRg6i00K4rCg3h51+C4vSE1pu30AR0+hXAQAAAKwHAQ0A+MDgHfystemkNGnDgk/CXTlBbEogk+RPs8GjOZBKCsLTmUIKIONj60+y8SP/dyDLJtCJsWrudKVg78P798ZMRpsJGA7FH83vPpqxD2vzCYaYejpeP2q4fefHb66eq7tyqurKmZpfvrvQfOPqqycP9IP9w/jfCAAA/g+BgAYAfDjMZqN+6Nb3F8XRIVGT2IEcmyAuOYBDCmDbBDFtA+k2+PhRP/amfORB+e8ltI/caR950T7ypn60lPqxB9PGx4W1NdD9rLoMNRlHv/L/BDyEEZNxqH+gp7P9xZMXj1qabt+49t3FC9XqmtLC0rycwizpCVnq8fSko6nxh5NF+Bw9IDmekVwgTS3NUejyj16q1v7y47ePm+61PX042NuNGvXD2JgqUbNhoO/eT98XpEuSvoravGD2qumuKyc5rprouHKCQ7Sb88Y5U/mhXtlxO86rStqfP0ER5MP6xQAAAP4RCGgAwIfBjGE9Ha+r8nO/mj891Jka6UCNsqdEutI3zJuUsjagJHnX+YL0azVHb58r+uVc0ZXqw7UnUnL4G/YELQqd4riIOW4Rw2YJw8aLS1vx6bTyQ8re7s7Rb/AXYBg6NNDf8erFk5ame1evXKrWVBxSpO3atD8yYJvvkk0eX6xb+NnaL2ev+nTGsk8mh08dHzzRKWi8Y4CLvZ8jBx9/B7afPcvXjuXnwPZ3tA9wcghycQyb4LpsqtuKmVPxz1q74LONHvN3BHqlbt9QLE/7rq7q3vWfnra2drS9MgwNYv/rVY2h6KsnD79WF/OW+66c6+Y3nu7nQPFl2frRbQNotsF0cjCVFEQlBdNIYSxqKJe2fKLjtsVf5KdImm/fxH8FMkNGAwA+cBDQAIAPgdnc3fH6ZE76itmuIU6kKBfaCmf65hkuR7ctu1d9uL/hQk/D+d6mi/0PLhlfXkY7bqBdN03dt/Svb3Y+uPK9Nj9p07LF9pTFDBtPBsmXQ10+e8oJaSryF9ehzWYUQTrbXv108Zz6yMFccaxk3fItngtXzZ4WPsEx1Jkb7MgOtGcEcukBLFoghx7ApgUwqQFMmj+T6ksn+1LxoXjTKF40smUolsGf0LzpdC8aFX/0ZTJ8GXRfFt2PRffnMPy5+DBDnO3CJrosnzFlh5d7fPSKPAlfe+Jww83rg/19/zthahgc+L5emxAdEj3DMcSB7M8l+3JIvmyyN4PkTSf5MMi+TIoPzdaPQQpgUgKpNiEU2zAaOZhBDnNk7/JaXJt/tL+763/nSwUAgP8hENAAgLEOj62B/t6qgtxVn00IdiJFOlPWTuEKPT+9cCDmbqnicmHK10fjLx6Lv3hccu5Ewun8hHMnU3+ozm78sbzj4bdD7XdMXU2dD66dLcpe/eUnS+g2XgyyN5saOXtK5dFcg35o9Jv9KbMZ0w8NPn/04Mr5UyU50uRta7d7LYyeOXnZZJcwF/sge1Ygl+HHouF9HMCiBnHoeET6MWz9mCRfpq0Pw9afRQ7gUsOc2MsmOqxwc1rp5rJ8ikvUdJeoGeOXzZy4/JNJK2a5RU4fHz7FNXC8nZ8z24ND8WDYejFtvZkkHyYRpn4sCv7K/nikMsiBbHoQlxHkzAme4LDq0+k7g7zyEgUXtBUPG+/1dnViKDr6q//LzBj2/GHzQdGedZ+7RbnSQ+1twxxI/lxSgCN9xcyJW9znJq4OPRy3Vbl3fcbWlfwVftu8567+xDWYTQ6i2+AlHUixCWZR8e+VfO/2J00NxI4OAAD4MEFAAwDGOqNB/9PXpze4zwpysI1woqx2Y6WGLDyduvtrBf+sPKZesa82a39VTozuEE+TJ1AdFqjyBFWHxTVHJKeOp/ygO/Lo59OmzvuDbQ0/1Zau+WLWUgbJh0X14tLWLJx758qPo9/sH0BNpuePWr+p1eRK4naGeEbNmhjsZu/nQAvg0vyZFF8GxY9J82XTvNm0pSyKO9N2EWOctyN1+SzXnT7z4lf4Zu1clS/YWp7O0+Uknj6Rean84BXdsZ/rCm6eLr5xrvjm+ZKbF07eulh662LZ1TNFP1QfO1eWVZOfXibnHxZuTvwqaF/oougvJnu6UL6k/cd86n+4Mz/yZNt4Mcd5s2w96bbeLIoPi+zDJgc4MiOmuKxb9NmBbes1x/NuX/1RP9A/+m/y7zPfvvp9/LqIZVMdwpyoIQ7kECdygAvlK/cZRWkxty5UdD26OtjZoO+9P9TTMNR1Z6DrTvuD734+U1Qk3r5jyawwJ3oQkxREsw1kkIMcWeLoyNY7t6ChAQAfKAhoAMCYhqHo4+YG0bqwYFdKqL1N9AR6sv8X1fFbTqXvqsvcVSvbUyPfV6OMqcnhVR8U1OTG1+RJanMT6g4l1h9KrM1OqDmYoMtNPF+Z8/jOxb6nt78tO7Zy9lQvJs2TSg6w4whXL+/pah/9lm+ZzdjgQP/T1uZzmvIDezZv9lkQ+cmEAFe2nyPDl0PxZ1P92Xi5krw5ZH+8XKe6rJs/KybKL4e3teZY5rXTJa0/n3rSePHVg+86n/7Y9/LqUMcNfe8dw8BdIz6D90xDDYgBn7uI4TZiuIMY7xCPhtumoduI/o5Rf9swdFs/8MtAz8/dr75//eybZ63nW2/V3Pq6qK4gWclfuydq8Yr5E4Onc/0dGUvpNl7UcX40Wz8aCX8MYNN8ObTg8fYr587YHxVUelDedPtmd2e7+S9slUYQ5NZP3+4IXBzizAi3p4ZwySEu9G0es2uPpjy9d2Gw8w6qbzEjD4ymZr2+YaDvdl/ntd62n/peXel9fa3nxU8v7l2oVop3LZkTbk8LpuMNbRvsyNgX6nv3yg9/dSMNAAD8HSCgAQBjmn5woLb4SOgUjr/dx2FO5N0LJlfw1tWn7ahN31Yn3VEj3VWr2Hs6O+ZcDv+bXPGl3IRv8pIv5CWfykmoy02qyU2qyklQKcQVClFVXsqtM2XdDVfLUwTe9kxfNt2PQQuf7HKqvABDR6+DmjG0u73t29M1WYL9e4K8I2eMD3Dh+NjRfO2ovvY0Tw7Jy57szhkXNIWzPXBeVtxaTV7CtbPFr5ou9b++OdRzxzDYgOgbENN9FL2PIA0mtAHBGlGsEcEaEHOjZe6jw034I2JuwIbvYea7+KDme5ZpwMyN+BMEu2vC/zxG/C/MfA9D76LIHcR02zh4fbD3an/XT22Pztz5sbg+/8CJhO07/T/3crRdQP0Pd/p/edI+9qLZ+DDI3nhPs6nBzuyNiz5P3BBdlX/kUVPDv7e1o/HW1Z1hHsEu1CD2uEB7W/+J9CzexpZrpw1d982DrcOGB+jg/ZePv7t9Q/3j18e/qc05V5Fx4eSBSyXp36vkV+sON3xb1nbnXMu3mqQon1C8v5mkYCY52I4piAh5fL8Bw/6dLwkAAP5GENAAgLHLbCY23e4N8/TBo41rs3IyJ29LWF3GTm3qppoDm+rSN5/K2FafukXFj85b5ysNXZDgNSclaP6hjeHqlH2ncpOqcxOqDiZWKRN0MrEmg1+tiL9cltdQVyaM8PMhru2jB9gx9oZ7P3/YMvJ2eFz2dnXeuvxtoTRpX7jfsjnT/Fy4/vYMHzbVh0P1ZJF8Hejh0502eM5J373yVFF688/Vrx5f6uu6qu+/adLfQVGilU1m/PEeillqGLtLdDDxpAHFP4g0mLEmYpBmM9o8TEwThjaYUbxr8Y68j5mb8EfUMvhzs7kFG24yDzeYzfjcMw/fxYi5g5lvE4PdQkw3jYM3h7qutj3+5u6P5cfSduwMXxg5x8XHmeZB/9id8pEP1caPauPPIAXZMSKnOG9YPFfB233l/Onu9tf/era2v3jGWxvm50IJYH/szx234jPXqoIDHa9umgYfDOufmPpant09/211Xn3JgZp8Se0xcd0RcX2uqC5bWKcU1mcJ63OEtbni80VpP+nyLh49sHvJ7HAuNZROCaFTQ7nsrJg9nW0v4ZpCAMCHBQIaADBmmYcG+2uLj4ZM5vqyx4U6UPa5z9IlbqtJ265N3VhzYGNt0vr6+K/y1/qkeEwXfObK+8R571S7rW6cjVPsd3w+JW/rilNycU12olYRjwe0OkNQkcYrSd5//pjs9MH0FTMmBbAYfnRK0HhOTf5hM4q0v3h6Xlsm3b9l5Vy3kEkcXweKjz3NnWPrYU9axP44ZJqDZHVQmUx47XRRW9Olwc5bxv67iKERMzZgpoZhDA/fRgS9h5kbMQyP3ft4E5vxJ9h9M9JoNjWajffNpuZhpGXY1DpsbBk24OmJT+uwvsmsbzTrG4hHw32zsXkYH1PLMNI6jD40o4/MxJNm/PWJQe8PY43D5kazZZWaSGrsrhm9S7wXchc1Ngz13uxtv976c93pk3LpzhWrvpz8Je0/PRgfezFt/dgUPyYpgEsLdGKFTXERr1+hLTra9brtn5ar0WgszM4InGLva2frZ0cKncI9VSQdaP/FNNSKDT3qfX7j54uldUXpNUeTag+JzuSJz+WKzx4Unj4orDsoqj0oPpUTfypLXJctqskR1x2Mr1UIi+I27fhiRiiHGkQnBTGoUdMm1ZcUDA0OjH5jAAAYwyCgAQBjFIZhr548TN600seOFMAhL5/AztsQWZe2p/rANm3y+qrEdTrhquMrPdLmT47/xEk03Yk/2X7/RLttLqx1DtTVTvRN05xz1kbUySXVCokmU1iZzi9JjS1I3FeYFKNOjxcE+/nQaQF0mj+TvOnLT6U7N210/zxihqOfC9nH3saHMw5/U0+ubeA07q6IhbUnUlqu13Y++Wmo6xfTQANmbMbQZgRtRLBGPJGJejY1osZ7eCsPY8Si8jDSNGy8b+r/ZajzZm/b9a6nlztav3t+59zd7yqvnyn6XnfkfGlWXYG09kRG3bG0uqMpdUeTa48k1x5NrjuaSszxtLNF0m9Vh66fKm78sep5w8WOJ5d72n4e7Lxt6m/A9E1EguORbbK8F17SluVtPNyHzU0o0oiamowDd/varz9uOHOmVC5Y4xcyw3Ep19aXZeNHHxfIIAeyKAEOrLDpE75aOr8kJ/NRc6PJaBj93X/r3s3rG3wW+jnRfbnksOnO2tyUgbbb6GCrsa/p6e3zX5dl1R5NrT4kOXU48cyh+POHxBfzJBdzJRfyJGcPSuqz48/kJHx95MC5g4lnDibWZ4nxgK6W8gpiN234dHIQmxzEpPhzaVu9Fzbfufnv7S0BAIC/BQQ0AGCMQkym21e+X/WpWwCXigf0pjmT1aIdVSk7NalbNEnrteLogs3+qYumJH3iIpnuJJriIJzqtGc8Z5MDfbUdZZUDLcqOsnHG+Py9m6ozRFWZ4vIDvJKUuPzEmOPxewuE+6RrV/kyGf40WgCNHMikhDmz/O0pXuyPPbkfeXD/awnnv6LmOMt2rLxYmfXywUVD323TUAOGtJiQZhPaZDI3GxBiWzOx3ozcHzZZihltMRvuD7T//Kz5wu0rldcuFn5fe/hChbI+P02bK1FliTTZ8eossUopVilEarlYo5CoZPFqqUgrFWqkAnWmQI0/SoWVmUKVVKSWivHHSqmoTCosV4rVhxJrTmScK836TnfkyqkTty5VNN2o63pyxdRzl2hoYoiON+Mpb76PYk2o2dL36D3D4N3+1z/fvlReJuft9J7rw7XxY47zZ9j6s6m+HKonm+I33m6j3+JjGUmvXzwjbiH+e2azWSmJ9Ztk78OleTvQU7evef34BqJ/gg09vP+j7syJtLqD8acOJpzNTTqXm3AhL+Fibnx5wpbsrWGSyCX7/eft8fs8LmRRxsYwbWrMhYNJp5Xx1XKBTinUyQVZW5dHTeAEMGwDmGR/B/rhJP5Ab/eodwcAgDELAhoAMEYZhobOqUp87Sn+LHKoA0vsv6T2QIwmdUdl8sbKhLVl+yKUIfMS5rgmz3RN/3SyYuHsbI95aQs/3TKeu5xlG8EmhbJJYXaULXOnayUx1Wmi8uS4kqS4fPG+E6I9B3du3O2+yINK9qFRfKk2xFHNbFsfOxtP+48DpzJ3hHyhOih8dLO+9/lVY99txHgPQxpRtAnFWlBzqwltRtEWDG0eNt3HhhoHu252P7v85O6py2eO15/M0BxNUOeJVQdFlVn8CgW/Qs6vlL4ZtZSvwVtZJtLiIxXpZGKdTEJszpaK3oxMpJGL1fJ4fFTEo4R4IouvlBElrVKIKxWicrmwXCGqyBJX5Ig0eQlVJ1K+0R28+2Nl+6Nv+zt+xvR4RreiSCOGl/Rwi+UiRfzLbjLp7xl6b79s/ubn+vz4aN9QN6478yNvNsmbhQ95KZsaMMlxW5C3Jv9wx+tX797X8PWr52vdP/d1YHhyKMvmTm+8ehY1Pkf0Tx/ePHfmWGr9wfjThyRnDyWcP5Rw8VBChXBzQvCXGz91jJ7KWjaZETqRFuBK9Z1A953EDJ/hkLzKX5cWW5stVmcJVEq+OiM2xueLEC41kEHyYY5bu2BWw42f4FQ7AMCHAgIaADBG9fd2F6Qn+HGp/hxqmAsnZ+NyTeq+8pRtZUkbyoSrCrYEprpPT5o1/siSz+tWR17Zv+1WAu96Qpx269pd08cHUv4LD+ggpm2UEycjMqj+gFiVxCtPiMvn70ldu2z13JmeXPoSuq0Hw9aD+dFS9keeduP83ejidb6nStJfPvx6sOeGydBgMuHdTFzthyL4tJjRB8QgD9D+xvYH3zZeUV+tO3ahXFF1LLEym1+Jd2GWoFLOU8l4apkAz2V1Jl7MfI2MNzJaKU8n41tGoJMJq+RC/FErJ0ZjGTX+qBRrFPjE46NWxqvx53K8s/HaxrMbfy5SyQSVMn6lTICneZmUVyaNq5QLyvGPKAW1x1Mvnzpx96puoP2GZXdHKx7TGNqEDDcgw40oHtPIfWSosfPplQvlyr3hizydSB6sj5fSx3nRyR508lJ7uvckh/it6y5fPGsyEkfLYRh6SnUyZLKjD4fqbk+T87b3d7aYkZeP7126WKw8nS05fVBSnxt/KjfhVJbwyI6o7Z+6rJ/EWDeeutqFssyZEuZMDXSh+brSvJyofi70oIlMftiSirT96iyhKluolvFO7F+/arJDIMPGh/aRvxOt/KB8sO9/6WaKAADwF0FAAwDGqK7XbYlb1gTY0wPs6CunuhbGba1M3VuavLVYvLY0ZuXRlV4Z86eXB3re2rX1aWL8i7SU10rp8yzpQ2Xm6Z1bNjhyg0kfhdJsQhmUTdPdqiW8mmRR3s6NuzwXBE2wX8ImLWaT5jPHfcn++EuH/46c56qIXX3zXNHrJz8O9fxiQu7rkXsGc6MBu28y3TcjrRjywDDQ2Pni+oNbZ77VHa46kqLNFldliXQKAZ7LFfI4lYKvGQlifKQCnVRQlSnQZfC1mURAa+W/G52cr1PgIxiZKnzkAp1coMWH+IhQpxBpLYO/Jv6CeHAT/4sY/ptRCNT4Wyv4KhlfkyHUZgrVmQJVhkAlFaizxNVHky5UKh7dqu9pu4HqiX0d6HAjMnwfIQ7Oa0IRYod024Pvfqo/LlrjHzHNaQndxp1JXsiwXci0dXdihsyZejQj5eWTR90d7ck7N/g7MJayyIEzXS/VFZv0z148uHa6QH5KmXguK+FUtvh0XsL5Q5LcrZHrP7H/ahJjgyttgzPlKwfyWgfaKjtqlB0twoER6sgIcaAHOFCCJzHl25dpsoSaLAH+bVGl7I3xJhah/WjjfFmk/eH+zx62QkADAD4IENAAgLEID6m2Z092hnoH2NGC7OibP59xUrizLGlXsWTTSdG60l3L8iO8tFGBD/hx3Skp/RnSfqmsVybvVirbFIrm9AOH/X0jbD4OI48LoZEi7Jgntq1PWx62csYkHweGO5vsziUv4Iz70tE2cK5LTvLmO1dUg69vIP0NJv19E9KkR5sM+CCNKNZqRh4OdvzScEX3jfaw9khKSSavQiaslPK0eNRm8rSZcRoZXyXlaaS8KrmoWibCu7laKtQRI9DJ+FrZSCuPniqlYGS0+GQJtUqhGq9hfJR8dZZQrRTho1IKKxX4xwUavM5/P3h2ay2jwVs8U1iVKayW4u8uHtlOjX95FTJeZZaw5ljq9TP5LTd1g90/m5EmYl+HuXV4+CGG/71MTchgY8+Lq1dPFaZsjvScQF/AtfmC8dECps0CFsnPzTF+fXTFIUXorMmeTNISlu0qjzlPmn8c6Gi4pD2iU8afyUo4rRCfypGcPZhQm7Br7/wpq1wp0c6ktU6kDQ7kjVwKb/L4nCWL8zyWHpg3b+t4pzWO7GVOjCBnyoaFU8sP7NUQvwYIVOmxGevDwlyYAWyyN8MmbLLzvWtXYBcHAOCDAAENABibzC+fPNziuziISw3h0vcs+qyYt/WkZHuRaENJ7OqKbVG166KeSET9aRnGTDkiyzLKsvTSrAFFdndWzkuF8oeYmE323FDSx4EUm0AGZflE52BnrjeX5smmeHApHo6Ur7zmFMrj7t2o6e64ZhxqMJuaMaQFQVpMaCuCPTAaW3te/fz41pnLNcfrCzLUOfEqhajScpGfOoNPLDPLeHgFauQ8y85mwcjCc5VUWCMXV8tFOgU+Qo1SgM+7ufzrVGcJ8alSCrXEcqxIQ0SzQKUUqLME6myxKgsfUaWloVUKIRHWCr76ncHr801DWxak8YjXENtCiJ0h+JdhWbrGs1tUKefjL6s9JK4vTPtanXP3x8pXLd8Mdt9GjS3EVmm0BUOa8b97+7Mfr10oStu7MmrepAWscQvoHy1m2Hg7sUKnuLhzyIvp475kj+NvDO9+duNqfUHtoYQamaBWLqxVimqz4jWJe+KXfrbWhbLOhbLGYdwmJ1LGglmn10c3CPmPJUlPxSktcfE/7dh9aKnHjsmuy5wZy6faHVjtrzqwT5URV5Yec1S8ddUnLv5ski/D1odDu6hRGQ360T8IAAAw9kBAAwDGJvOrp4+24QHNIodwaDvnzy7hbS0Wbi3ibyjZt1q9dcVd/v6+dLyeFSZZFiLPNslyTPIcvTynV5nTnn3wfkZGToBfCHlcINXWj07y49B88Hq2o3o5UEOnOx3kbW65VjvYccuov29Em00Ykc4o0mpGHiDG1rZnV376+mTNsTStXKyWCfEMVVkqWWdZXa7C+5jIU75m5GI4YmeFWEfsVCa2cFQpxFVKsS5LqM0WjYzOEsr4VGeJ8Hn3uWXE1cp4fPBP1BGfiz+J1xEjxl9WKxOpFcJKJTGWkhaqLFulid3SI3s8FIJKBU+l5KmVxMr0SE9XKUcKXqTGk1pJvAje9xp8FEJ1juh8ZVbTzzXG/nso/qsC+sCINZnQBqOhYaD9RtNlnXxXtN8E5hLmOE82yYtNWsqwWciw+Yz5UX5G3C8XK07lJtbK+PVyQbWcX60U1ykkByK9101grnUkrXew3epAKgn0aJUIXqYkv0pKfp2U1pGY0SFJfyVJbRSIjgb6bJ7suHwic/vC6cWCzWUpe4oO7M1P2bN96aeBdlQ/BtmbTso/kDTY3z/6BwEAAMYeCGgAwBjV/uLZ/sjAQCY1gElZ/+nUwphtZaJdRYLtBXs26LZt6EjPHMpQGDOViOIgns5GRY5BlmOUHRpS5HYqD7XKFKUb1oWwaP4U2wA62Y9D9XKk+k/lxq72/rHuWM+Lq8hgA2K4j6GteEdilksDkcGm9offX64/rjuaVJllubBPKtDIBWo5T00sNo/sZia2T2iILchvF4Pf7Fp+U8m/TZaI2JthGV2WSJf9x1OV/aakq962NXHKmxKPY7x3iXdXyXmWId7r7XMesa/DsryttnxcbdnXgX8lxKdbHt+81MjXZil7jeWKRpXMcjBItqi+MKPhR01/+21E34RhLRjWbMa/FUP3u59fu3quaGvwl0udyV5sW2+GrTvTZi7tP2vyUs+dkNYrJTWZghoZsWO7Wi6qiN+1bc74dY626x3GbeTa5C347AmP1yNJ6RAnvkxIak/PGDp4CMk/bso/Zig8/jpPWb9tbezcSbsXTj0Ws6YkeWdR6u7ClN3CSC9/e5o/g+xDIx3YuqGvq2v0zwEAAIw9ENAAgLHJ3NPZLt+/w59J86OTIyY6Ht+7uVy8r1Cw+/i+LVW7tvUrDxnlOYj8oFGWY1IcwseoyNMrDg9kHXmlPHRq+/bNkyf40m3xMvNnkf0cadHzp55U8p82XTQO3DPpGxDjfeJsDVMzZmo1mx70vrx240Jx1dEklZJfKYvDW3kkQIlutqTqu/O73RSWdd83lwO+XV1+N2SJgH6vm9+f32rb8vwP3+vXgNZYdk6P/N9fryx8N53f1rNlp4flSkRi8F8JZIJKKb8CL2m5UKUUniuW3fq2svf1DTPxTWgdxh4i+vumocYnd84pYtZ6O1J8WSQP5sdf0P/zdO6B2uykaqm4OpNYg8dfqloqVH4Vvn4ie4O9zSZ7m10O1OvbNnWJEnoFiV3i5MGcHKSkwFxWZK4sNlcUmtXFaFmBvuxY/a61KYFfnohdW5K6Kz9pR1Hy7tSvwvwd6Pg/sR+dIlgZ0fW6Df+nH/2zAAAAYwwENABgjBoa6Ncey/VhUf2oJH8ONXNNRIUkpki850Tstur9u3py8ozyQyZ5rinrMJp1xKQ4olce68059iwrV7tx4ya38WEcqi/9Y2+2TdBEtjja/84lVe+La6ah+wZ9I3EmHdKKGZoxY2t/+617lzXV+SmVWfxKeZxKGqeV8UeOnKuyHHyh+f3+41FjuR7udw1dbTmd49ei/YsB/e68XX4mmv7PA/rXerb8DmA5LM+y5UONd7NMMLIJpELGJ65WPCSpLki//W1F36ufMX2zGXlgxr8t+gddT67FRXn6OlI8WeMW0v+rMH4XcXZ1BnG1IrGejb9Iyn6e1xdrXRgb7cdt5Y5TfD7jET+uW5TUK0kxHszFykpQPJ3LLelcUTCMT3kBWpH/Ml9ZsTu6kL++JGVXUcru4qTdGRsjA52YeED70kgxEUGdr16O/jkAAICxBwIaADBGmYzGy+dOB7ra+VNIAQzKjsWfVSbxiuL3nojbruXtfqbINigOY9nH0JzjJuUxU05Bb07+E+Xh/Og1q8Y7+7HJvqxxvpyPg6fZHU3c9fLe16bee6ih2YS0mEzNiJEoRVNfQ+svp8+elJYreeWyWLWMRxyagU9mXJWUVz3y/O1miX80v17J927F/hqv/0pA/5rO7877b6R5uxo96iP/JKCVxG7pd2ckoDVvY1olE1ZIBRUy3umijDvfVw51/DJseDCsf2Dub7lQJA1wY3iyP17C+O/0jZHEtZKZ/Gq5SCPl6+Sik+KdO+ZOXetE2+JE3sElqQO9XseLu8VJpqyD5tISVHXSpCo2q/B6LsRURcPl+cPlRXhPD1XmX0qJKRNtOZmyq+TA3uLkPRkbIoKcmP50sg+dFBsV3NX2avTPAQAAjD0Q0ACAMQpD0Uf3G3YHevuRbf3JpGVuLidid5YmxuULdlfE7bmTJh3KLjDnFJkOFhoPFQ0cPvn6SEn55h3hLk5LubRF7I+X2o9b+6Xb2cLM7qfX0IH7qInY7mwwNWHoQ8zY2tN288e64+pD8RUyYtVZI+dpMmO1GbF4PetG7ngiJ84q1iqEWqX4j+ZNjxK9q3yzGPzbsvTIIvHIEXVWBvSoVh614P3+jAroXzeQvEl5Jf764pFz8UYG/89KYjM0/uWJNcS1hvHaDKGOuNkhT5UjPlUsbb5Wo++8OzzY+uBa3calMwOdKMHjGTk7o7V4eWfydJZ9IHhMn9i/Yf1Ul7X21PX2tvucGd+tW9UhSdBL5ebCInNlqUldYqgswsoL0YoCpBKv53xzKdHQQ+X5P2WI1fE7y5L34PVckrI3YYV/oCPNj07yZtiK16/s6ewYhqOgAQBjHgQ0AGDs6unoyJMIAtkMHxuSH5uVsCysPElQINhXHLPvoii552ApcrDcmFeqP1HZU6Q+L0pePW3GIhb1C7btYifyV54zr+jy9G230MEmzNiCGlsw4qiNFryeOx79cEmTq1KKVMQdtuM0mcRoLUPUs+WSQTWe1ETC/qOAfjuWiwXfL92RDn43oKtyxO/X8/sl/W5AE6/z64xcyPjevL3HCnG9YJWSONbDcgqH0PIREVHJynhNVrxGKVYr8BGpLMvPGoVYJROqZSKdXFItk2gziTsdVkoFZXJ+ebbwh6rDz34523Xngk4al/VV2JEdqzUZcSP3VlRl4N8fkSqTd2jryujxnLUO9LUONjw3+7v7d/VlpJuPnxguO4mUF5tUxUhlsbmsACvPx1SF5rITw6WF5pOFQ2UF12VJWsnu8uS9Jcn7SpP37fNb6GdH8WWSPBk20thd/b09o38IAABg7IGABgCMXYjJePO7SytmTvciUT0ptIgpbkf37iyXCAtj4jSxCTclh/oPqfTH1Z2FqnOipLWfzF7CZc3n0ha5MLaGLLz5damx+w6G17OBuELObMSnRd9zp+ladV1BmjpLpBk5NVlK3GR7ZDRS4p7b6pF7miiIQ5T/aUATf+AfB/TIvN/K78/7OzfeLDC/uRDwt5Xm9+bN/cDxXCZO0LM84lOdFY+PTiHWZSVolZKR24PrlBK1HA9lvKHj8Q+qZCKVTKzFA5oYMd7TlTJhuZyvUgrq8hK+Lcj85nDy2UxhfaagSsYnTrzO5KnS41SWx8zVIdGunNUO1Ggn29TPpz9OEpuO5A6fLDaXFyMVRUh5kbmscLgkHys7Ya4sGC7NHy4tHi4rHigrvCpL0iXur0iOKU3eXxK/Z/3n0305ZDygvdi2ZbmKocGB0T8EAAAw9kBAAwDGtO7218q4/Z50hrst1Z1G3zBvbnFcXOF+fvG+hNq9mY0Z+a+PV1wUpayd8ckiDvMLDnWRC3P/yoCmK7XG7nuIpZ4xw4Nh0wOzobXv5fWf6o7pciWVxC21hdpMflUmEdB4NI+MWs4bSWfLTQEFqqx/KaB/7d2RK/zeb+g/38jxfjq/OyOnfLw/I2fqvR/QIw39znN84quVCVUKiU4ePzIauRjPaLyeiUcFMRrizGliNERe8ysy4/BXrpbzT8kFZ6WieuJOMTxio0tmrDYzrjI9RiMVJER4LXdmRjtQV9iNy/Vb2HlQhhXnm8tK8IDG8HouLRw+mU9MWb55ZP9GaRFWXtJ9suC7dEl1Kh8PaFVq3OHdXy2f5uLHpvgwSd4O1B/O1pmMxtE/AQAAMPZAQAMAxjS8qG7++MPGJYs8afQlFMpSBm37/Pkl+4VlosyTMZmnxIoz4tTNs+cuZTO/ZJEXu7L2LPO5f7kO6WnChh5gxoeY8bEZeWLqa+p4+OM35UqNEk/PODUeglK+TobXM7HReSSdf7eEjAexZTRKYhfEn8y/EtB/ntGjAnpUTP9JQI/MH65AW9aeicPmqhTianl8Fd7NxI2+RUQ9S4ndGiMNrVHEq5SWWx4SlwaKtFKxRop/HA9rwUguV0t59XJhDbGhxXI+SUasLp1oaPz7Jgx1XzGevYJLXsH6+NTm1UMn8ohNGhVFaEWhubRguCR/uPgEdvIEsQJddmK4jNi/gZaXvCg8fD5FoE3hqVJ5FYmx8WE+wU4sXyaxAXrFZ9Mab/2MoujonwAAABh7IKABAGOa2Wzu6+nWHj8SOXmSO9nGnWobwGbvWuBRIEzTKYqytvPWzpnnTme4s+hL7KgbvOfd/aEG7W9B9Q9Q4yPM8NhseoIMtLxo/u5ciUyLJ2lGTLXlkA1NZpwa72biJtgjGWrZUkzsNn5brkoBcUPBrH8hoInbcQt/7ebf1rDfy+g/DOiRhn43sn+dUQE9cmngnwf0u0Ps4pCLa2TxtfKEWkVCjUJSrZCMLEXjuYzXs1oRX6kQVSqEKpnwbUDHq6Ui/D9VcuIED62Mh9ezjjg+D/92xeky4qoz4lRp+zWZ/Ix1oVHjWXhAb3ZktKQnIsXHzeVFKHFWXcHwSECX5COlJ5Cy4+bSY/hHzKWFxvLi+7mK03hAHxCoDggK4ravneXmx6b4MYljCqW7txJn2MEVhACADwEENABgrDNjWPuLF8dTEkPGO3kySD50SpCdw/JZn+8OXhEx5wt3LteDxVxMI/k6Mw/GbHr8y9fdT6+b+prN+idmw1N9d3PT9fpTJXJNVnyVQlQtE1Rl8oiAlvErpHGVxF0G3wS05ao7y9EZRLYS51cQ98H+Z6PJIu7XTQT020XrUQ2teedIjT8P6FH1TAyesG8DWvc2oC13KLTsSCbq33KfFDlxs+4qmahGgbeyWJPGK0/al8/blr0tOnllUHyENy/IPTZgsSDEUxLll/lV5OF9G0vi95SlxGoyiYxWEWfbiTQysU4m0crjiY3RclGlTKBSEIf0VSneBPSvK9CaDPwT+aXxO5PCvfgLZtVtXdt3PBfFA/pkvrmsYLiiaLiscPgkkdF4T2PlxC4OjHhe3FVy4of0hJpkniZNqE0XxQV6BDowfFhkb6ZtxFTXr3Uqo35o9L89AACMSRDQAIAPAIoizx89zI3nBzqxfZkkfxbVj033t+f4cFleLJoXk+rJIC9lkAJc2GsXzOKvCio4EPdTfemrez80fVdTfyyzKju5WpFQTRzZJtBkEPWpVggr5EQjEjfBttTzr+u4WsshFVqlxDLx70fz7+btLbvfXWn+kxn5wyPd/O65HKMWnomFbeIMDfzjeNDzdJaKxRsaT2qVQqhWiCqIzSfEvgudEv/FQELc3+QA/8TeTfI14TzvBdu/mBk92WX5RIcIV26EMzvUgRVmz4xwZIc7sMIdWeHO7OjpE7bMnx0f7qPYEl2aGlelSNRI43UKiZq4rBD/AsSVeJ3jX8mb98V/wbBcZJkZZ6lny7kl+JO0mLNpvKaDaf1Fh9GiY0Q041NWNFxeRCxCl755jpQXmSqLe8oLrslTTiXxqlIE2lRR3s4N4W5O3myqJ5viZU/dG+H/8skjMyw/AwA+EBDQAICxzoxhg/29965dlu/eGuzI9KXbWO7RTQpgkQMY5CAaCR9/qk0AzTaYSQ5m08IcWSsmOW36fOZez/lx/u5JUQG529aViffUZIiqMkWaTKFKyq+UC0bmzdqwgkjnt3cb+bWe/3lAj+yBfi9/f38s9D8IaMuIdVnx+Ix+WcsJdFpiFVw4sgaskxGhr1bg0S8kNl2MnEYnFejSeaXindK1IXs95q6fPTF6ssMyF9YKV06EHT2cQ43g0qM4jCg2LYJOjqSTl9EpyxgU4gmXEWXHWO7IXuXmtOHTqfg3SvZVVIlwpzpDoCUaWqCS8VX4N8dyL0ZiLHdnfJPOxB5ooqerFcJzSvF1RcLjI9LewjyktICYskKksgipLDZVFOFjqCjuKT3xPD/vJ2lSvSRGJ4nVJgkO7diw5tNpXmwKHtDubFLkp5O/rasyGvSj/+EBAGCsgoAGAIxdZrPZZDDcv3mtMF2y229RlJtTAJfqzyLj48si++HDIPnTSX40kh+FCOgQFjWcS4/kMpfbs5bbM1c6sqOdudGu9isn2H81c2J8sGchbzve0JUZvErLjawtK9BCy1EbozZsEKe8/ZWA/kcN/ft6Hgloyci8/174l1StEFUrBFUj+57fbAsZWTgX6mTCiqS9mav8d3w5dc00hxWT2CvGs5a7MKKc6JEO9AgHRoQjI9yeHs5lhOG/VLAo4XhGs6lRHDre05EsShSbuoxDW86hL2PTVziyo1zYq2eMl0T4lEh24w2tU8Zr5MRi/Mjea0tD8zTSOMu8OfWvSi6oVwi+kQmuKiWNh9JflxzRV5Xqq8sHa8r6q0p7NEWvTh5tOiy/nCE5HR9TI96nk8SoE3iy9Ssjp7guZVM8GCR8/CZwC+UpxP1TAADgwwEBDQAYi/B0RhDT8wfN2kNSQZjn6pku4S70YHuaP5fqwyH72NMDx9uFTnWJnO226otPvlo0d4P7Fxs95q1f+OnqT6eumDYhwtUuxIEe7sDAM5pYf+VQIx0Y4U7MNbMmJkb5VyTHqKV4y8ZrlMQdrdWK3+53/U6//ksB/esWjt8NUdV/vKnjjwI64e1I3q5Gv3nTkYCuUQirFELtyNWNWUK1nF+lFGkzeXm71+z1/nzDTKc1k1grxtOXj2dEuTIixzOWTbZbPWv81kWz9/jMT4oOk21dc2jfliOx27N2fJW0Onyn94INX8xcPs0l2JkV6ECPsmes5DJWcOjhbGoolxYxgbNmziTF5hWadH6VDH93sY5YmydubaiVE3uv31y5aAlonYw46q5Ozjsj5V3IFFzOSvrlSOa9fOWNw9LL2SmXZPGnk2OrJfs04j2a+H3q+P2qhLj0NVHhU1zcmSQPJmkJ3cadRUrcuubZgxYMg8M3AAAfEghoAMCYg9fzQG/Pt3Wa1A3LN37iEuVEDXekBDtR/R1pQW72u4Lcc0W7aguyb17QPb57ue3xL+3PGl6/aGh/fu/141uPbl366XSF6lBa5s51axbM8ndgBNvTwxxZYXhA40ntyIyaYLfbfW6RYCceiDqFRENcCDh6Rvr1zVHKlqj983k3qUfvx/h9W/++nkWWT/81oH+bkYa2BLSlYomXJT63SimsU4qq02IV60K/mjNh1RSHNW7caDf2ikmssAmMNZ+7Ja4OUikkl6uLXt39vuvxrZ6XDb1tLX0dD/Dp7Wjpbrvf/uxO681L5yqOFmSK9kb6hrjZhzrQI+wZoRxqGD5carAdFc9oUchS7QF+rUJSbTnNA/8+WLaGE1vG321oYn1aSewwqZHx66T8uvS42rS46pRYXXKMJmm/OnF/ZcJ+dVKcOolXxNsliQgMGe+A1/Mihs0C+rglbNKuYK/7N64hJjj7GQDwgYGABgCMLRiGvn7+tFRxYLv73JVu3GWOtAg8oCew1s2flrkz+ofqwscNP/S0NQz2P9EPPUfQDtTcg5i7TZbB/xMxtRv1rwZ6HuM9fe/ahZoTiv3L/CJmTQpy5QTjDe3IinBkRY7n7vWYp06KrVMkVGVJNAq8ZeN1ORK1UoQ/Es8tWWwJ6D8O3HfmDxr63fnT5WeRZdU5UZeVZHkkXrAqO/HX7RxEQCvxhLU8x+s5i6jnU5n89EjvLXMmrp5sHz3FYflku6ip9puWfHIoZuO9S7qXTVeGOpqNA08Q4ysEaSO+Pxj+/ekxYd3IcDf+jUKxLtTUYRh43t/16Mn9az+fVyv2b1z95cyQCXaBXBqx34NFC+XSw53Z+70WqBJjqmWiWvyLtJyRZ1mtf7MO/ebejW9v3PjmIxk87YE4TWqcOiWuMjm2Iim2TBJTzN+TFh0RPWtygCPbg0FawiQtZIxbZEfaEep984dvjQY9XDsIAPjgQEADAMYQFEWetNzP5u1cN2fSMidGlCMjzIWxavb4nP3rb54r7315e6i31Wh6bkRe6bF2g7nTZO7CAxoz96LmXhPWgz8nehqPRXyQLoOxfaD/yYvHN7/WFSRuXBE21TXIkRnhzI1wYi+faB/nPb8yfl8tXqiWvRNVeDqPTLblP//VgP5138XodH4zf7L8/EcB/c6mEZEGD3pFPD5V2RK8v2uzRbWZvOz1YVtmjV8/1Wn1FIeV05zXzp+ZFbPpxjlV7/O7poGnBsNzlPi2dA6ZO/XDPQYinftMWD+KDSBYH2rGn/ShaC+G9prRXsTQZRh61dPZ3Hjt7LEU3vqFnwbZs8K4zDAuI9SeGe7CFQR46A7w65UJNcTtDMVaPKAtVxb+FtByXqVlKqSxWjm/Siaok8bXpIu0ybwi3s7M9cti/N1XzpjkZ8/0ZJKX0MYtIdaeP1rqTBNsWH7vxlWjHuoZAPBBgoAGAIwVCGJqvXcrfsPyZTOcw51Zkc6s8Al2axfNrjkm7Xx8yzDw2GB4akJfDCHP9VibAWtHsE4U6TL2v+rveNrT/qin7eFg93M8CjG0D7OUohHFC7LbgLQP9D5+9eDWxfLje4M9wyc7hblwIp3Zq92chH6LtAf4dYqEamLp15LOb1egibuQEBktea+YrQvoUcVclSN+9/S6dwKaeCm8nomt2MTpdW+a+81dUbLFVVnC+pz4o7tW7XeftW6649qZLqs+ceUv8/vloq7zyW1T7xPU8NKEthvQ1wasw4B14WNEu/FWRvTdQ/3tg33t+r52dKjbjAyYUXwGEVMfgvQZsJ4B7LXB2Nb9srnl6tfpm9eET3YJdmAH2zFD7FhhTmxBoLsqKaZOLqklzssTa2QCzbsBLeVVZsaqFfxKIqAFpZJdCRG+e5fM2zhnavS08aET7HztaD5sijtt3FIGaRH1oyUc0sr5MwuVBx633EdMJqhnAMAHCgIaADAmoIip5c7NxA3LQyZyAhypAU6MkMkO/FXB39eV9rc3I8aXRtMLI/LCgLw0YW0I8nqg6/HN789qThzKTeAlbl0vWLdC9NWqtJ1bjqVI6oqPN9+4jPS346WIEuuvPUak02TEC/Jp888X5fs2hk5zipzAXenKWTfVOWV5YE2muE6ZWEOEbLw2mxiiibNF1Vmiqn+wR/nfC+iRev5dQ799/d8uWPztqkSBLktQRVxEKK5WimqyRZWpu4XB87fOc/tqzvivvpxaKRc9vfe9aeAJMvQCNb02Ie0o2oH/Nc1ot6H3RcP1705VFhdnZR5OjZfG7k3fu1Met/9ISkJ5Xs7lc6cMve2oqR/DBk1on364x2TuMSGdyNDr1w9vV2anhU4f72vPCOIyQvCMdmLGeM+vThPWySRVMuLe4G+vKeQTh0PL4jTSWLU0TiPn6aS85BX+y9zswu2ZIWxaMIviy6J4s8ieTNul+HAoYTMnHti96eo353q7OjG4ZTcA4EMGAQ0A+PuZMezFowfS3ZvCx3MC2KQgJ1bkHLcswfYHd77XD74wmdpMaPsQ+moIeTkw8Lj53g8FWSk7IwOXz/s00G28n7OdrwPHz47jb8cOsLMLdHAKcXNbt2iBZN3qcyWFbQ8aEX0PgvYa8azEOo2GFy9arxanC9bMcVsz0WHdJIct86YXxG6pkyfU5SRV/Q8H9B819K8B/fYV3tazRsnXKvk6Kb9aJqhRinQy3uF90Xu95mxfNJ0f7v5N2aHeF7eNhqcI8spoeoWg7SjSMdD79EHDTydkybuiglbOnxs81c3P1dnb2XGpA9fTjutpb+ft5OQ7aWLwrFnrg/zzMlIeNtzUD3SgSB/x/cF6hkwdJqSjv/PhqYKctQvmBNgxwrisYHt6iDMrKdK3Kk1QqyDu5khcWGlpaOLmiHJelYynzozBvzxdJi8x0jvChRXGoREbqRmUQAbVl00JcOUsnzM5bdfmK+dPtz1/ajIaYOEZAPChg4AGAPztzF3tbQXS5KipLgEsUrAdLWKa6/FUYduTBr2hc8jUaUC6TMYOo6Ht0f2rRzLFy5d+7jHJfokd051B86bTAhg0fxrFl2zrTyEFUsgBFIo/herPoAfZ24W5TdwdElhXcLS/7bEJfx2sa8jcYUDaOp7dKUyKXTnFZd0U502fjM9aE1ovFdXgIZst0RDzJoursyT//27heLeeq/B0fnO14u8Oy9NlETdPIQ67wMdy/HMNnqqZcSfF26TrQ/b5zxMu97p3SafvbDIMPTagL41IG/4LBqZ/9aTxulywO2rhp0sn2Hk4spay6UsZtKVUqjuN4k6nLKHZLqbYLiLbLqZS3JnMxSzWEntu1Odz8uKFj2//jBl6UKSHaGhzD/5dGuh69GNdxbov5wRxWaEsWjiXvmKSg2L98mopsYujJltSpSR+u9Ap+FpZnI7YyEGcD40/KeBtWjd7YgiXGsykBNPJgTRKoAMnPzXp1g/fdrS9NBognQEA/0dAQAMA/mYG/dA3tZro+bP8uLQge9qK6a5Zeze/enjPZBocQoeG0D6TsWew/em3VRXbw/x9prjMZ1MWMEmL6CQPBsWbTvFj0XxZ1CBHdqirXbirXTCHHsCghDBpgURb0wMc7aJmzziwY9Ozplt4Qw8RDd1pNLx63ng1e8/GtZ9M2jpzfEa4V32GgLjRd06iKidRnZ2ozUqsykqoViZUjc7l9+dfCWhhVc7v65kIaMnIjPrc6ixifffN/f/wwTNaGlstjTuxb13a2iDFzlW3zlca+x4hQ0+Nxud64wsUfY3qX107W7Uj1N/ThbuYRfFgk5eyKV4cOv4LhgeD4clh+bs6BE92jpw1KcjN0ZPLcKdTfRhMLyrVi071dXDY6utTczS37/UTFO0ZxLr6zV0GtMvQ+/xiZfHKT6ZFspkRdEoIixo9fXyxYFetIsGyiwOvZ0GVUlCtJPZyEGdxjNxjJT1GvjEiarI9cb8bBsWfSvbnsi6oKvSDg6P/1a2EYShqGkRN/ahpAEPxEIcdIACAvxMENADg72TGsKetTXui/Lwdab529LBJTsnrVz67e82k7zagej2mNxp7u14+KjukCPt89gI75gIWZQGDvIBBWsiiLOYyPBzZ0V/Ozordps3NvFhx9GLZ4ZI0YUyoj68Dy4/D8Gcz/blsHzuu30TX2NXLm3+5gmDdQ0g7inWa+p89vf29bMuqjbNc0yO8atJ4NXhAZxHLz1rL4HFMHMTx11agdVlvVqDfXXh+N53f/9yRDRIjVWqZOLU0tiJtb96+Nco90S2Xaw1dzYj+mUH/zGh4iRrbBrsfVBcfCvls+iIu05PD8GCQvdhUDxZ5CZu6iEVf8dmcg7y936iKGr8/9fjm1zfOaY5K4lZ8OnMpk+7FpHuSbT2oVE87uwC3SUr+/hetd4xIF/47hhHrRo2dvS9aFft3hDlyQxiUUDYtkEPd5zlfnRJXrbQsz2eLq5VCPKCrlG++WqKhM2LVqTEHVgUFOzH8WFQ/OtmbQRWvWfn6+bO/svaMFzNq6sSQ18NYhxltx9B21NRjxpC/8poAAPBXQEADAP5G5r7uTtXhrMDJXC87ctBEh71hfg0/XEQGu03IoBEzmNDBgc4X5blK72mT5rPpC+iUxQy8C2kLOPQv8Xqe6ByzOvLqeV37s7t93Y/6+h4NDjzp7WhtvfXd0QRe+LTJ3hy2P5vlz+F423G9J7ruWRn5qPFnk6HDaHqNIq+Ng08bf6iThHsmRXrr0ni1ckmVMgGfkTJ+uxn6nwT0+7cq/DWL3wxxpeBv683vpPNv/f1+QI9cpfcmoGUx5en7DvLXX6kvNPa2IIanBuNzxITX8+uh7seHU+MCZk1cyKUvYVKXMqieTIo7g4TX80I7xsovP7954Uz305aB7mfGoeeo6aVx4FnPi6brp7Tr3Rd6cBheDKo3g+7FwLOb4TfRJW511PPWX1Ck24DXKtpj1Hc8unt1i8f8AC49lMsIYdMjnNg5m1ZpM0VaPKBz4muUwlqlEA/oka+WCOjMOG0mX5Ucs993QZAj04dJ9mZSw6dOqD9ZZBgaGv2P/y8xj9SzGetA8XQ2d2NYF4ZnNNKBIb1mMzL6jwMAwP8KCGgAwN8GMZnuXb+6xWehjwPZx4m6dvFnZ0sLDP09JtQ0ZNKbUINxsOf6+frILz/7gkVdSKe4M2lL6JSFTOoXHMaSKRPiNq9puvXjYN+LIUPbENoxgLUPYu0mtNM01Nb+uDGPH+fOYnkzmX4spg+L5cFmeU1w4a+PftHyC2JsN6JtBvTVYO+Db4qzMzZGqg7EEQdxyPEoJHZuEPuSLQGtfXNj7T+Z91edRwU08ZF36jmh6s0e638Y0FXE8c8CfEYCuiJjX0n63qr8tP6uBoPxsd70VG98gRjaBruelOQc8HJzWMylurOonkQNU72YxP6NRVxa+LxZ3+kqB14/Mxq69aYuPdYxiL4y4t8fpNPY//L6maroBXPxhvZh0r1pNB8GYymT7ulsJ1y/8lnTTdTYiSBdQ2j3oKH9YmX+sllugRx6GJMWzqJtmDVZm8Yn7vCCB7RCWKsQVr8N6DdL5lJ+lVRYLNq1Yd4Mbw7Fm0nx5TK2+S19eP8ehmGjfwL+GQxDEFMPhnWjWDdmJs6xRrB+s7nfjPVgaBdq6h+GRWgAwN8BAhoA8Lfp6+k5eVDp6cTy4JKWzZlYKk/ubXuKoCaDGTUgxqG+7sunarYEeM/n0OczyIvoZLye8VnApH3hwFkZ6HX98kX9UMeQocOAdA7hYx7ZftCFId3oYEfD95dWzZvnzqD7sPBMZPiw2Us5bJ+J4w/s3tL9vNFkatOb2/Wm552PflZnJ5alxtbKE+otU6OUjBzHocnBA3p0H//5jK7nt/P7gP71nikSrWU7xLuvMBLQvy3rZsaqpLHlWYL2x1f1hkdD2HM99sJkfGXoe14oS/n/2Hvvt6jOtW//P3i/z04EpleKNaaYHRO7dIZi7y0mxoIFELBQhyagtKGq2Oh9YArN3jWxd7GLdBiYvvp873tGDDE72XnedyfuHMc6j+tYezHMjKyV+eGca3/u617w9efuAoYXkGYeU8Jh+XKZEj7DU8iYKWSoiw8aetsRowZBdQipNVADRgsscItIYggZ7KzOy5A4CyU8YM9sfw7bl830Af49WpQQuK73xQMM1ZgpnZEa1PY9O5K4e/FYpyU8znIue7GQvfe7RQpZnCJH2pQbBwRaNfzXDmdOIhuyYurTow/t2LT6q/F+ApaEzZjjIizKTDXotP/b0AWBGwnwX5PU4VCdjThlJigzThpsDk0RepKkh0nT0NB8AGiBpqGh+TCQBPHk3p1NcyVuIrbvOEHUd4t7XtwjUD1CoAiOm42GH4+3rnGf7e4kmM1nufIY7lx7D46DB5fpKuC4jh+dEBnWP9BpxIZM2CCCDWL4IEYM4uQQTgwB5aJQbe/LJzvXrJjNY3nz2b58jj+P58fnewv587/8tDx3r0kPTLTPTHbjxvZXN8+U741SyZKAPTdnJzRmxyvhpiqx9aByYn9tyb9TNlf+DXW2hTfeC4HEv/8OcE4czEXYrLQhK6omK+ru+VoCeY3gb0wUHINNmnrO1JfN+Wy8t5gP7NmL6+DFZXhzWT48Bkw/i1nTRExN51MMGURQPYYacFyHUoNmiwYKtHXqM4UOvrp11W+8s7eALeEx/bhMf2sBEQcOnRuz09Dfbia0RkqHEv39L24H+bovFvCW87hL+Kx1X39SnhiuyolvykloyolX5Vjn/Y3oQ9dnwfHVisy4vRtWLBgr9uUwfQXsdR4zb1+5iGPY+5+D3wZ8QihSRxFDJLBnykBQJmDPJGXCCT1FGS2kDhSFm+kmNA0NzV8PLdA0NDQfBr1OW3Ew12ei83QBI2DSuNLsZNTYh+N6FDfhmLnz6ZOEjRvcRQJXHnsWjzGLa+/KtXPj2rtxGTP5bNdPxmSlxOmNGgOpMxJDCJBmoFmgSC0ON/TWkqSup+NZ+LrVMwQsTwHbR8CBDs23OrRY8J3E9fmDHxG8F7H0EUSPvvfxydJ8Zc6eJlliS06CGpjuzxud/DuBHt73RJ5t26xbai1o3j8PsMv5l53pfx2htnWgbUoK1+fJYpuPZQx13cWQdoyEk7BJvO/F3aub50m8RDwfHtsbCDSP6cFjefJYQKY9eQ6ejux/cuz0wICRITNmIFADhelIYhAjBxAo0BrCorPg2t62u37jXTwFLC8+04fP9OMx/LkMPy5DIuQs+PLT86pak6EXofQINUCgfYqCjOVjXZbwOCuE3MXO3MwNK5RZ0sachMbcBFWudKRA244KuL4wrjJ5d7D3TH8hR8JjzRktztgVpunt+V80jAnUgg9AS6YMOKm35jcMBKknSYOF0lssBgofspAILdA0NDR/PbRA09DQfAAokux6/TIhaMNsZ/ZMJ84qn9lXTzfh6BCG6zFMj2gHztVVLfh0ohef585lz+IyZnDtZvHs3Hj2cP6GkOs61lkaFqQZ7DFReqNFi1JagtSS4GjRgXOUGsLxoVdP7343TzJTwAYC7cVnS6BAcwP4fIlQ4P/pWFXJQQIfQMh+GAs2vLl/XqXKS27KTmrOTVTlxSvy4xRvvfCPC3Q0KKtD/7wR93DFwiiItd4J9G+lqBVwkh0UaOs2LtK6nLhbZ+oI8xsM70SJXhTro8x9R1PjfMY6+vDZvlyWN4/tAYoPCjg0wweUmP0N1+7Bj+dQVGfGjCRmsGBaCz5EkRqcGkAt8AsGhQ1dO9noM9rJS8j14rO8+TD7ARw6gM/05TO9HHmhqxYPdr/ACDgZGsX6X969GixxX+4kXCrgLBazt3tMaUiLbsxNUuXGjxToBhlQZ5jetqZQpMrs+CO7ty7+xFkiAKLPXj75i1sXzv3xJjRFmCkg0BY9CdvPetICjwT0ab2Fgu1nC6GnCFqgaWhoPgC0QNPQ0HwAgEXd++nqeslsd0eW53hx6HcrBrpewbQupiUQTf+rR/Hr17rzuJ5sjgeHPZvLmMmzn8W3d+PbuwOBhosI+cu9PZ7ev4MReqDLsOVMDZEWLWYZQuBRiyL9V0+ovSeOdRdwvflsb6tAW4McXImA7zPWKWVHEIFpUAKursPRnu7HPzUdTG/K29OYl6jMTwACrcyVqrNjlf9eoN9a8juB/rVP/6KGHfr99xmudx1om0DX5CcMdd+niB6E7DXjfSQ5hGo6lkz7p7eTQMJl+nKZXnyOB5/jbhVoLx7Dl8fw5jFm8RwOpMRhJi1KGOGqO1JrIQctpIakNAQFu/W4sT8/IdrHxcmTzwHfLryAQAugOvvDzbeZnkKOxzina2ebMRRGPlByEB18UxAZunyc8wpH/hIha/k4YXXCjsb8Pcp8+H0DOLS1Xw4nQytkUQ2wouGFyOJVWQk75nj6i3i+PE6AWJAeFqwd6PuDTWg4qA4fslB6ymIC9mwrKNBAnYFDwxMDQaDvv4yGhobmz4cWaBoamg8AYjKeklcv+ny872j+3H9+UpiejBi1ZkSPoIOIruOSqmL+pHHA7bw5XE8Ox43Lms1nzBY4uPPtPWEYmjWLx3UfP65w317cNEQRQxZiCDiiTaAx2GEdGux6nhoU6M7jeXM5PjAcDAUaOrSA5ysUeLuIf5gnMQx2YOSgkRpAsV5T37PTpQWN+SlN+XtU+cCh45R5sY3ZsSprMOOP1EiBtp0PP/Ku4K9sGv070WpbBtom0A250hO1+wmsCyd7EXIAIQYoTHNRXevuLPQR8WB2GUgzVGeOmwA2ob3h2DgmcGgPAWudn2d7232CNKJAOi06i0VrsWgoyyBJacG9uv/j+dVebl5ioTeP48Nj+fBZNoEG9uwnYHmJODNEnPTYcLOxB+5NSA2S4AtJY+2Kz8ctdxYuF3MXChm5gavB9w0lvFe/EGgVuMasKOtoDnAJcars+KORwUs+Ge3H5/rxOKu/+fLqyRYM/YPWSxGYicR1FGUkKT1J6SiLEWo0ZVtEqCcwI0X9ryd70NDQ0Py/Qws0DQ3NB0A7qDm0N9FvnNhvjGCJ69c/nj+OmPUIZjAj/X2vbmeFb/Jy4njw2F5wRDHbg8dy5zGtxXDjMtx4zFl89kwxb6X7rEtNDYRpgMK1JKGDS81IHUFotf2v6w/nL5j0mZeA5w0snM8ErukjYHkLOD5CLlBPH0fB0umTH10/RxADKNWPEj2Yof368WpVfnJzfnJjfpIyL0GRG6fOlv5bgW6wZhXg8Obs2JHn1gwDrIbs6AbrbiM/Lw18+1prThqGH37OdShy4pSyWBXcjDBakRtblxf74KcmiuzDiX4TCf7UQWSoY1/IVh8nIbgQibVhDK7LC8ZU4CQ7mGaGu6gw3QUM99GCfOkuo6aDJIFlAuO05oYpuCav79WjnWuWeTkLfQVcoOASa/t5uFg+Ira3kO0uYn8f4N7d/tBMasC/S2AD+jeP17tOWeosWu0kWCpgR/q7NeYkqvYnqvLjbAJtG7038krhHZDFKTLjwwPc5znx/XgsPzEvLXSbpqf7DzehSWDJJD5IUaC04CqgScO8+yCJDpKw/fyH3oeGhobmPwst0DQ0NB+Avu7OXd+v8B7N8xsvClwW8Ob1YxQ1mFGdydTz+KfjGz2negtZnny2J9yMmu1pXSHnYXVoNz7TTcCaBUxazJkt5q7xcasvKuxrf0oiOgozIPr+B9cv5SXFLvzmnx4ivo+Q520VSptAewk5XiIO3EBEzJ/3xQRF6QEC78OIXpTswZE3L+6cUeTtaclLbspLBALdkBevyo5TyYANQ+X9rXonyu8V8GBb/VIorSvtRiQ9bAKteGfPOXHqHOnbwXC5scrCpK4XPxFEH473IZZBhNS8uH/tB083P7FQIuRJBGw/OPWZZbtGHz4TCLSXgOkBSsSaLWR4jxEWxEfcu3qONA1ZcIMFN1ow3ZNbV+K2rPMd7+Ir5vrzWAHW3rOt/QzsGdx2LzEbvBuoJVM/v3vtBEIMYDD1oaGM3Yk/rFo6zmmlo3CZgBM47YuGtBh1QaJ6hEDbFhGOvN56+H0gsXDHpqWfOPmDf0XAWvLlxNuXzhP4H94DBUg0bqYwLQlj3FqSHCLwIRLXkQRC2zMNDc2HghZoGhqaD0DHy+ffes/0cObO/cwlPnyjRtOOwvyG1mToutJS5TdWAETQE2ZzuV5We37r0HyWO5/lIWABjXblM2fzmTPFvPnf/HPz4vl7woOzYiNit2xcF+Dj//kn3k4ioJhwsptNoPnwxCrQXHD0AQ49wTk3aTdi6sSIPoTswdCO/lc3gUA35SQ15iYo8+KhQAOdldnCCf+mlLL3S5EVDev9juz7Am1bbPdrgYb5jZzY1pL0ga47QPEJst9MaVBi4GJj3ZwJ4/1FQjhXRMT2E1gvcIRAWxvSTC8Ry03AcBezfD9x+dbDNXb9unxpdE5MRNyWDYFzfed8Ns7bkScRsv0FLD8+01fIkght+Q2rQItsPWn2vEljz7ZUmTFwfzQ4PmAx91WkJywa77REzF8m4q75zKU6aYc6L0Gd975Aj3ToBhhKiVOkxwZ5Tpkjhn+wxJGbFxup1w79wSa0FfBcgiRRkjSTJGI9If43L6ehoaH5D0MLNA0NzV8NRZLPH91fNvOfHo7ceV+Oy90bpdN3YZgex3QmbYe6KHc2dxRwQdiBFnCtS9zeNqFtDu3GZXgK2O4CKNNufJargOPuKPQZ6+I/cZzv+NHezmJvMd9HyPHnc/z4bB8hGzilL+yzQoH2FHK8YXG9xojitv+gG3qBkv0I2YthHbqu+02H0tS5iarcuIY8KShVjjUG/Ws5HmHD/yq38POv6mXRclkUTEKPkOaf7TknRvkLgYbjLKA9y2JUcP/C2NPlMm3fA4zsIYg+8HdiWH+ZbJ+PWDxHKJDAOApbIrTa87BAgwLnnjwGvHtAo2EXn+UnEs51cV4wftyCT8bPGz/G30UsEfP8xDx/EccfOLSQDQTaR8SyCbT1awbcDxz27McJFeX7zUgPSmoIctCCay7Vly78dPQCMXepI2/5eFFpdJA6N/49gX7PoeGehdnxykxp3ta1i8YJYcCaz1jrNu3RresE8Yeb0MNYpdlWNDQ0NB8SWqBpaGj+anAcu3f96uIpn7uLuQFfji86kGZC+3FcT6BaXf+ro6kxrhw7b6vveghsMyLeFnRoPstLwIEmzWV6g0c4DE9wYn2aRMQF5Svk+gpgp9NfwPa1dmTfCrSQDYVSCBPDPiKOhwt/d+AqTX8bSvSZqV4U69D3PDxRkt2YBwQ6HthzfR4UXNUvu8sKON7Ymq/Ijqm3rhEc6dDvch312THAm+usVZsVaTsBT64DL/m592wrq0Bnw+nRCuswOBVcuWgdwZErPVuVo9c8NhNdGNGLkf0EPpAWtk0iFM7h8/1FPC8B01sIjfkXAm29ZBhltqqqn4ATwIc1R8ANgMWZI+KCOzPH0SrQYlaAiO0rYo8UaPBuvlxwznZ34pTvTzMZu1BCgxMaCut/cOXEymlfzHfmL3biLRnDPxS6viknvnF4Csc7gR7p0PVZcCC0Miu2OjF8s+vkAEcO+NskLvyirFSDboieQEdDQ/M3hRZoGhqavxocQ69fOD3/nxPcgMN9OaGmpMCMD+DEEIkNDXU/y9wd7AHbz0xPIdtTyPGyTnH+2aG5TC+4YwjLi8vyhlOQ4eZ53jwGbJryWUAB/a1HPyEb5nqFIzrQVoH2ErE9bW1aF37kljUD/U8Qos9EdKNoh6730anSHDXcGQR2oOW5tqFs0Q3vZmLAJYPAqq0nVgm2CnSMrazrBa3jNXJi5dkxdTJQ0XVZ0fKsKFg2mR42abltWaHMVvCFDW8XFEKBVudAH1Xmx5+ryTNqn5jILoLsQ7FeAumXbljrK+DP4fP8wJ0RsiRieHW2mIrNoWGOmceAJ9bgClxoKIBrDf15zDk85lwBe66ANVfEAd7sL2b7Chn+QJ2tAg3nb1jvErhjfjAbzXYVMvNTogy6DpwcBAJNYn0vH1zd4Dt7/mjhIkfuImduXuAauHHjvxLoEQ4d2wAuMCtakRGdvn7ZgrFCCYyaMAL9PV4/ayNJeoYGDQ3N3xJaoGloaP5qMBT58czxeV+McxNw5kz6pK7sAFyphg+SmGaw60lS0HoPPpyY4SXmeIrY4MTWYLaVN8/qzcPlxQM+Dfev9uEzrMbMshUwQm+xtYRvO9C2cAIQaHD0FrK9xwqSd23SaZ+b8W4z0Y1hHfrehyeLZaqceCjQubHyHNtQtlhFbiwMYMhgBkORK62HUzWsnWOr7yqzpUqZVJElbciE3dZ6KNPSellsXVaMrRoyo0DBPa5tTejhzjRUTGtO2pb0sC4ohD1pINCNuXFwGWJewrnqAsNQm5HsxIlenOgn0P7o71dJBPx5QoGfiAuvTgS/JEBptgWgR9TbGAYQa6GDj9ABurKQMUfIDBAw5ohY/mKWn4jpI2L4Dd8uP5iHtgZdoHNz/IFAi1gZ0jCD9g1ODaHEAEkMdD2/vX2J3/wxQKB5Cxw5sh+WN2f/ogNt3cf7Z4e2XmOMPNO6N2FWbEVC2NrJnwQI2HDDcBf+GaX8D8+zo6GhofnvghZoGhqavxog0FdPH184aYI7nzvns4m1xfsRfADFBzC0T9PdlrD1Bw8B10fIhXEL0duML5wvMVzv4gq2ZXOeAmveV8DwFgIjhFIItBLIJXitTZdHCrQntGf4bpLxwrzknai53YR1oGQXirZre+43HUxtzIlXw71OgEDDtIYS9pVtm5tIoStbdVkli7OWVC2TNsoSmmQJjVnx6sw4VYZUmRkHSpEprc+QNsCKVWZEKTOjoChnwjgHTHRkRdZnRtrE2ubWMCqdHS23tmxhANr2L+bGn6vK12seI2Q3TsIIB4n1R/2wykfAm8Pn+QKBFjElYtZIgX7v/gCBBuceQoYnuCEihgTqMix/EdMPmjcDJjfgCsIRAi2Ed8lPwPYXctwc2XnJkQZ9J05pUUJD4gN9L+/tXrlg/mjRIif+fDE7bc2iJlncO4G2BjZ+Yc82ga63teEzIhXpMeGSWfPFXAmX4cVnJAdv0g4MvP/hoKGhofk7QAs0DQ3NXw2OoTcunF3y1WcePO6cTyZUHcoxIz0Y0Y9gPZrep1nRoW582Hj2ErC9YQf6fYH+ZbE8BSzo0FZNBOUlgovnbAXf5P0ONMtHDBMLcz53rizci2MdCPYGwd+gyCtN+w1FTnxTdrxaZms5xyqzYoEoK2Xxyqw4FTDjDKkiLaYhNbo+OaI2cWd1fFi1NKwmNrwmJhweY3fUSHfUxO+UJ0bU74lUpMSo9kkb0+Ka0mMa06OARisyYaoBNptt0yoy4SMKW3M6yxrtsLalFVmxoBpkwOClJ8uyh/ruY1Q3RnYjRA+O9e3dsdVLxA8Q8mA0Bdgz8GABFGhr4vndd4m3N8cWiX77oJDpLWTYutF+bwXaOr1OAKVZAqUZpsatb8uR8FngbT3H8MsKM0zmHowcQnAg0Jq+5/ciV8xf4Cxc7ChYIGLvW7OoURavzou3beX9LwW6HrafYSK8NiNCnha577sli0cLA3gsHy7je7dpT+7dJgni/c8HDQ0NzX89tEDT0ND81RAE/vDGtZVTvvTi8vzHjN2fGqfXd6B4rxnvHhp8Ubk/YxZcFwiX+sF1cv9OoGEw2uqInkKrPYuYttiGhM/24XPg+/xSoL1FLF9H7qoZk26ckWNIO4q1m9FXqOn5y9sn6rOljcCYYRgjWp4Z3ZAeo0yPbUiLrU2OqIwLL4kIOhoeeHT7xqMhG48Grz8atL4oeENJ0MaSbRtLgjaVBAeWhLyt4tDNpWFby3ZsK9+1rSYmuD4pXJUeqbIlnodndMAhdzaBzoysy4Sd6VpwkhHRkBkDCvzrdbKYpqNp/Z03UaoLwTvNZDe4RRV5+zwEXD/bCA5HcGkOtgEjIwUa6rL15sBWNI/lzWPDgslvhrfAATi0RMSw2fPw+GcYfQECDSPjIraPE1ciZPuKuHMnjT2uLEPQPoTQmLEBEtN0td0Om+e30Em4RMxf7MjL/H4ZuF3q3Li3G4//K4GWZ0TWZ0bVZUVVZ+6uTt15KGzjqolj5ls3cAkYJ5IfO2g2Gd//fNDQ0ND810MLNA0NzV8NRVEvHz9cM+MbLx5P4uycEBI4NPjKjMIsss7w+oy60mO0yFMA98ODcQvbpLYRUyb+lUDbmtBv7VkC0whsPx7Hj8eV8DlQpm0WLoT2LBGz/Vz42+Z56DruYchrE/bKjL0y6Z/cOFmpyIFJDEVGbF16jDwtuj4lsjYxsjx2x7GdwUfCthwO2XQ4aOORLRuObt1wbOuGoi0bigLXlwZufFtbNtmqZOum4q2bSraB2lgcvPHY9vXHwjaURGypTghVpEfaRnnUZ0fVy6IaYJYjQp4ZUQcqI6IuPaIubbc8Pao+I7ouA0hntOJAUk/7dYzsNuOdCNWLYD3n1VUBE0b7wJEjbBjhEDHgUAvb1Q3b80iH9uGyJRyOhMuRwP26wd1jeAkYPsCefynQPrAJDd6TA8uRC49OvGVuX9+5ccaM9pnxAZTQUOjAi1uXN7rPWOQoXCriL3URZG9cpZbFqX5XoBtsGg0EOmN3Tequ0qjgENep84VcXy78Pwrit/zQ19VJ0UsJaWho/m7QAk1DQ/MB6Hz1YqPEzYvP8XQUbVk6r7+zDUF7zHiPHu28c/PUaslMVyCFcGwz2xNOaoMzJXx5TGBdvlYRhMVj+8DGqlWdoT3bVBt2nX35HH8eJ4ALiu0L3we4GsOWbfDhs/wduf5jhVk7NhG6l4jphQ57bkKf63runikvUGUlKtLi5PukNSlRNUm7q2N3lEVsL96x/Vho0JGQrYXbAg9v3Xx0a+CxzZuObd5YFLixOHBjCahNQKA3lW/ZXLFlc9mWzeVbN5dt21xmPZYEbzmyfcvh7YHFYZuLwzfXxIcp0mCQQ54dKc+JkMt212bsqs3YXZe+S562qx7Y8z5wAkw6Up4Be7fAod88uogRPSa8CyH6MKz35d0r37pOkQg5tugFDHzbxtjZEt4iFrhdNnt+F4P24bJgH9rq02/dWvDzyA4/uPiSAYeTiLlejnxfMc9fzPF1ZHuM5oduWNnb9wLFNRisARLtv3VavfTLCQuFvOUiwcpxTodCN8IsuFWgbSM4fr2IsD7LGuHIjK5Li6xJ2VUVH568auF8FwGcxcF1WDnly4c3r/8vdiWkoaGh+e+AFmgaGpoPQH93Z8z3K7z4bFcee+G0r9rbbuFYvwnrMRG9b9rvJoRudHcSePK5ngI2kMJ3Oea3YyXe5hOgQNvUcHhNIQuGd/kwEwxTDbapxjD7+zYV7SMAPs32FbLnjhGlbf3uze2zuq67iP4xrnvce/fMmSOZ6vS4hr0x1cmR5Ym7SuPCi6NDju7eeiAscP/2jQdDAwvDAgtDAw+GbDy8feOR0MCjYYFFoYEl4ZtLYW0pCd1SAkQ5BGY5ioMDS4O3lIZsLQnZWhyytWz7toqQLVXbt9ZFb1elRCgyIhsyIxRZkeqsyPqM3TXAofftqk3dId+7U566Ezr0vgig0UCp6/btfnxZjaFdZrzbRPSgWA+ieZ2wea23mAuu1w+OcH6b37AJNHTo4fbz8D2BM/7e3bR3v30n0L6CdwLN93Hk+4m5/uA9nbgenziqaov15gGMGEKwAYIcpNB+9ZHcBRNcFon4K0T8tZ+PrZSGqXLgLiq/K9DQoeEgjrTI2mQg0DsOhQWu+HysxPqHScS85upyFDG///mgoaGh+e+GFmgaGpoPgE4zcDAxxkPAms1h+n86/scWBW7qNaG9JrzPqO84KS/1meDiKeR5C7mecJIG2xplZg8vGYS7eXvCXAe0ZJs0w9nPtoIr4d5uSQ3K921KAVqmn4AVwGfNE3DmiTgrvxi7PcA1N/T7G3X7h262vGwtP3sgRZkWVZO8szxpx7GE7ftjthTGB5Wm7azNi20uSjtdlXNJcfB6y7F7Zyoenq9+fFnedkXedqn20fnK+6dLb7cc+7HhwMWqnDNF6a0HkxVZ0pqUiFLp9mO7txZt31wavLkqdGv1jm3y6NDqqJDSqG1Hdm44Er6+ZOfGkugtxxKCypK2lydur0gKrUwOq0wNr9q7s2af1ar37m4pzSaRTozsMZE9CNFLoD0XlBWuYrhrDBw2Zw0u2yIccLj1ewHodw49nHh57wm22wILbmoI1Jk7R8zxd2R7unA3LpR0vHpswvRmYhAjBwlCY0H6s3cFLRjrtNRJsEzE2zr9S8W+aFXu2xWENnv+lwINR3CMEOjy6PBgj5ngz/bmMT25jJTQIN3Q4PufDxoaGpr/bmiBpqGh+QCYjYbGsiKJs2A2i+Hj7HR4Txxm6jOhfWaiH0P63rTdDFu9xJXPgRkP4M3Do6DBuZuA5SZku4tgtMPaZwUCzZEIOEDI/IQcP3C0bq1nK3A+h8+aw2MG8Bn+PMYcPmMuj7lIyF7EZy5z4q4cI9z69YTcFT5n03bdKc06kR+nsG4cqChIOFeTd+9c1dPbTe1tJ/vaL+g1N4xDt0y624jhNmq6i5rvIqAQcLyDmG4ihhuI/oZZd9M0eE3f++Ngx+XeZ+c6H556eavl2Y+qx61VV0rzmtJj8zavSVrmHznHbYfvzDDvaTt9Zkjneaasnpe+deX+nesPRwQejdlaFBdUtCekJGV7aWp4RerOytRdJWmRpoEnJNVrILpMll4z1q3re77KfYqHECZVAvgcP2tPHTah30+H/+zQ7x4ZKdDw7sEOPSxfAXsO+F4h5MwVc3ydOe5jBYXpCUZtH4obTcQQSg6S2ACp6wpd4LtwtHiZk2CJmBO3SKLMkirz4uHOMsPt539RtgEjUKCjapMjquN3V8bs2LNiob+Y68lx8OIxNvh6vHpK76hCQ0PzN4MWaBoamg8AhqI3L51bNWPyLKaDO58ftnRhf/tjI9pnQPtQpN8w2H6irmTupIme0KGH9yDks90FLFcBa7YQODQM+1oFEc6q8xFxJWKuryPXzxE2UOeIWfOEzPkC5gIBc56AMVdgHyCw9+Pb+Qvs5vLtFgjslgodlgsdVjuyNn3Cj5k9oeAHv6ulqXdaDj6/Xt/37Iyu65pRcwfTP8CRNhx7TOGPLYS1qDYL9dhajyjqIWUBR1APLOR9az2w4Pcp7B6F3CNNd0nDHUJ3B9fdQTV3jN03rqsPB8+dsX7mZxunfbppysTAKZ9tm/FlmMeUqLkeCSvnyAJX5wWvPRD+Q+HujQdjNh2Sbi5KCC5NCqtM3lGavOvRlWYL3m0iO/WWHj3RhSA9tYUy34mjJUKeP58L7NnWhB4pyiMdWvLLAR3vyibQsLsvhP37eXzWAiF7jiPHazTX95tPL55SIyYtihrNpBajBilM037nyvfTv1rsLFwq5i0Sswu3r1fK4hqgQL/dQuVfl3U8nzwzaligd1XF7MwPXLdknLM3l+HFcZj/+diTijo6xUFDQ/P3ghZoGhqaDwBFkm9ePI9at2omy34mw2HplK8utTYYTD0mrB+OfUB6O1/dS925zcOJ785je/KAQHO9+BwPawcaOLSbNa5gyx54CtgSoM5izlxn3jwnznxH9kJH9gIxExwXOnMWTRAs/kK0YrLL6qnjvp05fvXUMUu/ECwcy5gn+scSJ7v1k/gZazyu1aRpXp4yaX5CzfcJ9JEFe2rBn1nI56TlBUE9o2xFPrXAekIRTyi8jcQfU5i1gF6TbeBxC/GIIkE9JPEHJH6fxO8S2B0CA8f7pPn+y5uKXcvdfpg6PvDr8YGTx2+Z8snmGZ+H+U7fvcAjftWcjE3Ls7eszN22qmD7twVha/NDv80PWpO3edXRkHWl0dubj2SZ+5+geIeB6tbCiRy93c/vRK5b6SXm+9oGQtuG/f1Snd9asnW94G8JNHyVmOslYAUIOfMEzPlClp8Td5YLJyLoh672pxhqxDATQulwcogy9zcfyV/x2fgl1vbz2s9dahJ3KLLj6nOkDcObeI/05p9/lEXBjWOyohrSomv3RFTF7aqI3nEkZMt3//wMzhbkMb0cOUcyUg06HUVR739KaGhoaP5boQWahobmw6DXDlUUZHs68Wcw7LxdxLLYnbrBdjPab0B7DViv3tT54NqZrQv9Z/FYbjy2B5ftwWO5g+Kz3AUsDz7LE27fDQQRKCB7jhN/gSNvkZizzImzYjRvyVjeqq/GRC73LUoMPVmZffd89YvbTa8fnmh/2PrqQcuzG/VnqtP3hSxKDZzbekjafU+FaH4i0PsY9Rih2nDqGUk+p4jnFvIFRb2g8Oeo7lF/x7U3z86/enjq+Z3mtmuKR1fkjy7XPb4sf3K14dl19fNbzS/vneh8elrTcdk8dJNE7pPYAwq7h6N3gEZT+F2L6Y6h49L+iLXBnl+Ge06One+auWFxYfTGqpxI5ZGU1nJZS2lm46E9dbLIQ7GBWcEr0zYuli703PTV+K1fTtjhMT31hxUnSvIJUweK9+iIbiPeg5t7nt68sHzGZHegv2KuJ3BoIccbfJfgs7xgvxmWLSzu+asfRz7uLYD5ch8RO0DMmSeGR8k4cfj3yx7euWo0aFDUgGEGhNCSuGbo9eOU9WuWjXNa5sRb6syJnDNbmQED0PXZMAD9nkC/jT7/LNARVoGOqdkTUSndWR4ZVhwWFDR72hwR15cHVT5u8zo4zI4WaBoamr8PtEDT0NB8GAgcf3zn5iY/z5nMj2fxGGs8Zz6/e9Wo7wYCrcN7DFj3kObZGUX5Krfps4TcGWwHNy7Llc1w5zFt5cljwAiHiC1x5Mxx5C4Us1eN5n07Xhg043PZllXnaw48v3ViqOeOSfcYNbVR+AuKeAaLfIIRD42GG92vT3c9P2EcuEYg9wjiEQ7U2fIMI58jSJvZ+Fg3cOd12+nbV+qutJacbzh8oiK/uVimPpKmPJCi2r9HXbCnCVYyOKry9zTuT20u3Nt6dN+J0oxTVVnnlflPrsn1XZcx/R3KfN+C3LOY7uH91x9fqDxflnGttuDRifL2u8f72y8PDlzTDt3RDt0d0twe6rve++r88/vNVxsPHUsOiVjssXHqp+smjl736ZiNUyYFek7/sbkK1bcbsS4z0YeivZihW1W8f/6Uz2ZbJ9BZ5/1xPMBXCx4cjG3Li9tq5I8e4GkiGCu3Jsvhdo/e8Mj0d+T6OXN8xwg3L/K/fem0Ud9vQnQopsdxHUZoKXTwUl3591P+udxFuNyJu3wcryBojUoW824H75ECDV3Zuie57aQeCLQsEm4ckx5buyeiInZn6a7Q0vCQ2Dm+8x35vjyGl4D5vdfMF48e0lsS0tDQ/I2gBZqGhubDQFGUVqMpSkudzRo1g/GR7xjHo6nxZk273tytw7sNeJfB3D7Q29ZSU7xg2ldT+MyZPNYsNsOV4+DKdXDjMTyAe/HhDiB+YpjcXTiGs3byGNnmFXebSgaeXUU0jwnzK5LosJAdFNFuwV9S5CuCeIaTz1BLG0q1YeRjDHtE4E9I8ilJPMdMbb1vfnx8s+nKydLm6jz50b31h5IbCpPrC5Lr8/aAkucm1ecmNeQk1csSGrLjFdnxSlAyeFIvi5dnSeuyYmqzoqtlUVXZUdW50crDSVfVh17cVGGDNyymB4ThPqq7bxy8jww9wPVtJAJs/gVBPSWoZ7Dg39CG448w5IFBe0fTcfWSsnDftpWrJ0/47tOx344bveKT0Zsks5vKDuBoD0r0mfFenOjT9T9rKM6VTHR2E3M8xFx3odWPh715pEC/Pbc9QWSdrg17z3BpJhwpDb6EOHE8R3O/lcy8ca7VrBtAED1KGDFSjxNDJDak7XgWvWrpkjFOK5wFS8SszTMm1qWEN+bB6XW2ERwjBdpmzz8LdHa0XBYJnqPMkNbuiayI2VGyI6QsPCRz9fIlLiJ/HtObzwqY4PzT2VM4hr3/EaGhoaH5b4UWaBoamg8AsGfEZHp6/27Kto2urI9dmR97cVlbfL3uXzqp1b0xYN1GtNOIdeiMr3vfPCoryJB8OeEbjsM0lv0stv0sjv1sroM7n+ElZAH5m+vMnTeO/4PHl+WZu9vvn8B1j0nkhWnwUdfTy9fO1F1qrbh6ourG6epHP6qGOq8jpjYMB9r6HBb+DMeeGbX3Xz869WNj0bnKgsaDe+V5yXV5ybW5SbWyBODKCmupshOVOYmK7AQlOMkF5/EN2XGgFDnxypw4RXZsgyxGnhVdlxldmxFVkx5VtS+iYm9EVXp0bXbsicqMjraTBPqMJF/j5GuSaCex16j2kan3tub5uTd3mt7cUrffUnfdb9J1XjQPXkfNjwikDRm49/LmicPS7Ru++uw7F+dVo53mjXNa6zn9dGM5gvYY0W4T3o3hPbr+J1V5+xZ8NXGWiO0qsIZbYDxjhD1b28zAlW0F7RkK9NsffQQcP+jQLC9nzqYFnmdVFbqBTgw1mc1GFDeg5BBOaAhj78nKkpVfTVrqLF4m5CwRM9PWzmvMjlEDgZZFw/3JfynQ734cFugoeXakIidGmQkFujwqHAh0SVhw4eYNqz8ZE8BjSWBfnFVzqIDe05uGhuZvBC3QNDQ0fylAnQkca3/yqDhr70ZfD7/RAjfGP7yZo/wY9ovGOOfsDBpov4+YOxGsS492gDIY3nR33FPXHNqyfN4sZ9FUtsMMtsMsLtONz/QUMXwcWXM/dYz6bv6lxiPa3puo8XH3y0tAl+sL9xbvjSzeE3ksOQpUcUpU2b7oSlnc8er8Z3dP4MYnFPZC23fr7uW6liqZ8nCKqmCPKjtBnZ2kyk5qgJWokCWqZIlqGXjQesxJVOcmgVLlJChzYTXkxNdDh34r0A2y2Pqs2IasWHlmrDw9Rr4vpjo1sjIl4lhyaFNpGoW+suDtBPKq98XV+2drzpRmHd+fdDw/4Xhe/Mm8+OO58S150ub8uONHUq4oC9uuKjHNI0LzpPvBheKokLXjRq8c47jYWTRvjGid94wTNUcxtBsleox4twnr0vY9Pt9Y/l2A61Qhw1XEcYcxaK4Xj+PNh+XDt4Y0oC6zPUWwA+1hdWhvERcINBz/J2D5OXO3LvS8faVJo3lmxjRmVAvDG6QOwftxsr/zwbW4b1csHe+y3JG/UszdMGl0TXxIc16cKjdWlROryo5VwGsfEeHIhl3nelm0XBYF28/Wgr3qrNja5IjyyLDS8JCS7cFFwVs3TJ7kD3eOZHkImQlBG7VDGjoGTUND83eBFmgaGpq/DpIgNL3dLdVFu1ctXDhhjDuTMZs5yp35kR/Dbq693QIue903XygL0sy9TzFzpxE4NNJlNHfq0dc9Q49vXT9Tf2R/zLer3EWCmWymh4Dl5Wi3fPrEQ6kRT2+dMA8+1PfeutxaVJUTV5S0uyh2R4l0d1lcREliVFFCZGlSdHFCRMmeyKqMOPWhtFut5S+uN11UHlQfSa7PkzYAEcyNs26qlwD82Lo5yLtKUABjhtJs7T3nJiqGqyEnYbjigEnbqkEWB006M0aeEV2XFlWzL7I0dUe1LPr5j+q2y4qL8gMthSmK9ChF6u6GpB1NqZFN+6JUe6Oa0mIbU2OUSZGKPVE1iRH16dKL1YVvbp1G+x703jh5bNfW9ZMnLhHzloh4C11E38/+5lJTtVnfbsJ6DGSPkezQGV5cu6hKjw5eNHWS1xixq4DjIeB6wvHYXF8hzwvO4rDusQL3+uZ4wCnaHHch28uRN2ec00aPqcXJu+9cUmt0z7R45yDWbcT6UXQAwwZQtH9o4HlR3M71X3220lmwypG7drxQtnZBY0a0OkcKvjaAO6aUwSHQ71rOUKOBPefEgCMc/wztOaYuO6YhN1Ypi6lN2V0eGVoSGlwaElIUvC3Mw9UPeLyA6c633xjg0dfVQQs0DQ3N3wVaoGloaP4iCBx7cu+mLDJo1ZTxvsJR3qyPPRmjZrJGzWSOkrAZc9nMpTze6tHOEQE+1+Ql2MALBO0yod1mpFuPdevwHpOhs/3O1ehVy9y4LHe+g6eTw/Ip4+oL92na72C6Z71tF0+WppclhxfHbi+KDMsPDkz5flX8mmVJ61bJQgJLE6Lq0pLkGUm1GQn1OUnqgyktx9KUhYnyvBhlnlSVK1XnxVkL2vPIsnaaE95J83v17lfvTLohG5il1NqNjpFnRtdlRNVmRFRnRMpz40BVws0Fd9Um7FAlRzTE7TgasiHjuyXJq+Ynr1yQvX5NVWS4ck9sXXxkZdyuiuTdVZkxt4+Xm59e1Vw7Dgx7zUTnpWLuUmfhXBfBavcpV07IUaTbhPegRBeOdZt1r/s77j+6frq+JH/n+mWrfab7fCJ2FTPchQx3EctTzPF2hKrqDTvQLHdHzrKZk3Z/t6iprODZnXN9HXf0hhc6vGsA6xok+/TEAIJpSGQQ6euoy8/aNuPrH8Y5r3Xir3LmpiyVqPZGqLJjFECIoT1LVZlvd1H5LYGugwIdaxPouuTd5RGhJduDioODQcUvnBfgyPcSMDwEDitnTn7R9pDeToWGhubvAi3QNDQ0fwUYgjy+dS1hw+oF4wUS3v9IOP/Hm/V/AsSsLf6eZWlJJfFRm91nfPvFJ6lLF5zL2vdMWaO7/xPS+5Qwd+FIjxkZMKED2oGXjUX5iz8f7wXs2fHjuV8KCqRBA69uUoaXpo5bN+WFDck7qqODC7f+EOI5e/HEcb4uYg8x18OJN2fi6O9nT5UFbZSnJ6hkKcrcZGVeoupAUkO+VFEgtQn0sEMngGrMT3xn0kCgf+3Nv13x1kQHdGirQEfVZUTWpO2uzYqqSo+o3Le7am9ETfJueVLEsbDN22Z/vWKi8zxnrp+Y5QeT3IJVn0+ULp5bKd1dnRBZmrCjODGsIm3X/aZi/d3TfZfU+7etXTFetGy0cKET39eFv3WRr67nCYp0oVgPjvbiaA9u6kKNHYP9bc/bLl+72NBYXXA4PSJ609JtSyXfek1bNXvyD57TQhdJ0kN+qDuw73JrxbMHZwcH2/TIaz3yRo90GpDuQXOXjhrUUoN6VEOatbeaG3f4B2yYMH7TOJe1zvydbt/IE0Ibc4ANS+vz4DUCe1bD1Mr7Am2rOjh/A/wIZHqEQO+2CnRQcNG24LTVK+aPFnvxHDwFDgsnjb924SyO/9+sI6SsgP99/xc0NDQ0fxq0QNPQ0PzpoIj52pkTEUvnL3QR+vPsfXkf+4kc1s+cVJ4a9eLWBV3306E3D5/9dPp6XXF7s9xwtlV/tkV/+aT25jnzsxvEwEvSqDHr+x9eO7tlrpuvmOkrtls8WZgXH9j19CfC9Mbce/d+S0lrepQqOqRo07frPp/gxWHMZNpNc/h4isM/vmF8NIX58UweI2C8c/TyBaqs5KbclOaCFHVBkqIgTpEfCwU6L264EtT5iY0FSeCohPb8xwU6wVrxChj/eJuKrgdmmRlVnxFZmxFRAyotQp4eW783pjBow+ovxnlzHTzZ9h4sOzcYYgFHO1e2g0TM2+w+/WhESHVyZOWenWWJITX7dl6vze+4IL9bf3jvt/OXjuavcBEucBQEjHUsy0xCta/NeA9C9JqsJo2h3SbkjRFpH9Q/HRx63NNzq/3Fj6+fXHn+8OKzexde3jv/5vGl3hc/abvvGAYfoMhzE/Jci70cwl4bkTeouRtBeo0Y7ECb0YH2uzfil60I/PTLwPHjNoxzjvKcVhW5rSUH3iV5vrQuN0aRI22USRXpw948PP55OLkxLNCyGLnMJtCxbwU6NLg4KOTYtuDsdeuWThzrAweq2EtGC5qryv+3+xGSJE4SZpIwELiOwPUEbqZIehYeDQ3NXwEt0DQ0NH8uqNl0+/K5iBXzFrjw/XlMPwFr3gTHkPneF+Ul2o5HBNJJol2E7oX5zZ2hG6fNl1rw883oabX5nFp/sVF3tVV396K5/Ynm1RNZVJhkDNffyW7RZ5y00OUdTy6QaB+qf33rdEVjjrQpMVyxc2uU23RPh4+n23881WHUFLuPptr/Ywpj1FSWPTjOYNkHjHOUbVnXmp/akp/clJ/UtD9BlR+nKoj/ufIT35UyL8Fav3blX9dbdYb2DPvWce+Gu8F4QwZcWleXEVGXEVW/L7oiNvzbLyd6Am9mjHJjOoDyYMHjLIb9bDZjFsfBQ8TZ5D6tNiWqJnl3bcrO6uTQ+oydp4+l3mwovFiUuWnKp6tdhCudxYtcxN+7TbneWmcyvUGJHjPaaUa7zXiXiegawtr1RIcWeWXC2g3IawP62ggUGX2FIC8wUOanpKmNNDwGRegeI8anZtNz3PyaNL4hzd2EuQtDuswDL8+VFKYvXhI1eWrIPz+PD3CTS0NP5yW1FoA7E9+QJ63PjW3IjlFmxSgyfzEB+jcFOgc8+a1Al4aGFAdtLwraXrBp07dffubDY3qw7bzFnLLcTKNe//6n5zcgSQLHTAQ+RBIDFNlHEb3gSOL9FKYlCdRC0VEQGhqaPxdaoGloaP5EUAS5ffl89Nolc0dzfPl2fk6cjV4z5PkZL+9eM2u6LeYBSvcS7bitu3tae1ltOFuPnKpFTlabTlSaTlSZwMnpOv0FVfeFJlV++uLJn3qLHBZMYEatdn92oxE3d5H4UP+rW6qDifWp4er40CMbVi0ScWbY/w/Q5W8YdlPtP54GBdpuCosxlWk/nWE3m2P/w8zJivS44wWpzUCg8+PVI+35lwL9TqPfybGtGnJg/WzMVs8e/hUcymELhLybkaywTXPLjGrIjKlNjgyXuPlwGe4MOw8Ww5XJdGMzPVhMNxZrNos5i82ayWHO4DA8ReyMTasV+2IV+yIa9u2oSw+XZ0c0HUo6V5JRvGPT+s/GfOskWj3acdFYx+3zvG6drHvz4JK+9yFqajcSHTqyc4js1FJdOqzThHQa0Dda4pWefGnGoToThkdY7y3s1VXkwRnk9gnzjePGG8dNt09h98/jbVeIlzfxjrtY1z301e3BK8dfVRddTJYqpGEtmbHnClNPHUwGAt2Un6iGXfbh4Ru/3IMQflWQRdVmRYIajnDAoRzgmUC1a/dYBXr7diDQxUGhhVu2Bk6fIuGxPNl2XkJWTvQu7UC/5d+vI6QIAiEwLUVoKHKQIAdIspei+oBAW0ARfRSuIXET7dA0NDR/KrRA09DQ/FkQBP7y8QPp+jUBY3ge/H94Odp/7zXleMUhXc9LEtFSiJ4a6sbuXTSfazC1VmLNFXhLOdZaamotMrQWmZqL0MYipKlU31LxqDJv19zZ3iKWvzN7o9fnZ+pkmP45iQ4O9b2+qCqpz4hoSNlRFxMU4T3DzeEfUxkffc20+4ZpN9UBCPRHU5j2U9iMqSyHGUz7mUy7ABdBZfyuEwWprfv3NBckNP52B/q3BPqdNI+s4V/FKaz2/E6gYWVHw21EsmOVmbFHdm4B1uvuMMqTae/GZMxiMFzZLODQbiz2bBYLCDR0aLbDbJ79Vu8ZDXtjmmVxKnB1WbtrsyPkuTFN+5NaZQlxczzWOItWu4iWjxHPdxYUhm36qaLwfmvV61undQOPzGi7gejQk51GvNOMdpmxN2b8JY48JbUPgTej90+ZLyvNp2qM6jKzqgxVl5sby8wtFcipGvP5etMVlemnJuR6K/ZTK3GpCT/VYGyteVp/5Gpp1rmj+04dSm0tSGrNS2rOSWjMliqy4C6DcFbdvxXoHKjayoyYuj0RFVaBLt0WWrwt9Oi2kGC32X58tjfb3oPnELfpu97ODup31xHCGYiYkcAGSKLfQg5aLDqCGiQoDSiSGoSPkANAoym0Dzg0PdODhobmz4MWaBoamj8FkiA6XjzL2hUSMFbozh8lGcPZNM+ttfqwYfANhQ2SZg2heWO4ewVprSJVxZTiGCU/TNUfIhQHzcoDBvVBo7rQrDxkVh7VyI+cSQlbNpbpK7SbM5azZ+tiXfcNCuvS97262lJfn5OkTItUpu4q2cmmSqgAAIAASURBVB24etKYGQ7/M5UxagrDHgj0FHjy0dcs+284zKksxnQWYxbT3kfEKYkKPQkEOj+pZX/i7wv0r0X5dwoKdF7cuyWJwxWrzI1VQJOWqmVxaeuW+fIZ3gw7L4a9q4P9LCbDjQP3J3dlsVxZTHhkM105zNlc+1WTP6lO3NWUHQd3KsmJrs8FGgreKu54blJ1zPbvJo5ePcZxhbNwhYtwy5TPz2bt+emo7Gbl/nvNpa+uN2varyG6JzgCvPkVaXxO9N/Fnl0232w1n65B1SWk/BhZc4SsPEJWH6VA1RwlG4rIxlKipRI/UY2fqsFO1RAnasiTtdSJGuJUre5M3YvG4qvFmacPppzYn3w8L6klO6FJFgcEWp4VVZcFkxu/L9AN1u2+wfcHeXJkVUR4eWhoeVB48dbQ4uCwnT4+AQKuD8fBnWO3bYGk/flT6nc7xwRuJrF+iugniQGCGKQoHUEOWh16iKC0JKmjSC3QaArvIVHwHJR2aBoamj8JWqBpaGj+FHSDmqr92YsnjfEU2Pm4cEKX+d84q9YNvEbMGhLVUNoO9NFlw6lqTH2EVBQSdfsp+QGq7gBZk4fV5iH1BUbFfr3igFZxqLM8f/+agPmC/89P8D/LJ7s0l2WSaLtZ//LepWZl3l5FOsw5KPdGHgnfNNeFP9P+oxn29tPtHYBDf838eDLro69Y9l+zmVPYzOls5iwWXKVXHrvjRH7q8fw9LQWJjb8d4bBpMThRFySNrN/T63y4xm54Ih4oKdyuLx9YdZwqN06dJY1e6OPNHuXDHOXFsHNnAm9mzLZtTs6GWY7hcnDnMRZ95lIWH96clwQHVOdKlbDi1TnxjdkJzVnxUQHuK0aL1riIVjsJljtzK0I33irMuH8s+25p9oPa/U+Pl3TdUBteXDC9voS0nUOvNZtPy82NZXjtYbLygKWswFKabyndbyk7YKkotFQestQcsciLLA2lFlU5pa4gQTVWEOpyqqWSPF5FnK43n1G8aDh2+Uj6iYJkWwcaCLQqK1qRGQVXSf6uQNdnRyusUZZhgd5RHhZeHrwDCnRIeJT/nLkigS/HwZNrv3Lal0/u3fmdSXYUhWOIhsD7SHKQJIdIUguLGiKhQGsJSk9SBlAUpbdQGorowTEt+B73/rvQ0NDQ/CegBZqGhuY/D2o2XznZ8r3bNz5iOx8n+1WzJl1UVSC6HgzTY5iOMnQTT39CTpdjqgKTMk+vyNerC0zNB5GWQ4j6oFmeb6jO1lXlGuQH9IqjjwrTw6ZOXCT8aMFou/Clbh1PruBY16snl9XH9jamS5v2xSjTo5VpUYfDA+c5C9zs7dxGOcwaxZjqYD+Z9fGXnI/+ybb/msOaArPFLFcuc9nn4+XJMSf3px4vsEY4rN6s/LkSbaXIT7CVMj/h1wL9vjcP2zMU6PxfCLQKCHRBvAI+mKDOiote4O3DsfNl2/uw7D1ZDu5spiubMZtrDxzaZs8eoDgMd57DysmfVCTuai5IhvNA8uBAPWDP6hy4IWJTbtKxXVu+nzRujbPwWyfBEhEr3n92W2n+0/K8p5XZL+ryuloO669UE7fV+LV69GQFqSgl646RNYeoigKyLIcszQFHoiyPKM8nKg+QVYfJmqNk7TFLTZGlpsRSV2ppKKeUlZSiglJCn7Y01lDHG0wn6182FF08kgEFOjehMRt8H4gBDq3Mim7I/IVA29rS1nor0LYsuCoztv6tQO8AAl0aFF4UHBY3f+ECsciXzfDmMeZ+6vLgxjWC+M0xGrD9jEN1JkgtTupISg9cmSKHKOjTwKSBQJsIi9nq0FqK6CUwDUX95rvR0NDQ/L9ACzQNDc1/GOBAr5+27dm6UeLI8YPbnYwpy4439L8kMC2OawljL/H0Bnqu3qw4YGrMN10oNt+sRR8o8cdq8nEj+aiRvN2AX6lGjpeYVceG6g63xAR9N5a7TGi3+nNRSdouRP9Cr3lyXl0kz5M2pUW3pMeoM6Ibs6TFUcFLPxs7Y9RHs+zsZ9oxptnZf+0w6muW3WSWw1QueyrbYTbHwUvECvGdrc6MO7k/uQUGoOMb4SCOdzWi/fyzJccrrRo9ouJ/XSN62PGqvJ8LvrwgoSEvrrFgT1N2Utq65b5Clg+X4cVmuDPt3Tksdy7bjcOCQQ4Ww43DdOMyPHgO7jy7rV7TGmXxLflJjdCe49Q51sqNU1oH7anSpTsls1aPEQGHXubIXz2W/7S6oFN9sP/4QcPZo9jFEvJyleV8JXG8CG04TNQcIisPWioPUOV5ZFkuUZaLV+SiFblYVT5aXYBUH8TrjuC1R8jKw1TlEarqGFlbRNWXkQpYFlW5RVlpaaolT9YbT9U9lx++dDD1ZF5Cc45UJYtRZ0sVmdY+tG3SSFZEXWaEPDOi/m2960DHKHOAbcfUp0RWRoTbOtClQTuKgsMTFy9d5OToy2V6cx18XPh3f7qC4/j7n6dhCDixbggnh3BKR1BGymKEzWZSa6GAQ2spykgCe7Yg8AQGOfqBQNMdaBoamj8JWqBpaGj+wxi0QzWF+Qs/H+8j5i781FG2e2PP69vAZghcS5l6iTf30XMKRHHEpD5A3JWTXScpzXlKc4HqP0/COkt1n6ZenSRvq9GTlW/KcmXLvFc5OaxyZIV4fHP7XD1qev3k1knVoX2K3PjmrNjmzBh1JhDo2LqUyNAAj5ksu2n2o6ba2U13YExnMKYwHL5hOExlMWawHVx59gsmig/t3HA8L6F1f2JzQfzb/MYvc8+/SmjE21rLv18jBPr9zrS1jZ3YmL+nMWdPuXTnyknjPTj2HmwHDw7Dg8tyYwOH5rpzONCkuQw3rr07385L5LA/9IfmnIQT+/c058U35sbByotT50NBBwLdmp+yP2jdyrGOq13EK5xEC4X2pzN36S4UI5ePEVeOWS6VWM6Vks1HsYZCrPYAUXOArN4PCqvIRaryTTX5qOoQ0ngYbTqKqg+jyiNAss3yQqT+sKnhiL7+sF55zKguNiqKCHW5RV0BimqspFqriZO1ppM1HfVHLhYkHc+OVctiVECgZTFKGOSA9lxrLaDODZkRiszIBlu6wzqFQ5EdrcyMlqdEvBPokm07ikN27lm6YpEzFGgvjr2XmHPr8gXi9wQaIXCNtQOtw0k9SQKBNlKkzkIAe9bB9jNlhgUf11kFepAWaBoamj8JWqBpaGj+k1Ak+bLtYdAiPw8RM2CcOHiB98Orxwmkj8KHKEMf3v5Qf6XZrCpGFAewq2VU32nccA43XyIMl3DdRXzoPDF4Djp052nqYbPpTOXd/XuCJ49Z4eSweiw/fsVcXdfDwb5Hp+sONeQlKXLim7KlTTBIEKWWxSozYvO3b/AfI5rO+Hiag910hv00B/tp4Miyn85hzODYS5w50hX+LTlxJwqgPTfvT4Dt538r0LDB/L4u/7pGBKl/0ckGZRNoVV5iY25SY2ZiytqlEjHbjWPnDjSaCx3aA6gz1GiWB5/pwWd4CEZt9vxGnRXXmpfUkp8A1LkpLx5UIxy6l6DeD9+zpSBFtTf2uy/GrxrjtNxRtEjokLvO33C5DLtcTFw6ajl7jGw9gjccRGsPErWFVPUBqu4gLj9oVhw0Hy/Cr9eTj1qotuPUo1bqtoq6XEeeLCfOVpF3mvC2E9izU9iz08ijk8hPKvR4JdlYaWmqsjRVUs2VRHMldrzKeLzytfzQlYMpLdmxjeDmWwUauHIdzD1bBTorEtizMjNSkWUdgw2b0FENsijwNHny7sqIsLLQsLLgcJtAp6xYtcjFScJleHLsPUXsmxfP/Y5Aw9nP6CBJDJAE1GgSOrQ1xQGjz0aCNOEksGczCa16iCIGCNxAb09IQ0PzJ0ELNA0NzX8MiqJ0Q4M1R/L8PhN4jWGv9fhGXVxg1nZZ7bkfefFQe/G4ubkarz9sVhcQT+pxw2nEfA4zX8ANFwntRWroAuxG9521dJwi7qo1rUXN0ZtXOzksdWZ8+4XLYel2VPf6/o8tDQf3KXKSFLJ4lUyqkkWrc2JU2bHgXL43Onb5XB8nzjSHf8xgfjzd4eMZTLvpbLvpnFHzJzpJVwbIU3cDe27NT2gpiG8qiFfb0he/UudfCrRVsgv+jUb/vkCDoxqOT05olCXWpURFLvKdM5rvybN359p78YA7Mrx5QKMdPHj288eLdi3wrIgPa8lNbMmNhyntkasSwZvvT2zcv6epIOV4bmp0gPfKsc4rnB2XOHJ2ek3qaS3Er5QS54uI1sO48iBRX0jKD1N1hy21hRbFYazpKHKxknjUZOm7aBm6Qg1dsQxcotpPW+6ryUvV1C21pfcqYbiGIzdJ8y1Kd53qv04+OIUfr6SaKiygmivJlkq8uQJrrTS2VnY0HAEOfUIW25QZDb7AKOA8u8jabFhAoBuAQwNjlsHGM1BnWykyouR7dlfuDivbHlYWtKN4a3hRUHjqytWLXZwlXKYX18FLzLpx4SyO/d5u3gSBEpiGxHspcgAO3KCgQ8PeM2nGoTojJGWGsziIIZIw0gFoGhqaPw9aoGloaP5jEAT+7OG93f8/e+/9FUW6rv3/Bd/1rvfMCE1HsnF0Zpwc98wYUJCgKJgd08yYRYLk2AQVRaAbdFRiJzKdu0HMOedEjmYJHSrX93mqwYB79p59jvu8e9aqa12rVnVR3TTV/cOnbq7nvtcumj7RJehL753b1z7tvoMjLyikH+9rH7xwwmquIzRyquYAbjpAtenIoaPE0Aly8BT19ATV3US1mvG7WvRGHXqpGjmpelx/YN8S32XuY0K9XVZ/M/lsbdFAzy2zal+dJFOTK9bkparzktWSJE0ejNhq8pM1e5MrMmL2rF++2fcHpnee8ww3l6ApnhHBM/ZF/arek9AA6TnVXJgG8xswrJyilqa8jc7vFqAdIWldIZw/os9PM+Slq9KictcvX/fT5wCXfUROviLObBEneKJ77NyZBVtW1e6INeSlMLXnZL0UGC5MHPY+MbBuf4Zh346Ggux9G39ZMXkCAOiFnsLfPve6q9xNnVXiR0ow/QGi/gClLqLVpXRdCV1fTOtK8UYZfqWe7jlBD16gbBcpywV68Dz18AR512g7ocCvaunBSyh22U5dI8kbJHKVsl2nH563Nikxg5wyKkiDnDYqKb2cNCqIw5W2BlWfpvj8/ozDuQmGEYCuAQydG1/H4LImLwE6n3FeAuRpANDpMaroCFlYhHzz9rJNUcWbI3YuXREy1gtGOABAe/5zgIb/4SBQDHmO2x9STCtoCuAyZQW4DDCapmwkMUBgLwhsiCL/sJLNihUrVv9zsQDNihWrdya7zdakrQ3+ctK0CS5LfKYe1xejSB+BPidf9FiunrUc0RPGaloto2oO4roD5PV6srOB6mgk75vwy3X2Eyprk8zWUIo2lGINZXiD8pGyMP7rKas8uQvH8tZO+6TtStODC+a6/TvVeen6vHRtXpo6P6VeklQPEE0CJ5XANXa5KZo9ydVZsfLkyLL4sPLEcGX69trd8bq8FHOh2FSY2rAPbNMMBUwiYrgC/fo6wleG6WcYgH5Jxn/I0K/R89/JQIODakmyDtaS07R5Kfq8NG1Osjo7QZUWKUsMO7Dtl4L1K37fukaVtK1+R6w+J8mUn2ouSNPlJ0F6hn3xkpl3wvwWAND7MzT7MnUFWaaCXaqk6DWffbx0nPdib9flE3nnClPIs9WYuZjQHqLVxXR9KV1fRqvLaW0ZZZBhjXLiYh3ddpR+eo4euET3X6SfnaM7jqIX615ofkePKukn53DsKkJco9BrNHqdtl+je09bGuV2XSlplJF6GW1U0ACjTQrKpMDNSuRwxSNN0WlpSgOM0ECGBgANuz7nAlyG0KyFn0s8AGgt2M9N0O5JqBXHKLdHyLZGyDdtL9sYWbw5PGvJspCxwxnoWZ68q6dP/IMIh0MUEInjiAW1PsHRJxTxgoaJ5wEK74c5e3CrhloBZf+JiYasWLFi9d8XC9CsWLF6Z3rx5LE0LW7GOO6MDwSbls7u6ziP4b24tQdvv2U7YcQb6yhDBa2R03WlhLoI1kSPK/FjSuywHDWWo9pSXA2Ol5KaUlJXThhUbb/nbJ3stdqDt3i8IDx4WtfN4xd0snpJhjYvXZcn1uXB0dkQoCWJagDQ+Una/GRgvSTNJBGbpRkN0qyGAjhx0FSYbgL0vC/tpQ1MCw6mS8Zw+7m3afhtUB5lNdPj+Q16/qMKtBQGRXTgd0lSNXnJ2txkfW4KbLKRLzblpphyks17UxrzxeZ8cCTFKEkxSlMc5WemEd7w4EPY3wNWoDO0+7O0BVkG6c76rJR1336xZJz3Em/XxV7OjenbiDN1iL6IAPSsLgU3KoCeKW05aSgnjDLMWI41KfGz9fh1A37bDEzcNCHnaqzGUnvlPrz+EHZViz86RVqv0pZr9NA1uv8y9aDJZipHdKWEvpwCAG1gbJJThnKqQYk1KNGmihZl/jFJsiEnTgtHEsbV5TMzU/IStfnA8QCgAUaDfR04siexNi1GGRUp2xIp27S9dENkyeaIjEVLFoz18BMyAO31TxYRvi44khBHMHQIsT21DfUhlkeY/QWOWuDwlD/uJM2KFStW70osQLNixerdiKLIjvt31gVMn+7JCfpswv5dMXZrG4H1EE/v2y82EU31lKmS1CsprYJWK6h6GVVfRtZDYobQrC4n62V0XTk0wD6dAtWqLu9OWzfBbbU7d/kE1/Q1we2XzU2lubp8sTZfrMlP1ealqPOTGYCGhgAtgdYB9JSkGCRpRrgIL91YAAMbL22AfgOg3yLgP0XPfx6gX5E0M61Qk5+iBYal6CQDwOW8FHNeSoMkxQSdbAQwCmMbw/TsAGgI3wVifSEc6aIB3pepKcjSSXdo96Rvmfb94rGeS7xEiz2dVJuXoCdq7GoA0KWw8AwAWlNG6ssxQM+AofXDhg9NMgRu5YiuBK09RFUeoioOgn3byUrkipa4YSJuNWA3TLbTNXZ9OQ4QXCejdOW0oZw2QoCGO2Y5YZITZoXFJL9RurshJ16fE6eBdWj4rwCGnhN1kgStNE4ridflJYA/FgJ0aqwyMkq2GQB0dOnGqJItEeLQhfO9AUBzfITOs8cKr58/8ycB2iHwlSNJnCQwhptx8IgdPciKFav/HbEAzYoVq3cjDEWvnDoa+sUHPl685dO/OqqTk1gfhXQTbZfQY1q6sQZOtjMoaZ2KVquoOhlVU0pXF1O1xWRdKVkHYBogtYxmtpROZdUoj6RG/zLBHQD0yomuu34NfXC81iARG/PStBJAoilw4WBeEjOiD9oxN9sBnTomOqwvAKAshi0sClKAYdfnNw27wkn/BXQedZoDoHX70t7wWwCtk6ZrC6A1UjEEaGjA0Mm6vCR9frIBOtEoSXoTnV8tHATvENCzoTAdWA8BWgwAWi3N1Eqy9LlZ4bOmLRnrsdTbdYkX5/eVAeiRakRTTGrKYZlf+6r8DEvIWnCwnNKUUWpwqUuIuiKyrpisLSKqi8jqYrqymKopwTRlqK4cM8hRuFJQYTPJMa2M1Mkp6HLKIKON5ZSxnGRMmeWUSUE0VjzWlpzITzHtiTOAjwP2tkvS5YPbmCQHQOsk8Yb8BPAjbXZCdUoMA9DbyzcyFegt4SnzFzgAepbQec4E15sXz/2DQSqsWLFi9Z8jFqBZsWL1bjQ00F95QBI42d1/onvkknltN86S2BPyWSt2+SjZWEebKiFAG1WUVkXDQXdyqq6Eri2i64qoumKirpSoLyPV5RQsncIKtEUtM8RuWTvBdZWby5pJbrvXhpyvLDTmppjy09QFqbUFyZDSYLEzRSuBo0YYgH5ZtU3WFcCuyZCh3wJoXUEa4xGG/nMAPeo04D9ZgdZLM3QFGdqCDI00XS1hgtHMG9blJzMADUAzUSdN1EuTGDv+hJcADRA/TSdNMzAMrXdMeCnMAACtyc/S5+0I952+2Nt9qbdoqafz/uV+iEmB68poHaBnOaRnfRlpgEVoWi9nDsqGqVpdRtWX0HWldE0J4GayppSqBvtlVG05UQc/BVIjxwFnA24GIK4BLyVnlg/KSBPA8TLKDHcAQ9NGGWVWIk2V1w7ubNgdb8pL1jN3BUz+BPwtAKBj9ZI4CNC5iZqd8VVJ0YqIKNmW7WUbokrWRxRv2pYQNHeup6uvgOMjcAr+ZPzdq5dYgGbFitVfQixAs2LF6t3ocW/3zsiNARNE8z4cm7HlF8uTdtzSZ3twBTluoM21tLGCNCoBQNMQoBWURkaoiyj1IaoeAjRZXwKpTl1GAwPI0yss9WWayHVrxvJXubusmeCauXROA5zfkWqWpNUXptQWJuskSYA+9cMAnfo6QGsYa5nJI4CSHU2UX9KzFuaJxQB2dYxHgzLT9eLVw5ejuR1PH3mWtgACNMwl/1mAhhXoemmaWgqL0I43DBhaB7YFSTqpw8Pv/zWAhvSsBwAtFQNDgJYChgYAnQUAWpebtW3WT4vHui/zFi71cCpeNdeqLSWNClqvAABNassofTlllDH0DA4q4XHAwXo5oZUBSqbryuhah8uBqbpyqr6cUJcTGvBT5r8BdcAKGs4jlNN6GQBowlRGmMvBFlagTUycw6zEDld2qAqO7k0w5SYa82EKBVbTJRCgddI4fX6cIS9evzdBvSOuMnG7PAJWoMvWR5VsiDy0cVvMnIAgDzc/octM/piff/qy5fZNkmQBmhUrVn8BsQDNihWrdyAcx+9evbx1foD/eNd5X3xwYHcyaXuIPbpnPWvED9dQ5krKqKKMCsowXAqlNGWkGkBzMVUPXOIwrS6hNSW0vgycOVRfVh/+2+qxglUe3FXjhGnzZphykk15YoMEQGRqvRSWnCGA5jvCG688knwYZlD9CPLCcMVo2IXWMIY87TjfMfOPIWb4LMDNkjRgiLCwDAyAGBhyLTOs+9WkFfhqTMvnkTV/6dqCDF1h+jBJM79dUwAAOvmlR5Inb77zkZ3hh8MQz7wNaTqg53pJula6U52boc/JCPP5YdFY12VeguVuzpXrliGAm8F1hgAtozUyBnwVtFEOu2fAPnRyyiCDhomOMvgR1JfCyw63I1aXguM0DIHANYgwCgJfR0brymnwLEOZwzDLYZJTZgUw0aB6pik+lZ/SkJcEANoRRDFIkwwFjKXxhrw4XU5cfUZsZdx2eXhk+ebI0g2RxRsiizaEb5/pF+Tq4cvnThc6bw31725vZZcAsmLF6i8hFqBZsWL1DoTY7SfNxkVff+433nXhD5/oqg5Q9l70/jnbkRrCrCJNStKoZABaRuthkIDWMKw2gs5MooDpWKwppgylpFE+pJExAC382d1lxVhB3KzvzHuSjfnpOgks5TpSEAx3prxpwMFveoSbdY65g29ZA2vGjF97lp6JeTiA2GE4CQUu4wMoDA2zyIVp6sI3RhW+DdDM9tXv1TDJ6TcYWvp3APp1hoYN7JgqOABonQSWn+vy0zWSLF1epnpX6uZp3y4cJ1zmzQcAbdq+EdNXkMYKuFJTx9yo6OAMFEC6tInBaMbDAK2DhlVquOLwTUOAZqyF50CY1jLWl8F7G10p3IEZaAUJ3KCgGpUWs+LSgaymvBSzBKZlDAXJxoJEIwRoQNIJRgDQe+LqxTEVsVGybRGlm8JLNkQUb4g4uH7bth99gkQes/m8Ga4uqRtXPe7rYQGaFStWfwmxAM2KFat3IKtlSCMvC5gyAQD0splfXjtjIAc6LBcbkMZKBp0hPZMj6AZpDLJaCVN+hhVomqmDwgq0tgQANGGSDelkhtjNa8aJAEAv9+Zv+fZjw65EYx4D0BII0IwdAO1IRAxbXwCjDiNmVvW9Bc1vAvRrC/5G/PII+Kl6n1gNtgwuA9cXpALXARfCrRq+/ojfCG+MBmgHZP8DgB7lEYCG5wwDdL5YLU2vl4IrkKGX7KjNStrwwxeLxgmWjeOv8HQ5mR6DGsC9SgVlUJJ6cK+iYCYIjgD06wz9OkC/xOW3DEvU2pcwXUZDdGZsKKNNMrpBCd2opA4rsabK+/L8I/kpDZJUozTZKE00AW4GliQaJAmG3DhddmxdanRFdGR5WETJxvDi9eFF68N//23zpm9/ChS5+wn4Pu5cSUpM/7OnbBsNVqxY/SXEAjQrVqzegQb6X5RKcmZN8PQdL1rt+13f/Qvk0+ahExqioZI2qmAddCQ5MAxkgJXhsI9iZsvQswOgdRCgSbPcapCfyIhZPU643N1lkRvn108naLPiTPkAHNO10pExgY4mFUyg4qXfBGiYdX49qfz6YJS3Afp1MzXmYYCuBy5Iq4fRkdcMjkA4Hv3EfwdAw4f5qdr8NE2+WFPAAHReVmVq7K/ffLJ4HH/ZBP6aD0QXspMwcJ2ZCAdpUBAGBZzCDQDazNDzaww9fBujh83pYHeOUX4J0OpSgvlHAQPQpRCgdSW0voQ2ltFmOUPPKujDCrxJ1V138Jg0tUGaai5INhckmaUJJkm8CdBzHuxwp90RU5u8XbU9AgL0hm1F67YdWhe275cN6778Lkjk5ifk+3oL5dI91qHB0V8sVqxYsfqPFAvQrFixegd69vjR7sToGWPdZo0T/Br0w4vum0TnTWtjNSA5uIiNYTVYxRyGMyat8cqO8jNDafoS0lhMNSoQk/LegT3rp3gudXcJdXVaPtlTEbfVLMk0vFyTx4QoNG9O/hteIDjazERux87fP2G0X9LzcAc6yKxiaIiwDMXmw4daYOnIU94cQAhzJtJ0uMNkPF5n6Dc8ktlwmOlm/QZDwxWNLwHaUXeXpmvzAEBnFEVtWvbRuCXjeEvGczd/NemKJJ0wMCsFdQpSPwzQMDbzFkDDFA3j4f8G/D2AhgEbdSlZX0JpoGktvLehdcWUvpg2AIYupxsUjgo0AGjssHKgUXVqfwYA6IaClIaCpAZpgjk/3pSfYNqbYNgdp8mMqUmMUkZFlG8NL9kQVrQu7OC6LdI1v6355PMgkaufgBs4yUOvKkfs9tFfLFasWLH6jxQL0KxYsXoHetjbHfPbyp88hQCgtyz06e+5idw7j5grKMcMDkhmr9Gzo/bssLoIPhwuc5YAOCMNRVSjHG9UPao8kPDT5wtdnUJcnReNE+auXdyQn2GUpAOABkSr3ZeuHikAj8SOR3Pw2377tFfr/Eb2IZRDw6yzriBdJ8kA1uanA2sc27x0da5Yk8cYdqaDkK2WiNVwgSM0s5/G+I1ud6PpeaTLxx8BNDzyegVakgp4vT4/TQcr0OLdaxaHTnBdOl4Q4s2J9vnybsleCNBapvGcTs4AtII2jAbo4Ri6o/z89zyqCE1piilNEa0dNgUZGgI0fFkHQDcp0UYVcrL+7MGdjQWvKtAAoM25CeacBGN2vDYjpjo+ShERXrZ5W/H6LcXrww6u35K/+pflUz4MchX5ClxCP510/mgjjqGjv1isWLFi9R8pFqBZsWL1DtTb1bEhNGiap9BnnCB82ZyB7uvW68cxAHCjgwGlwwD9Mr+hPgS34CAD0JS+mDSVkA0yslE5pClTbVgeIng/GNiNs23617rsFBNgRykTjWAAWrfPMabEQa7DpV+GhofHl4zC5b/n4TN1hRnAcOelARlLMzTSTGC1BHZfBtv6/HTgOmZbL4HcDIiWQWcHQ8P9kZ1UteSNgYV/BNCvM/Q/AGidJI2Jr6TDcYx7U1d//SEA6NCxvJAJ/Mzlcx6blIReRauVsPGcTk7qRzLQEKDlwzbCLhw07AwNWLns7xve6pTCVZ7QJQ6ApjSHaC00pSt6CdCUA6AblejhCvyM/lLZ3oaCVFNBilmaZJYkmPIgQJv2JBh2xKvTYqpio+Tbwks3hcEK9IatB9dvzl66LGT8uACRcLaAs2ba1613b5HsCkJWrFj9RcQCNCtWrN6ButpaVwfMnM5UoCNXBAx0Xx262oTp4TTp1+IBTEgDsvIIQ2uAi5gtA9A6CNCUqYQwlVINCsQgv5or/nWyVzD//bnCMcumeO3btMaYl2GUZmoBRO7L0O1nStHDM0oc2PqyDOyIIGc4wPotaH7dgJszHYb7jGHzZokYcipE5BGGlmbWA4CWZNRJMmol6bV54joJXNLn+KUAox1+HaDr84cB+o/8qs/0HzD0GwAtTYMLHKVppoJMadjqkA/cQieIQsYLA8bzzqqkg+eMuLGSVgOGhimOkQy0gjLL4Zo/h+H0k3LaAJtp/JFJLbOUcxidh+mZAeiDwBCgmQgHA9AwA001wkWE+Hnjzar9Zji5JsUkTTZJEk15iea9ieY9ifrMuNqk7RXbI2Rh20YAesuhDZuT5wbN8/Lwd+PPFnE2Bc181NP151YQgnNIiiRoyjG4+888hRUrVqzesViAZsWK1TsQAOiVs3+aCQB6LD9y+Zz+rsuDVxswPWzdMBwMgEvQGAOGhohWPBIJgKkAJl/L/NRQQhmLSWMJaZYRJuXjyoP5CwNDRJx5AqdgD+6Wn76qy4g3SbMMgHEB7w6Xn98A6JcI62DofwrQL+nZAdAMOqfrJelmaaZJkgF4Xb9XrNmTqt6dqs5J0+Sma/IzNBLI03W54HfB9XywOA39BsSPVKD/TtX5jwD6db8N0EwfaGaJZGF6za64sDnfzp8oXDBBOHeSW1iIj6X3xsD1o2hDDa2tpDVKSq8gYP8NJrNhlsE1f69jtKH8FTHrS0nGrwM0MAUZ2gHQgJ4hOg9bX+TIQDsAmmqooA6rsKYq7IL5Tn2REb7DFMjQ+cmmvCRzTpJ5d6JOHFcdH6mMCJNtDSvbGFa8fmvxxq2HNm7a/OP3Ae5CX1fuLFeXhLVL+589Gf2teksUiZH4IEX2U+QATQ1RpIUiEXB09HmsWLFi9W8WC9CsWLF6BwIA/cucGbM8hLO8edsWz+rvuGC52oAbXgH0Sz4bbuYAABpyczGlPwSrzvqSEZ4rpo2wCE2ZygGf2fXKE5mJK8a6BgvGzBU5h45337t2iSkv0yDNhImL/ZlwtDWczJdeLxXXS9IYi+G+VKxm4sgvV/W9jc4jhoXqVxgthY0+6rITiqM37v5lUfqiwJR5fgkBPnH+MxOCZictmJO6aG7WzyGSTauLojdXZyWq9w6XqJlt+kuUf7Wa8C1o/gcADYcd/iOAhn1FDIXpkm0rl3zmHfKBKGSCKPTzSZrSXMra2X/vtK2hlgQArVWSBiVuBgCthLnnPwfQrzM0NFOHZlwEuVl3aNhwEWHpmwBdgR6pwa403aw9pIchEzhe0ZCXZMhNNOYkGnclqGEDu23ybVtlW8LKNjAAvWnr/t/WrZj6IaRnIcfHnVu0S2yzDI3+Vr0piiIJbJAinlNUP0UN0pSVIq0kMUDiQxTL0KxYsfrfFQvQrFixegfq7WzfPN9/tjt/tid3y/zp/W3nrdcO44ZyWssANFOKZpqgFdMQl4GLHCYNhyjDCEPrmRMMJZSBAWiTjDCpehWHEqZ9G8QfEyhwnivi/vr5h4q4MJMkQwdj0BmaQmgHMdflpwJDhpam1Unhtt5RfnZMDRxuxJGhGe4ul64rhF2iYe5Zmm4oyDQWZFZmxRSErYkLnrn2mw9XfDJ++RTvZRPcl4/zWDbWbck4tyXj3ZdM8Fw+0XvFB+NWfjRp5dQP1n41dcuM78TLggvCflGkRatzxVpI0oChYa89HcO7ugLYR4/pxQFHHqqBC1IcHgHoVP1LjwboJI2EGfedn2TMTzVKxMZ9GTU5iWtnfjrvQ9HCD0QLJgpjVoQ8bL1K2buR9qvWxnpKX0MbKkijijApKLOShkv9FHA7nIR+HaDhBX8Dmkf+SzC84wBocJMDc89FsPYMPyA4KpI2gNdRQoA2V9INVeiRevTmyUvVBzT5Kdr8JH1ekj43UZ+ToM+O12XE1SZEqSLDZFu3yjZtK9uwDQB00cYte5f/HDphrK/IZaaI4ztOdFyvxtB/soKQIhCKeEFRAyRlISk7RaEUhdCkhcSe4aj1z8U/WLFixerdiAVoVqxYvQM97O6KWbnQz53n68FdF/D9i9ZzthtNhEEBR0AbYOiWmcFRzAQAiihjEWE8RBgOQXo2QoAGB4dLmw4bS2lTGWkuI43ywZpy5aY1Abz3AwWcBUL+Yndh7OwfNDvjDXCdX4a2MEtdmKUpzKyTpKkBMeenQEuAHd2aYac5HaRnx5jAdLgQUJqlLcgEMK3fD+nWUJBhLsyqzozZvXZR2MyvV34yftE4UbCby3w3l1B37kI37iJXlxB3l/kewNz5HryFboKFroJQV8F8N/48N36Ih2jxOM9VUz/YNO3bjJ8XysWxWkkWwGhdQZZOmq6XphkK0/UjwwvrC9PU+xiGLhxmaC0k5jQdnDLoYOgUrTRZy0z51kB6TtIUJOmkiQZpSoNUbJaItXmpCSsCg6a6BU4RLPhAOO8DUVONzG59SNj7yIf3rY1qwlBDmipJswrmN8yOCjSceOIYuw172JlkFBwoyMTNgV+GZ/6eYZBDX0wyhtFn8DnCT1NOg0/WCMvPtLmKNtXYj6rRB+dPV/9el5eqy0k05iQY9sTrdifosuLrk2NqYiJV4WGyzWHlG7eVrQ8vXh8GADptXnCwl8dsocs0kfOCrz66c/USQRCjv1VviiJsFNFPM7ENikSBaQqjAUmTQ5i9nyTw0U9gxYoVq3+bWIBmxYrVO9DTR307IzbM8eT7unNXTv/82YPTyJ1jqEkFBxCa5JTRsXwNkHEJbSohTcWw2TNTaYaBWpipZaCZWeIGa89mGWkuJ8zlmFlhM1Ze/33vlq8/mc93WcTjLeK7LPEWxgb9VJUVbQScKsnQSrPUcDxhujovRZP/0iPdmvOZ0d8FaUxf5wxN4Q6NdKe+cKe+IMNQKNbnp8gSw9KWBPzyzUdLJnuGePMXuHMBNy9yY9CZ2YKHAJ3neQHzgj34IW48QM8hEKAF89wFc914QW68uW6C+d5uoZPGrvry4/gQ/6L4sLpcsW5flnZfpg46Q7MvfcRi7b407T5mjAuk51QY8xgerAhbPtdLktRgO+yk+oIkbWGyHoC+JNWYm5K80Hf+ZPegScKAD0RzP/HK2LTi+ZMOu/0paXtE93dazpmt5mrKXEmZADGPMLS5AhpWix3N7GRwEaEepmUcAD2qCP2WmdMMpZSxjIIfkJw2KuDaRJOKdFSgzbXWU3q869pRVWH93hT97kRDdoIuO167M14tjq2Ji6qMDFeGbZVtCivbsK10/TbYw27dpsjpMwLdBLNEnB9FzpErQvs6O/7pEG8GoAdoEhAzSpI4RUFDhqZtqP0FgaPsgkJWrFj9r4kFaFasWL0D9T97uj8j0d9b4OfOXfb9R91XzOiD07aGCsKsIpjyJ5MfKKfNAI7LSTNAMaaWqWfq0xDLmGgBE9UlzXKqQUE1yIkGBdqgsjbVPW2sr0mNW+rtsYTHW8bjhvCdQ8cJogN/qs2MM0uz4HBvgMuSYQxVA3qWpOry4eBrXR5c8KcuyFQXwrZ3AKAB1GqkWdr8LINkR2VGdMaKeb99OzV0gmuQK2eeq8sCgMuuvEVufIcXwy0v1I033503zxOYDwAa7M935we784M8BAGeAn8Pnp+byxyRS6ArL1DECxTyQsa6r/nqk8SFgbK07TppphZ2x4Nb7b4MsHW0l2Y6TKfpmD7W6gIxrJ0PDzhMqQMuSB42AOjClFppkmZfau3umPRl/osnieZ5cOeOEwZM8YxcveDWpSYr8gyxPyPtjyl7L9J68UVTLWmuoo0VAHCZ2rODniFAg4fMBwEBmqn0w1uXlwBNw7L02/Q8Mr4b0LOpnDTJKHA7BClcScJPFjB0BdlQa73YQD6/21C6V5OdpN+ZqM9O1OxM0GbC8nNVTGRF+DbF1jAA0ICeS9aFFa3b+vuvG3757LM5It4skfM0D5ecxO0Dz5//0wwGjtloaggANElhJEWQNCBukqIhQGPIc4L4JwkQVqxYsXqHYgGaFStW70CD/S8q9uX6jxPNceMu/nLSeW0J0Xl58HAVBgCrsQL2O2sAMCenGhmDHdiTGI75gNuRmIGjqbDDVIOSMCtQc8XgkXrk5um+qydy161c6C5ayuMu4oxZwHcK8eJvm/7toaj1mr3JBjgpME3NMGgd3KbBMYFw6EmGRrpTU7hDCxcIwtbOBrCTn1mVkbBr9eI1X38cOsE92I07T+QSLHJZIAL0zF3oygcOdWPsymP2BSHugvkegmCH3fnz3HlB7rwAgM6evNkeLr6eLr5uHD+RS4DQJYDvEiTgBrnyAUav+nRK/Fzfg9Eb6/ckGwsyDZIMuAVvA1bEATenqR1zwgvhSPD6gpfjwR0YnQy2ainMogDILhOHbZ3zVegk8NvHzHfnzBvvtj5wxq3LxwdsDy3Ycwx9jtsfEVgf3n9/8Mphm6mShq6gGyspM7jylWCHbnxZhJYPN7OD9zDDAA1jzW8BtOMgk3gup4yQnuE/E0wKWN42qWAFGjC0uQJrrLHfPUkNNhsP7DZkJQNrdibVZyVo0+Jr46Mrt0epwsMVW8LLN24rWQ/puWj91pzlP4eOH+cn4s4UOvlOcq8q2me3Wkd/pd4S6WjBQVkpCqNopgJNEzSF0uQgjr4gCeyfIjgrVqxYvSuxAM2KFat3IKtlUKcoDprk7u/GDZ06rrZATDy61X+iHm2sogC9NQCYUznGPlPAjbDATMMeEcAOth4eCs1YCU+GdWslYq7oP6bBOq/hA213TxlSlgQvdBUs5jgt5LwfzB0T7MZf88XktCX+yrRwHVw+CGMPtQWAocXMiBNYftZKdugKdugBuRaI9ZIUVXpk5s8L1v/w1cJJXnOEnEChyzwBBxjQ8wJXbogbL8SNH+LOX/DKAJ2FwMGM57uDrWCeO3+uOy/Q3WWOu8tsd84sd+dZbs6zXDmzhRw/ISdAyIUYDc0N8XBd+dnk7f7TCjevVmclNkqzzAWZeqbvXp00DVylelh+Bu88RS2BhXMNjGuLYR0dPoR967R7U3f9uui3H6cGejnN9Rgz191prjdv9bSvj9bLrbYnQ/gLK/4CsT/G0Sco3kegnXj31X5zFWGqpo3ggoOLX0EdrgSGMM3cxgwXoWE36PI/BdDwNADQMsosZ56rhK8MXUGZKnBzhe1IDdZ1key/b96/uyEj1ZCRUpeVVCtO0CTF18TEqCKiFGHh8s3hZQCgmREqwAn+AYHuollCzkyR8+K/fXL17Ekcx0Z/pd4S04XDQpFDgKFpCoHoDDPQMBhNoEPghyxAs2LF6n9NLECzYsXqHQixWY9qa0M+nejvxgue6J6zbTXee8N+/YitqYo6XA1IDlZAD6uoJiV9RE42yanDMoDRDDqr4HEI1nIauEkBfVhJNcJ4gL2peuBCA/HiAYJ3Dw613T9nzt2wetk4twXcMQu4zsFcznwBZ/E40ZrPJsQFTcvduLQ4boNMHKnMilHtiKvYkVCZlVghjitPDP896rddvywI8/16yVSveWMFc4Quftwx/twxQXznuXznYKHLfDdusDtvvgcMaQR7Qs8btgAaoLOnCKDzfE/BXE9+kAcvwIPr58bxc3X2Fzr588cECJwCAY7znf15TgECToDAxV/AmSNwmSPg+As5871ESyaP/fXrqQnBs/M3rJQlbqvLTnZMadFL0g35YkNeGrA+N02fl2bMT9flpFSmby9L2LJjdciGH79YPNFjnrtLkOj9YC+XOWM5K2d8fkxdbnneaUNfWNAXCPoUQR4j2CME78WwHsrSZr3UaDfX0MYqsqEKP1xJHK4im6pIwNCApB1LCR3tOABDj9SYR6Ez7APtAGhIz+BMWHsmYekajjakDSraAOmZNFUgDSrbBT3Zf3ug+0pD4e5GcZpBnFabkVyTmqiOi6+JilGGR8m2RpQDgN4UzvTf2Hpg3aY1n33m58r3ETlPdx2zfVXok77ePxlfBpQMGJpEX9DEEE0M0oSFJodgbzsS/5OvwIoVK1bvRCxAs2LF6h0Ix9Arp4+vmfGNvxs3yFsYvdD30a3jRNdV22kdfrSWOlJDH6mmj1ZSR1T0URV1VEEeAawMrKSaVOAgdUTJPJRTTQrwkGyqwA9XoIerrKe09raLBNJpIbstRA9i7Wi73FSctG3RZK+5fM4CDmchhwNgej7v/cWevOWT3H/7cvLGHz7bOuObMJ/vw2f9sG3WDxt/+vrXb6cumzoueILA38NptuC9Wdz3ZnHe9+W8H8B1CuC+HyRwnufqMs+dO9eDN9eLP9dLEODBC/LiB3kLAr34Ad58fy9ekKcg2FMA8HqeG28eOM0dOlDECeKOCR3z/soxzhuEooix48K9x21wc1/B4y3gOAXxnOcIub4CQNguASKXOUKOn8h5rpdo4WTvX7/5ZLvfT+KFAdkrFuSuXZL/2zLpuuX5vy7dvSp054r5aQv944Nmhvt8u/qrKQsnewa6cucKOMEibhCAdS/uzz6fGyoLBwfaEPypDX1mR55j9keAnm14nwOgwbUiem/Yzpgwcy1+pM7eVEU0VZNN1URjJczSgNuSlww9PJWQKTDDZYWjPRJPh3kbZiUoMxvcoKL0Kho2+qi0m1XWE3VE+zna2txz+6Q5L7sxLd0gTq8RJ1cnJtRFx1VHxiq3bZdtjQT0DFyycRsA6JzlP4eM9/Z1480QOk13c5JJ99gsltHfpz8SRZEkQeJ2EreQhIViFhRSbP8NVqxY/a+LBWhWrFi9AwGu6Wy+H7dyYYArN9CNt+r7T8+oS6in94nWi/bzJtuJeuKEmjpWSx+rpo5WUEeV0EcAKyvJIxXAEKybFDQg6WOV2NFK+7Fqy4la6zkD1nyOGGrB8C4b0WMn+1C0225pf9h2/rCyMGae30J3t1AuN4TLCeVxQvic+TxA0mNCRS6hrrwFIv58ET9YxAPIGyTizOGP8eW/78t38uVxfLlcXxfuLCen2c7vz+GNgRwM3rMHL9CTH+jlgGaBv7dgjifP35s/Zxzfd5xLoDdvgQdvCfi7PN02T5oY/cnUzG+/y5vuU+IbqA1cdHL+ykuLfrm8cO2FBatOBq/Q+4fs+3567JQPV7gKg3mcII5zEI8zV8TzF8CAByDpIDduiKdw+Vj3leM9V030WjXZe9WUsSunjF0x2WvZB56LJ7iFjBWGjBXNBe9H5BIo5AaJeJC/vQSbgqZdOVH/9OldG/FwEOm1Y09R5AluBzu9NrLXjveA64PYu0hLO9l1bei0Yei42n68Hj9aQx2tIQBJO4rQDTBfPjzf++XyzeFUNNMFxdGr7uVDI0TnYXrWKymDijRVYA2Vg40V1jNqou0MPXSXtrXeP6k3Ze8ypWZqU8U1ySnVcQk1UXGVEQCgo2VbIsuBN0eWbgo/tGFL1MxZAR6uPq6c6a5OCz6beOXMiT+T33hDFBBJUQRbdWbFitX/K7EAzYoVq3chinr2qC83LhLQc6DQZcGH3qU7Y7FnD6iBVqTlwsAF89BJLXK8njhWSwKGPlZFH6ukIUkDdK6ij1bTYNsE9gE9V1uP1/SfVg9eO4x1XqEGWgi0AyN6EECHeC8GABrpRLDOoRf3bp00KNKTtv74/Tw3QSDfJVjIm89zXsB1CuE6z3dxCuY4z3V2muviPJfrHMh1DuBy5vC4fnyhH989ZOzk7bMC5np4T3ceM4s7xl/kEgDes6Olhhd0wFiRPyRpYaC3IMibN9eTs8jNZcuksXt/+qF+8dKTv268tiWqJTyxOzzlSYR4ICLDFp5h35qGbEyyb0i0bIh/vG773bVbz6xcVxE0P/ub79e7ey/hcEO5vGABuDJcfwFcaxgELhGfGwoscAHED15/kRt3gcglWMAJdnWBFXFXLkD/ua68AFeeDzNqJD9u65VjasTaZUV7htBeCwa4+SGC9iJIlw3vBjcYNrzHjnbb0G4U7SJt7WjH5f4LJisD0KTDTeAiV43ky0eGqrw+odDh10iagWlH4VlB6xW0Ds44BPQ8dLii/5wG6zhNDt6isBZioPm6psK4Y6c2OUOdLK5LTKmNTayNiq+IjFVFxMq2bJdv3V62CWL0vl/Xr/rkE19Xvo+ry0w3TsLapQ+7O9nsMitWrP5yYgGaFStW70Y2y5BBUTp/rDtMA3sLIxbN6btzGh9qJy2dWO9t6+3TyMXD2Gk9cbKeOF6HH6vGjzJuYny4mjhSTZ6oJ87p7VcP25vP4U/vErZO3N5FoF0YQ88o2k0gPRjWbcM6rFiHZbDtWcfNeyfMaml22spF63/6ZvUnU5aO9w51FS7g8+fzefN4XOAFQtEiT++fJ05ZO/WrrT/4Zi78pSZpjy4rP2TSRzP4/Bl8Zz+Riz8D0P6eAj9P/hxv4RxPQZCXcK67YKGX69YJY/d+9rlhXsj1tRu7w+KeRCQPxGVZEnbZEnZj8Xuw2N1odDayfQcWmUlEpBPhYjw8FQlPGQxPfrItsX1TzO114U3Lf6uYu3jHNz+Gf/zJmg8mzXUV+Iu4AcBC2K9jvpAbKuQuFLosFLksdIUdpucLeXOF3Llg6ypYPHHs2u+/SN/wc2Ploe6Wy4ODHUP2HgvSa0N7bVgP5Gasy0p02PBOK95lge62YN1gO4R1ItYWvO+6/YIZOwEZmjhWQx6ppgBAH64YWUqoGD3iewSgHehMvg7QegUFrcLNlcjxOvs1M9Z3gbDetmP3ULJtqPv6iaJ9+vSs+qT0usS0uvjkuujEmqg4VWSMMiJGHhajCIsp2xIlC4vauWjpPG/PWSLuTFdO0AeedSW/26x/Or/BihUrVv8xYgGaFStW70YEjt06f3rpZ1P8hS7+7vylX310TLH/Rcc10t5D2XuJ/lbi0R2y+yrReg6/fwq9ddR2/bDlauPgZZPlstl+/TB29yTZep7qvkI+uU0ONhP2DgzvRrAuHNJzD4L3IlgPhvagEKC7LFinFelE7N3IYPuLnhttl4+eq5Vr9+5WxSeVh20vWr9t/y9bCn7dvH9DWNHm7bLIpJrEnfrMwiO5irMHNDfkTScKKxZO+cKHz5/Jc/YVcP1def7MDMWZ3jxgsLPAjbfO0+Ogj+/x0BUPVm9+sS3JFpmORWdhUVlo9C4kJhuN3Y3F5OAxOWgMYOjdWHQ2Hr2LiNlJRGehURlIVKYtKmMoQvw8IrUnIrltW+LNLXGnt0RXrP1t1aQJfkIXPxF3loC7eMqUON+ALV99t+qDj5aPnbTEc8ISr0mrJn+25dtpO5asPBi2XZO952ytvP32qcFnD6zWriF714Ct02LvtqE94CLY8S4rQGcI0B3wpgLvtACeBheH6BrEO+x4B2ltJfquE/dPW87pB4/XIsdqiaM1cDUhU4SG6NwALIPNuV9GOCBAy0h9KaBnwlhOwH0lZajE9SqrQWVprEIumsi2M+TTa4TtNords+EtKN7Vc/2UIWeXNkWsTkitT0itjU2uiU6o3g4r0IrwGEV4HGBoeVi0fFvUtp9+muMmnO3G+0k0Zo3Pdw9uXCX/2QBCVqxYsfoPFAvQrFixejeiKOphZ3vS6qVz3HgBrvwFE70km3/pOHd46NE9EnuIYH12DOBvJ460ktYH5OA9vP8e+uIu+vw2+uI2NnCPsDYTtlYMGOlAUZjTsOPAXQjebQfGel7ahgKG7gakaEU7rfZWq+2BbaC1v/N2++lTt+pMNxWGG+WG6zLjNbnxqsp8o7LxVtWR2zUnb9ecuV174XbNxVsVp49KKhZ/+OVMHncW39lPwAU46+fBm+XlMsPLGWznufNiPv742LLVvRu2D25JtIeLATfjUTuIaMDH2XjMbjw2B4/di8XsRaP3oDF70LgcPH4vkbAXT8jBE/YAE/F78NhsJCrLEinuj0x+sS3ledSOvoScGyk7t37yqR+fA6jdhy+MmBN05lDFsTxZ467ixh0Hzem/N2QePLy77ERh1Xm5/qqmqevitf7e5iFr25CtfcjeAWxB4J2DFe0CAD1shp4dtmKdNmAcVujBFkE7UHA9B+5hD2/am89arzTaTmmRIzU405SDOlxBwX7bChjncBSkDXLKYbOCbFBiZgViUlgaKy1NtYMnNJZLjVj7efzZddxyC7HftmN37XgzgrQT9ofXGzTqHZna5FRtfIomPqU2LrkqNrEyOr4qMl4VHqfYFicLi1ZExOz7df3SyR/4uvJmuDpP83AuzEgYevF89NeIFStWrP4KYgGaFStW70xD/S8qC/OCxrkFuPGDvdwifadfUSs7rp9AB7tQ/JGNfGinelCiE8PaCLQNR9oxezuGtmNIGwYe4h0o1m5HgTvsWAdDzxCgIT2/DdCQoQFAd1jQliHkgdXaanve9vTuzeamkw/qj7fWnWqpO9sMrLnQqr3Yqr3UrL10T3vpjubyHfWlm7Vnju2vXDL1yxlc51m8Mb5Crq8718eTM9PTydfDOcSDH/Px1NO/bnoSkYJGisltaWRkJhm1k4reRcVmk7G70ZhsNG4PErvHFrvbGrvbEpc9lJBtSdxtTdpjT85Bk3Pw5L1EUg6ZCBnavj1jKCp1KDxtKGLn4+g9d5J3b/v40wC+yyyeywyBMHHx8gf6U/dqzt2tOntbdfKm7Ngd1albVWdu1J29Zjh768Slx23tloHuIXu7wxakg/mrO1/RM/QrgH7dVrQd2ALdhtjbiKEW4vEtrO0CevMYes5oPVZrPVJtP1KFH6kiGivxBtjRGTepMKMKNVVYTcoBs9J6tAa9aLLdP4F2nMcfXiOe3Sat9zHsvg2/a8Hv2IgHCN6K2jrwFz1Hy4vrMzJ0iWn6+DRNfKoDoKuiE2siEyrDEwBAK7bFysKikgPmBrq7zhQ6z3B3Dv5i4uVTR3HsX1w+yIoVK1b/GWIBmhUrVu9MGIpcOtb06/TvAj0EQe7ClZ9+WL9bfPe4/nHLVRx5aMf7bGSvjei0Y20Y1o5jHSjagaDtCNbmMDhuQ9sd/DcC0A6GZjAaG8Zo20j9lQHEZgv2wGJvtlvaLY9aHl67+sB04oHmZLP6TIv6QqvmUqvmcqv2crPu8j3jxVumC7fMF+41Xbilb1r13fczhRwfwfs+Qs4sD5eZXs5+nk4LRM5JH39y5bfw/u2ZWHQWBRyTRcbuJON2EfHZWMIue8JOJGUPIs61pecOpu8dAM7M6Xc4fXd/WvZAyi5LajaatodIzSGT9mAJO62xGdbITEtE9uPtu2/GZW378JMgAXeWwOVHAT/jt3X3DWcf1Fx5UHX1XuWlW4pzN5Xnr1WevVp/9rLpTPPlG4OPe6yWLgvSZkEAPUMgBvcMwLDM/Mqj0fl1gB5E2wfAU/BuBO3CrW34QDP54j7x6BbRdQVvO2+7d8Jyo2noSsPARePARdPAJfPAlYbBG032B6fRrov442vEi9uY/T6CPEDQZgRrseEPhoh7g+RdYAvxwI634ZbOJzcvG/bmqlMzdQnp+oR0TYK4Nj61Oja5Ojq5NjK5OjJJGZGgiow/uG7zyo+mzhZyZwidprk774ja+OzxQ3b5ICtWrP6iYgGaFStW70wkSXa1NGdu/CXQUxDkJggZ57Fr9bJbxpqWc0fQF10Y+tBOAIbuAgyN4JCe7WgnQ8ztNnzEryEgrEPDndcKrkzt+bUAAwDoFivWYkFarLZWZKjD0tfce+VyS9PpB4ZTzYbzzfoLLcbLzcaLd03n7x0933L+Ws+t+/3tHU/v3w+fH+Qj4sziv+8jcvJxd/b1dJrv4RwxacLJVRtsSXvxmN1UbDYRtxNN2GFL3GlP3Y1m7iX2FGD5vxMFB8nfi8miUryoBAM+VIRDF6MHDtoLfrfnFVp35Q6m7bSlZWPiPUhytj1xhy1651BE9pPtOdci07dO+tifx5ntyvtexJPExdwynmpWX7tfc+Vu9cXblRduVl24Wn32ivr0rePnH7e0oEMPbbZO68hNxcudP2+42hLttMAr1m1Hu1DoTszegdvacGszOnAffXEHe3Ybe3YLf34Hf34XPEQH7qGWZhRpteOtNrzNSrRYiVY70YYQbVa8eYi4P0TdGyLvWYlm8CEiT1uu19drM7O1KTv0CVn6hExNQkZdvLgmNq02OrU+MqUmMrkiMrEiKj5jwcJAN7cZPKcf+f8VNNX7pEkDbrdGf4FYsWLF6i8iFqBZsWL1zkRRlHVo0KSSLfx4YoArDzD02q8/Pbw//36Tsff2ZczyEMUe2vEeG9ltwwE6d9jQTive8cqQpF/BH8xywGprxyuGZtLPIzEGpviKttuxNivWZkFbbUgbYuuwP2+zdDX3P3jw+Oa9vqt3eq/eeXzr3ouW1sG+TsvzHtvQQ3To8dDDjqyNv8wSuvgJnHyEY/zcnELcnTdP8GxYsWpQvJcSF1DJ+WTKXix9j31XLiLZTxwqJUvLqTIZJZdTchmpkOHKckxZRqjKKWU5LS+lgMvLqLJSqqSELC7BDxbjBfvt2Xm2rBxr2i57wm5L9N4nsXlnNydsGDd5jtBlBmD3KWMbK2StF6+2nrreeuJ687GrzUevNh+/0XHh3qM77UMPe5HBPsTeabX/y9DssB13FKfhpbNi3Va8awiDzTqgwUGkHV4upB2DQZo2YNzOhGqQdhT+TwDeuljAhcXbAEajKGMEbFtsWLOVuM/kN9pQpLPz2ummvEJd6i598k594g5dQpY6IbMuLr02TlwfLdZsT6uNSqmOTi7dHLH2sy9mC3jT+WN+Er0n3rL66aNetvzMihWrv65YgGbFitW7FEmSrXduhi/wD/TgB4p488d67l676pam/u7RxoGeZsL+GMUf2skexxJAG9NHYojosBDDDP2K/xh6HgHoYRC0wdYTEKBfZn8RtBNhMtNWos1KtNpwAH/tmK0Lt/Sgg71If5+tvw+QKGbrQxE4asRG9NqRPsvT9n2J22eLeH4CDgDoAMF7a9z50p9+eJK+k9qzn87+ndy1n8jZRxYcIItLITSrlFSFklYpqAo5WSEjK8pxVSmuKgFbSllKK0toRQktL4MYDV0OIJsuLycOHcIK9tl35yHiXEti/uNEScPa8J/dvf1ELjM8eYumfXn/8qnBp939Tzr7H3f1P+oeegze2CPbi6fo0DMMeYzAcnuLDdwYvAXH/5KtRKcFXGS8Ywhvt8CL3GkFVwxpR+xtqK0dBRiNttmRVmCwg6FtKDTEaPCr7RCdWwA6Y3bGSDOCPrBjDxCsGbN3DD59cLJSbszMMSRnG5Oy9Ym7tAk7NYk76uIy6+My6qPTNdHptVHJldvj0+eHBrq5zxK4TBO85zdRcNxQy5afWbFi9ZcWC9CsWLF6xxrsf1G5Lz90yrhAV36gq3D1F59rd+26rdO1nz2NPush0EcIDlmWyTTDZhoA76zYsF+Get8G6OHVhG8BNIp0IeBZRLuFbLOQrVaixU60DYeniR4rnDDSbSc6bAT86QDZYcG7rQMdtYU5PkKun8DF19V5Lu+9LV5uR1evwSX7SelBvLCIOFhGlZbTsnJaIYfcDA12ZLSqnHJYWQbQmXKgsxIaPCShy0gFNKEoJeWlZFkxwGiy4JAlo6A3Nb88dOV8oXCGK+d7D86WZXOf99xD0IewnTN4qxj4K3oQtA9FH6HoQxRcHLzdjj+wYf8jgLZDDm4DtiKtFrTVCoy12QAu26ERGzwygLcOEG1D4PrAkEYrsA2DwRgr2gyNATMcj7Ta0GYbBhi6Bbe3YS/abx0z6/Mk5vS95uQcY/IeQ9JufVI2YGh1XFZ9bCZ0TLo6XixZ/cvyKR/6Cngzhc4zPTkpG35+3MMOT2HFitVfWyxAs2LF6h0Lx7C7Vy5uDw0K8hAGuAqCPD3TQhddr6i+ozc8vnWVGOrD0T4EADTeA/MYEB9fuuvvrYqDGYbXO3Iw9Ow4rR0ANIZ2I+B1iE4LCRi63QYMQBDudwxRnYMkOA7oudVGtFjIlkGqY4jotlk6T2uU0wQcPxHX140TxHsvYrz39agoYv9B4lApVibDFUpSJYfxDGg5rZQxdjxkrAAuoxWlNKxAl1IqaFJVRjAGGE0oS3B5MSkromTFNHjB/bLuHRLxjz7+Iv4PHpy/jeftjNuMDPXaYF28EyHaURyaiYZ3oVgXhnZgWBuKNdsxx83AsN9cPvjqfuOPjIDXYRIaqA0Ss83eakFarcx2CG0BHsRa+vHWfqJtkGHoIbx1CIfQDJdmotCD2IMBvHkAAwYnPxiCAN1G2Doe3718pOiQYVd+gzjPlLrXkJIDrE/eDYvQ8TsgQ8dlMVmO1C3ffe8vEswWcmaInEI+n3hEU4Ui9tFfGlasWLH6S4kFaFasWL1jURQ18PxZ9X5p6JQJc9yEfiLR0ilT61Ky7tbr7h1ufPLgOmbrwbBeFO+FXTVG6soj7ereJsK3AfrlOW12wIiOXAfebSXgUGsEustGwIcWEk4VsQFCxQCPtiNEp5XsthC9dnvPvQtNwR+OmwUHSjsHCt7fOtH7VkoSKZORCiVRWYFXqQgIyqWOkvMwNKughyvQIx4+UgG3ZAUwoGdYmSYVxRR0EaksolQyQlbRlbd/mZeXjzv3W2/nHz8SnWmsQm19dqQPRXsxrBvFYBc/BBr2wMaAHUgN//Y3LtGrJZWvVeL/yHAhJmx1Am1H2u32Nqu9zYK0DWJtAxisPQ+isDIN484w8dwO0+RM+dkCGBptZhj6PtgCbgaoPQiPtOBY59DDOxfrqhr2FjZkSRszJCZxnlG815Cao0+BRWhHlqM+PrM2MTNr4ZIFXh6+fOdZQueZrmPS1q140ttFkeToLw0rVqxY/aXEAjQrVqzevQgcv3/9aniwv5+bwM/VNcjdKz4g+EKJ7LZOd+/44eddd0j0EYb3OeYLIhgsISMwtNDNUPKrgqudmaj32sPRAA3wGtZlcYjOdmZgIeRRFLwsoPNeGw4MhxfiaDeJdGFw/HWPBRy09Txsvrx9YcB0V84Md46/cMwqD+Gp6EiyqoKqriSrK4kqJaBeWGNWlg2zcoWMgulnGVFRjleWE5Uyh6lKucMMPUOAplSOsjST6wAArToEno4placTkv24TtM8Xb4dz/1tySzL0wcAoFH0MeM+eAVG2vY5/hwbAduVvOqE/d8CaCveOUh0DQHjXRa004p02JAOKwKbQw+hEKMBTNsAVYMt4ujADW5XAEwDpG6BJI02I/Z7qP2+zd5sQVqGkBYb0ooMttw5aTy8b39T9r4jWYVNWQUNmfnG9FwHQxuS98AgR9IudVLWwc0RP3/8SYCQ58tz8hNxpgvfE29Y9ZQFaFasWP31xQI0K1as/i0aGuivO7Q/9MNJc4RCP5EgdPLEwi2bbtfV39MbW4+fGOhowaywKQeKQYZmStGQbiERwuwyg84AjmH91dEHenT5menp5uhQ8RpiwldzGL4gw9AA0HtQtBuaYXQbeIj0WJ48kOeJp48XznDj+AmcFgics2dNHygvo2prAUZDw9yzjFbJKOjhAjPl4OYq4HKiGhgAtIKugHYQNixFA4auKAUmVcVwR1lOKeTPS4t2+vnMFjr/zZMzbaqnWlmI23utVvA+HzEzGntH/oThavqwidH0/NJ/FqCxjiGi08KsI7TCi+YwM2MFtpce7jDNNJmGTVFg1hzuwOS0FboFRR7Y7Pcs6P0htMUK6Nna3n7x2Omy0mN795/cdfB41u9HdxY2ZkrM4nxTWp4xNdeQslefskeXsqs6NnnDd3/zF/L9+c7+XCd/npMP9/2gyWMT1q8+f+KIzWphY9CsWLH664oFaFasWP1bROB4860bCcsX+wl5fq682a4ua775omFv3gON6Y7W3HL6jOVRJ2p/ZAf4CNcUMi0ysG6U4V0E70Jg9ALOo36LHUdlPDrfAOi3DKEc5q2HK9wIDgcZ4lgvZum8dc4c8repPm4uvkJOAN9phZfr4ehIrLaGqqkmK1TAVIVyhI/lNMPHNCw2A2iWkVWMq8FDhcPgBIdJFeRsgNFkZSkBS9FKXKk8nRK/cpKnj7vz37xdlvn/7cHNk4j9oR19bIN//uj3/Cf9ZwDawdB/5yDD0Mwkmg6LYzgLA9B2aGbtpmPpIdpqRe7bsGY47hFrRy1tTx5cvlChPFFw8OSeg6eyi49lHTi6c//hrILGjAJTmtSQkgcA2pi2V52YIZ4fGuzlCeeW896bw39/Nve/Zri8953z//3Rk7/a36fy0L6BF89ZhmbFitVfVCxAs2LF6t8iwEZ2i+WkQfvLjO8BPc8WcILc3RIC550+WHJLY7hhMrecP2t53Ilgj+3EIwTvQ7FeAu/DsR4M64EYzTTQALYTo3LS/yOABq9mQ7swohezdw88vndoR8KcsSIfkfNskbO/wHnbl59eyEy3V1WS1dVkJaxDU1UqulIJzZSZaQDKlfJXrpKTVQpgqgoclzGcLacqYOka0naVnKiUYxXK9n3SmB++DPDk/s19zN8mCrKTwyzP2lDbIxR9Ykf7YKX8rbf9J/1nAHqU376AdmjYr2Ok80k7U/tvs2GwRwcT5GjFkE60v/3p7UvX6mpO7S8+mV90Mqfo5J6SY7sOHd114MgOwND7G9ILTOJ8k3ivLmVH9uLlSyZOhPQseG8G///zcf+/q/42JXiq50/C9//m8t6PXKeQqVMyt264c+UihqIsRrNixeovJxagWbFi9W8TRT1/8rg8b9e8yd6+PJc5XH6I9/jU0EUXFMpbesMtc0PbhQuPux/Y7Y9x/CmOP2YAuhfD4fpCgNQ26F5A0sgbDN31ZuuJfw2gmVwEnMaCoj2Ytbv9xqnYZfOmuXN8XDmz+GPmuXKjv//6cGz0YIWSqqkhKiupykq6UkVXvQRoJdyH9WbIyhCXq+VktYKqVtCQoR0nVMCed9UVVKUCr1Q2S3N3z5sT7MWb7sH5xst5wcwvb10+gln7UPtjBDZ77nvrD/xX/fayy3/ByMhAdWaOOmOIzm02OIawFeahcabVyfP2nktnblTXnj8gO1cgO5NfdjK39MTe0mO7i49lFx3ZdfDwjv2NTBjaIM7O/XnNz1OmzOG7zBGMmcX7Pz5u/ydy4U8na6Xa0h2rpn86g/++j9P7Ps6cOd6eUcsWNdRWWocGaJahWbFi9ZcSC9CsWLH6N4rA8c6W+7lxUf4e7r5cgR9g6HHjdqxYcVmpuqM33zYeuX30RO/tW0j/YwJ5hhFP7MRDG9FnJwBWQoZGMGah4ega7esM/a8BNBzgQnRbHMsNkV5rf/uV45r1c31mCDn+fI6/i9NcEfeXjz84sHJZ14Hfiapauqqarq5kaFjFkLTDIzVpQMyAnmvglq5W0tUqCpxZU0lWV+DVlXaV/E72juTpP4R4Cn3cOT+O5fl9PblOVmjp78KRJ3b7IzsAaOzh/xygXzL0f2PWt51p/QHp2dH+GW9hWkEPY7QdbUeQLtuztvYzJ64oqq8cqLhYoDovrTiTrziVJz+ZW34ip/T4HoDRgKEPHN5ZYM7aW7Bm3aqPPgoU8gA9z+H/lx///26Y9ukVQ4ml73x/37nzxqLYRX6B7gJfDtfHhevr6bZ6+rele3d2t7eSBDH628OKFStW/6liAZoVK1b/XuEYevvShbDgoFkCoa8L15/nsnzKB79v3nKnTn9fd/SO9vhd86nOS9f7e7sw7IWdeGKjHtuphygBFwJieB9KQIaGqwxH97xzgCPMAb/FlK/sAOiXXT5seLcFADQEVtimw472DQy0HqktXf3dFwF8bhCXM4fvPJs/ZvE4jz0B/jcyd1LVtVRtNVVbRTANOuiaSkDSVDVg6IrhaAeEZiVVBTAaoHMFUVOJ11TaayoHK5WHt0ckff/1AhHXV+j0o5vzjxNE+3clPe2+g9kfowCgkUcI9sSO/08r0G8z8b9oR1qjDaIzbJXdaiFamX52MNGBYd2AnlvOHr+orLp4QHVtf+2l/5+98/5qKt33/3/wXfeMCukJAew6jqNTPVOccWz00ItKb2LvKBAIReyQShcLnfSEIghIL9KTUFSkI3YpaXC/z7MD6ugp99xTxrvWfq332mtnsxMi5odXPuvzfB52QSMnvxY4NCu7PuF23bWbVVdvVF7JuHsp+e4ldvaJM8HffmdNwluTjC2JS6xJS+3ImJSDAU9aK/QvlfoZpfpVl6pOxDoeaLPSdAcOux2H2UnGun31OTPs5MjAozl0OgcKCsr/EVCBRkFB+fcyPz8/MzVVKRUF7PptFxFnjTOm4XG+mzaLzl/uk9ztF9X0CKu7pfeUFXWjPSr16wmd/plG/0QzN6aZGwVHpAJtyP/GMpHy87tJeW8FGhHr0Rnd2LRu7NWT/uq8G8d2brMmYGHbLsHYmoRxJhOPbdyY7uzUER87lZ+jExbqhYU6QYGenzfHzwOiPA/Cz4PezM/Vw+RpBflTBTmjmamV9LDLdlZ+a1cAe7YkLNtOMvplBSF8/76JgS7dzIRWM6nWTMD5G7oJNay1/1MC/d6Mv3f5yJL/RgamdY+m9QNv9A/f6B+8gTuiw+uz6iHt7PCbJ329VXcbs/JbMvLvJxfc5wmaOPx6bmEtJ7+BndOYcLvh2o3qxBuVV9MqrvBuHzt96IcfaFSSFXGZNQh+qRMVH/rrL+nB+0sTL421lutfKfWafs1M31hfbR4rZu/3X+4kYnbijXcSjJ0+Xxkd6NPTdl+n1X74AUJBQUH59EAFGgUF5d8OcOiXz58Jb6S7bv7cioCxxWLsKOSTFlYVSRn94nv94lqV8F63qKK7qHLoftvs5Nic9oVWP6meG5+dgwM6DAL9l4rQfz9vBVqDbFg4+3uBnkU6rbXq8ZknD2r5t0K2/7SThLEkYy3wRtZ4Y2vsMjcS7ux3X2Xuc6+mnxtM5c0I8/UyoV4qnBXka4T5WlGelp8LvFknLnyVl9V19WLhwaArNKvgTZ/TKLgd2M92Epb+Rlj6qwnmxB677obSOfUTxJ6fqDXjah0SPWzy/vht/yP50J7/IYGGxWYd3MT7zdwj4NBTuoEZ7aBmdhiI/vT4Q9W98uZsfnN6fktqYXNSYXOysJEnqOcV1HELGjm5jYlZ9QlAoDOqmSmCsKgTv/5ib0qxIRnbEJfZ4JfY4pad/HEL18Mr2SsoJTBIEE9/1CDTvunVzcGu65cTXdKMBJ+fvtpJggK9i2BEW0GNDfLtbmlEHRoFBeXTBxVoFBSU/wRzev3k2MjtxEuuG9dZE3FWJILdctMztjYVSZm9kkqg0X2iapWwUiGp7KtseNLTq349qdU+1ehhjVajHwPqPAMMeGHzwn/AON8KtGHHb3BlGjo00hgNx0WPzWrAT0e16tE3T/vaK0RXjgY4f7l6Nxm7m2hsQTCywS1zxBvtNSPt37Dm1PdfRf72I8vJ9ra/p+BIcPHpI6Whx+QnDhWEBCS5OzJ2/Hzs2y991q10MiPuBt6M+2wbcekvpGW715Ajgtx7WytmXgzMzo5De9ZOIAOwxzRwueQ/WX4e/tie/yGBnjHsPqh7OAVrzwOz0J5HdK9GXzzqVZaVt+QK2zKFrWmCllR+cxq/KbmwKZnfyMtv4uU3cvPqWTl1zBt17LSCcxGntv/mZE62IRvZEpfYEZY4EIwPf7OZ5eKWui8wdV9wkqdfUoBveuihnjrZzJt+rW5kTjf65omyuSj7hMPu3aaE3eB7CxHjuMqU4bevo75Wq9V8+AFCQUFB+ZRABRoFBeU/hF6vG3n0gEs/Z7PKbBcJa0nB2i2nnKbRStkpD6QVDyTVfaJapbC6S3Svq+je4/vtU2NDutlJ4Lhv26AXejmQnoe3+Ugof5f3BdpQhIabfhtWFgKB1ozBDVbeevn046GeelHa1ZOOFjvJmF2wDg0ceqkNDkjhMhvsn+zwS1woWM8VFJ/VVN+1Zn7rzL3XmO5bY+ZiTrQlGsG+BZLxTvyS7cSlvxKX/oT/zOmrtZmXzvW2lutmRzSa8Sn12AzSuQEEWqcdRWb2ffiG//F8aM//kEDPwpIz3McbmDS0Z7hkcGC0476qpKzlNr81U9iZIW1LEzeniRqBQKcU3E8uaOXm3+fmNfByq7k59zg3Si9cDd2103kl1Y5iZEtaQiN+Zof/LHD96msOjmmefohAB6Xs9ePt8+QF+RYnXemGDj2g043N68a0bwbaygSnna0tzYgWBIw1AeuwyizSf19PRytah0ZBQfmUQQUaBQXlPwewokc9ymuhJ+3WL7egGFuSjOxWUo/s3CG/zOyTVPSKa1WShi5xXYe4ukt2r6eibrS78/XkgE49odPBHfvUcEDH6Czw5jmo0UgFF+mNNnR3IFncg/BtFjYm1GpGDA49C5wVuU2jgUH2bRk1KDWyE/jQq0lVT9MdIefCaUcLZ/A+Sca7cEusiEZW+CXW+KW2eGDSS6yNP4PB/MkKt8QSt9QChLDMgmS0k7jsF8Jn26jGLt99nnAyuEFy+9lgm2b6Mfi9M9rRae34jP6JWjeuQQb26bUjOmQn87e7LSKbeC8EXvlofSSyY/nHAm3Y8Hxx2/MFOR5YHO0MrhiWWg7OwMDtacDJNPIQSrNmCPxxdOrR2RePnj7s7KupbBNJWrOF7TdFHZnizuuS9gxJS4a4KV3YnMq/n1LYystv5mTXJ2VVJ90qiIoLt7Z0WWliZ2JsS15KIy2lEZcFblh7mUZL8/RJ2+eX5hmYtMcvzcsv2dsrL/Q4/wJdlHSxWn57crRDpx6GDv3qcW/jnbhgT9pqc2sizoaIs19tFubjrmpr0et0H36AUFBQUD4NUIFGQUH5j6LValTt988fCbZaTrIAVko2opmRj/z2W2H0xR5xZa+svlsC0ymu6QQaXVTVU1M70afUTk3qtM+0wD7ngIOOqufGgINqdeM6/bgWBCrpuGETb7g3uGHCxkLG1Brkugb8aEGaDTt7a2EQ5zZshagf1ehhTwWQWuB2r5+oVM0lotTLVw/5+W79xsKcsA3/2W6CkTUeY4VdZoMxsjZeCoNZZmG8ZDd2qQXReAfRaKcZzn/nn5nnDpbz00d7G9SvHmlmDZVvQwP3GNwyBvF+rW5UB46wCD2k1iJlY/3gNLLtNjga1FYNA3UfdrAgij+tH5lZ6D9Z6AgHz5rRPzYE2f8cPsuwN4oaRDMI/72wAWZoVj+E3GzI0DSi6eCnc7NP5qafvBjofdxYrygqbS+UtOWI229LOm5J2m+IOm8IO2+K7mcIW69LW9LFTSnCpuSCxuTsxpQb/Mjo07u3u60m2VI+s6UssSMb2REx/hvWX6TZp3oBdfZP2+efstc/ZR+wZ+/0Q0Gi+LDCK2E5V8/lcSPvFHCHVDVzsyPzugnd7Fh/a1VMkJfDSnM7It6GhLNdTb188tDowMO5OXS2HQoKyqcIKtAoKCj/Uebn5zVqdU9766WjIU7rzG1IGFsSzt6M6v/dlqTDJ5tvC3tk1UppbbekrlvS0Cmu7ZJWqcprHja2PH3YN/t8VK+e1OkntXMgTzT6CY1+HMkYOCITLRB71sONwd8FqUnDSvN7heq39WlD4dkQYM9a8FAzBBxaox7SzA6+eqIcUdV33BNXi27kXou6dMTvpKPV/h0/+f/8rd+P3/h8v8lny2a/rd/u3/VzpLdL1oXwav71rjr56MPmV8971bOD4AVnEXv+i4FCD0f1DatB9LAODWvPcA9zoNRAbQ1ZmB9iKD9PLxah384VeVu9fhdYbH4beDMsNiPSDBwaXIS/TgPEfUyvfaJ5M/Z8oPdBU333nfIOUVFHnqwzR96VJe+8Le+4LWu7KW2/IWnPFLffkLWkS+5nSJtSBS1pBXW86xmHjh7e+qPzSoq96VIH6lJ7ipGDCX7/5k0Jzm6pXgFpXoFpngFAoFP3+qV4+6UE+glizoquRRQmhhWyw3KY0KFltxJ67pdq3jye003o1WMD7bVx/p6OK82sSThLMtZhwwo2/fST4cfz8+hsOxQUlE8OVKBRUFD+ALRqtfJ+c8Kpox4b1gCBtjMhWpMJe7/YcH6PZ3XyjT75vZ6iBoW0sUvS2CWu6xLXdEruKUprHtQ1T6iUs8+B+T3Xzj1Tzz2dNXgznHk3Do6wtWMO9njMAh+FvmhoclhQSUP3s2GH8Cn9KMi0Hu6k/Z5Aw2YPjXZYizRXGPor1OohoMLa2aEX493DfY19rRXKhpLOSnFzSX6DPKexJK/9nkjRWPyou/rlSJd26jG4E7wCrPgaZPcjb34/yG9fbMaApeiFaDVDWjUSDXz4rsEDVpEXHi7ejGj0Yi/1jBaJYcNF/fDU3NDU3MDU3KPpeThwY0Y3CJRdPzs6Nzs5N/P09cijx20tyrsVrWJ5m0DekSfvyi3uzi5RZBV3ZZV03i5uu1XUfrO442ZJa6a8NVPWlCFoySio5qQlBYcEffu103KyPRVjT13mQDF2pOAOf/9NoqvHdd/gdO+gdK+gtH0BwJ7TvPyT/XxzQ09Ir0QKEyP4rHA+J7yAE5HPoedxosSZV7sbirRTg/+tHZ9Xj/fW32F4u9ktN7GGw7ONnb5ck8W+Mv365YefHhQUFJQ/GlSgUVBQ/gDm5+eBQw+oFLcuX/D5/isbE5wtGWtHwbmuXn5ql0VOeGxbXpFKVtctbeiWNneJGjuF9R2Cmi5JrbKkrre6abCj88Xo49mpSZ3mqU43qdU/0S5Uo5EVh+8cGuopVEx4hLZqaIQw9EJM60fhVuHvxSDQamTmHZzaoR4yPGUaUdJZILW6Ea12VKMe1qlHNDOD028evZl6ODv7WGMYk2cY9KGBJV6D0c4gv/dvBOg1LCprYdlYrRnSGKRZDU9gwJX3yskfCDTi0IMGjUYeIn0gSHMz0geC7Lk4Nzg1PzADon+s0Y3oteP6mQnNy9FXAw+HW9tVd6s75WVtgqL2guLO/BJFXpkip0yZVabIutOVdaczq7T9dkn7rTttQKBvyttvSepTswSM8xF2NN+vvnAwIziaYx2oxk5UnLsZ5fTPP7I99mb4BV/32Z/hHQwEOt0zMN0zIMXH7+axg7JLkXImQ8SKFHAiRLxIIReGz2UUcmPEGVdbKwTTz/vndRPa6aHe+tLTztY2VKIVEWNJwXn/8n0pP3dm6g261zcKCsonBSrQKCgofxhzev3Y4GNBKtdv69d2VKwdGUMj4RyoVP+vt7BDjtffLFTKarpkTZ2Spi5xU6ewoUvU0C0GSl2nKK7rrWwYvN8x0ad6NT6gm5qc07yY0z6f00Gf1sCFehOzuvFZoNSwzxg2RhuOSJDeCR2M+r3y80IQgYaB0zmgc09DPR1BHHdBxEG0+jHt25thDwZi6kigTGthEXqxy+JDaf5YoJHyM/yNSFv2govPGtY7Ihb+QRYq1gvFdcPkDThPA47UWMhjRLXBV4hhjX5YBxu7R+e1k7qXY08f9gw0N6nKqrqk5e2C0k7+na6CO935ZYq8cmVuuTLnrjL7bnd2eVd2WWfOnfasko7bJW235W23RVWcNHbQ/kO//Oy6xtzRnOBginUyg/bsbEI68/NPyZ4+mf77M31DMrxDrnuDY3CGd1C6d0DG/iBBzNliZqyUxRByooScSDE3UsSNEnOixNxoETe2gBPDT77QVSPWTD3W68Z0M8M1wpuBW7+3JuOtiFgLKuGwk3V/dzu60TcKCsonBSrQKCgofyRzc/rnkxNVUn5coKfH+pU0MsGWSLAlkT02bDhlbZMdFVd3S9QlvqeQ1HeJ67slTd3iJoWkSSlpVEjqVPK6nrK6nsq6vtrG4Y6uV4OPZ56Oa1490U4/1WmeaTRPNbqnau2kVjep1k7odE/gWkOkQ0OnAxnS6h5rgV8iC/uQfFSH1sGbYWEYKTAjZjy8sAwRGjmsRsMjLEsbMozEcLJw8aOu64/yXkMz8ivARaTbBG74MgxXDcJ7RqehTy/sJgOXS2pG1MjqQGTp5DDsmV58Bdh/ohnVqcdmp0dmXg3PPBueGn307IFqsPX+g9p65Z2qTmmZQZ07C8oUBXeV+TCKvLvdueUKkBx40plT2plX2pFT1HKzsJKblnHi1EmLXV6b1zusIDqY45zMsc6mOFczgs+6VeHbfkvx9L0REHLD70Cmz4HrPgfSvfZn+O1P9Q28HhzMjwgtSoiWsaNF7CghlyHiMiRchowbLePEyLlxUm6ciBfHZ0fL0i73NhbNvn4wpx97M9krz2D5fLfZlky0IuEsV5pcPHFofPDxPLrRNwoKyicDKtAoKCh/MHCv7+mpntaWG/ExQVv/bEXCWxIw1mSsrRne55tNdAc3QcxVlbBcJa3uktR1yxq7gT2Lm5QgokalpE4pre4UVXTJ7ynLa3prGh63to0ou58OPpiaHNZOT2o0z9RaYNLPNPrJWc24Fg7BGNHqRzT6IY1+EBwRdYabAhraPwwzpw21YURVESVdtOf3K8qGSRrQkg1l44X69EId+m0+1OWP8n41Gi55XGjRHpmag8dZ8JY0Y1rtODzOQi3Wq8fmZkb1s2Mw06P6mQndzBP162H1K5ippwMvRvomH6ked7cPdHT0Nzb31zSqyqqVJfe6pBUdwrJOQXmXoLyzsKyroLwrv0xVWKnIr4D2nHe3K7esOw9JPrBneWeerJyddi0o8IyNhdc3XzisotgvxzmYYxzNjIE9e642O/Xjny/S7NO9AzP9Q276H8r0PXgd5kCGf0iyX0BqcCA//EzptdgidrSUGy0EAs1hSHixUk6M4HLYbcbxtLMHUs6GJEccvHX+tIgZXXr9mqpZPjv1SK8ZfTWmuhUd5rxmpSUBt5OEdfpyTUEK5/WL5/NoIwcKCsqnASrQKCgofzxAjHRa7ZOR4VqZmOG3z23TKkvTpRaUz2woxq5m5sFff3dxj5f8Mqs9X6aU3lPK6xSyBoW0SSFtVorre6V1KnE1uN4pLlcU3+0pq+ytvPegtmagqW6ko2m8v/PZWP+b54Oa6XG95smcflJn6OvQj2nn4GBppHN6YtGhF7uoF3cOX+jN+N0QDGSKHDLrAxn6gZSBkWaPGcR9p2HZ+F0+NuaPBdpwYnjlN9rhGf3ojGFYtW5UpxnTvBx4Pqp42FHddlckvs7MvBKZeO7whWOB54/4nz8ccPnEkcRzpzPiGKJkzr287EaRoPNOWfedio7iylZZZZuksltc2SWoUAgqFfxKRWGlEhhzQUV3/t3O/PLOgjtdeeXKgkplfgWw56488LAEeHNHjqgmJTP9+Olju3e7f7mWtpJoa461MzUC9uxkhnMzJwZv2nCRZpe0zyvdJzDTLyTTD1FnnwMZwJ79QlIDglL2B+aFnSy5FlvKjpVxGFJetIjDEPNihUzGjcijzINelwPdL/g5x/o4Mnwco30duScC+Fci7txm9neUq6cG5tXjw10NkZ5udsupliTcDoKR79Yt9WUlWg26QyEKCsonASrQKCgonwpAo9UzM30drbncKwesf7JdhbWmLLMnYR3IBOflZvu3bLm4z0t0/monv6hHXqOQ1aqKGhWyOhU4kd1TyatU8rtKaWlDVk4Jhyu8dKnwQlzBxRhh4kV5Gqu64Kaiqnioq+HNeP/czIRe+1SHtHZokIZpw0S89+vQ73VFjxh6jmfgBuDDb+bgNuBw9SESeAPUaFg2hiMv4KI95GiwZ0S4PzbmvyjQQJ1h1VkPFyxCb1aP6GaGta8G+lsr+LyLiaEHznjY7d/9894tG903r3NYZ267kmq3kkJbaeq4epXD6lXuX2zY983mkG3bQh0croUcFl5mtfFLOoR3O4UVSlGlUnivR1itLKhSFVT1FNxT5ld25RkEGkhzOZBpBfTpO90FpYrCovr02+nHT4XT7H2+3mS/nGprjkPs2dieauxAxXquNgvbtpXl5n7dP+i63/7rviAHM/0OZfgcuO57IB3Ys39wcmDA7bPH5FejSjixci5DxomU8pDaM+/8jeiTl4P2nvdyifd2ifN0jNlrH7XHLszVKmKP9eUDe7MvhJZls4d76vTqUf2bkfulwoBff7Ah43fjjHaRMecPB02MDKFFaBQUlE8BVKBRUFA+LfQ63fPJiZZ7ZSkx5/y2fm2/gkAzwdhRMPYUnNtK88Bvvo2gOd46x6hKy27j31EUVymKKzukd8rSMlPPhoe5uB7ZtStk609BW74N/G5z8PebQ77/6tAP3x759ccTljsY+9zS6KElN9IUtZVPHvW+eTExO/VUq53UzcFodBMgcFsWQwUabnkIFRkZ5WFQZMM+JlCdYQUa6ZaGKxEXdxSHxqx/t87P0P7xnov/1czoRoGUT88hr6wd0cwMPR3saC0X8CKPH3e28PrhC+cvltOWk2ypWBoZa0/GOJKxTiScMwnrRMS44I1ciEbOJGMHkpGDCc5lJdX983VBP/0c7uR+81x0TUZut6hMKa7s5t9V8CuVhfdUhVWKggrgzZ15ZV355d0Fd5WFd7vySu/flt5JTOMePHF8t5XXpk1OK81oVLy9Kc7OFGdvhqdRca7LKYe/+/oSzS5ln89N/5BM35DrfkCdDyLqDCvQGb4haf77U4KCbp48Ir4UIWczpLwoCTdSyo0yCLSYE8c8FhDv537Bx+2it2v8Pue4vY7n9zgw3G3PuVme9bA6H+iac/FsaRb7ycOWuZkR9bNHQu6VPetXW+HgtupOm9YUZiRNvX6FOjQKCsofDirQKCgonyDzOq1mfHCgrDA77qCX8wYTO9NlNMoyR5KxPRFrRyF5fL7h4PadFwP258Vf5F+5fPXgwUOWu103b7Q2p1pRSHYUoiOF4EzGupAwLiSsG5ngRiG4gKMZdc+6Nfu3bo318ZMmp7ZXVPU0tzxWdj0dejj9dGJu5tWc+uWc7tmcflyHDNlAGqbhtttq7RhcwIdIMxw7/f6KQ7gtIhKkDr2QhXEcyBaA+jGoxYhka2DGkP5puJMikiezmolZ/eQsMjlEqx6fevqgvij38rHAg1a/uXyx2s6cZEs2sqdiHUxg7IjLaCQje5IxjWhkT1hmT1jqQvjMjfCZK2mJEwh5mTMVZ08l0MzIDitX7Pvqq7M0x7RT4e15EqWwvFtY0S2o6uJXdhUCgS5TAHvOLe0pKG25niuIvnRxn9/hbTvcN2ywoVLsTAj2VByNYuQAxzzjnUzJ/hs/j9i5PWnvvky/oJt+b9cLHgTJ8DmY7h2S7rs/NSA4OTDw5snD4osRRexoGSdKwouE4UbKkhgSDkOYyLi8f1+8r9sFb7cLXq7nPV3i9jnF7XGI9qBFeNiddbc552LBOxGQfyXiHj/tzWTP/Mzokwdtcb4e9qYUSxzGgoINsbfo7erQoxM5UFBQ/mhQgUZBQflEmZ+bm37z6qGyU5zJi/By9PpmjQPVyI5oZEvCWhKxu0kEp7WrvL/9yu/7r10+X21JJe6i4CwpeCsyzoaMtSUZ0YhL7YlLHUjGzmSMOwXrQcR4kDBuRJwzmey6am3Q1u2ZUXHVeaLWkhplRUtfVfvDuu7B+4pRpeLpY9XLsb7XTx5NPR2afTmmnprQzsKxHjotyNOF6CZ1+ifInogThmjmJtQL2yKOG060+glk7/GnatgiMqbVjwAv12lBnui1k3rtU9hJMvtc8+bZ1Ivx10+Hxh921YhyLhz0D/7tJ6c1y21MCDQqkUbF2ZliXNZSvL9dd2jn9+fcLC7t9+CdCkwLO5gRcTgj/GDSce8rAU4nLP4csGW9yyqSgxnWyZzoZE5yNCU5mJAczU09N26KcHAVxzM7+aXAobuEdzsKS7vyiprT88svJaceOBZhaxPyw/ce61fRTIk0UwINmDoV60iFczY8Vprs3/xlxPYdiS5uqV4+N/yDgT3f9A254RNy3fsASAY4+hzK8D0A7Tk4MPPkIeGFMDkrCtizlE2XcOhiTqSYQ5fyGHJejOBK+MUAt3gflws+bvHebue93GI9XWL2OTL2OkR62Ie708JcrOJ9XQovnStk0hV1Eu2bx3PTw23lwuBffrAm4HfhMRZrzFIuxb1++QItQqOgoPyxoAKNgoLySQM0+s2rF8rWJlEGNzZwj++fN9HMCNYkrBUJt5uAtSTBWJCxuynYHSaY36iYnctxbt+uDdr57XH7rWcct520+jH4zxvcVxOdKUvdqUauFCMnCtbehGxrau713Q+Xgg7X5sq7YS91c4eooauoqbO0rruitruqtruyvqe6+UFj28O2tsGu7hGVcqRXNdLXM/6w7+njhy9GB948GZx+OjL9YnTm1bj6zRPN9FPt7DOd+rle89xwRPJCN/1c/frJ1LPB15MPX070vxh98GzowcSDnrF+1ZCqa6ir83FLq7LqXotcyjpzMnD7L7ZwHz68LRljZ4K1M8P5/LQh/pDrratnKgu5XVV5DzpKh/vuTQw0PB1sejrUNDnUNPawZrinsvtefkUuK51+6Kzjduc1ZLdVZBcTvAeV6EDE2pAItlSzwD//knk6svkWvyNfUslLv3nq3JW9Pie37fLd9KX7GnOnFWQHc4KDGc7BFOdIxTlR8c5UQtCXn0fu2sl0dU/z8s/0Dcr0Db7hux+o8w3fA5kL9hyS7hOS5huS4rc/OTAwK/S4+GKEnBklY0dKWBFAoKXsSDEbOrSEG1WScl58jR7v5wIE+qKfe7y3a5yXa4ync4ynk0GgI9xoEa42dHdrwaWzIha9+Na1JwMtczPD6hcDt2LDactNd+Gx20hYr+0/dTTW63TaDz8oKCgoKP9BUIFGQUH5P4Ber3v94tkDRUfR7ev+W7+zAtJMwFiS8bso2J0U452mGNdv1h6ibWPTD5VkM+tLb7bVFihaRKpmoaKusK30xt1bF5nHPA7u2uSx2cR2JcbGHG9jRrY0obh8sSnUZV8R50avrLFH2qyQNndKGtvF9W2iuk5BQ7ewuVtc3yGt7pDBdBaB1HSW1CjK6pR363sqG3qrGvurmx7UgDTD1II09dfAIBebHtS2PKht7a9t7q2uV1XVKKuqlRW1irt13eV1nSXVbfKKDsmdtnyJ8EIC3dXDZd16KzLRimBkTVxqvxIb8POGTMbBpuL0gZ7SyZG62VddenXvf889/u/5x/NzA3P6gTndwLz+8bz+0bzukX62b+Z552R/TU+toCT5/AU/R//v1rmsIDhQMbYmOEsizpJE9tz4Vayrx/Vjx6PsaYd+2uK3aYPbSnO3VVSXlWTnFWRHM4KDKd59pYnXulWHv/uGvnPXZQcX3j7fDO/g697Bmd77M4E6+xyA9gzbNg5AdfYJSfENTvILTDsQkh92RnaZUcyMlrOipCygznQZKxJEyoF7pki40eBdFXPjLgS6xvk4n/d1ifVyjvV0jt7nxNhnH7XXnr5nQaAjXC2El0JlHEYhO7JKmPZ6Qjk/O/q4o/aYg9VuKnknAbfbnMKJiXg2OYHuTYiCgvIHggo0CgrK/xnUM9Nl/Fy3r9fvJBrtIBhvJ2N+McM4blkbf9xHfjNBWS+ZeNSged2rV/frNP16bd+cpgdEP6ucfXF/pL/0fsV1YQo94fhe35+/sF1JtDLBW5uSbdYsP2ppXZqY1i+p7ZU2qqRAmpuBOqv493sL76sKG7v5tV38ui54rOniV3fyq7sE1V1CQ+51i+4phFXdwqouQWUnvwKm8G0qu/jgRzXgzk5RVae4sl1c1SG61ymq6ZYCQa9SSqrbc6T8iAuHft7hYLrSGk+wxWNsCEv8vlmVFhZYJ+I9eVShf9OpV6vmZlXz2v55de/zsabRh1UPlHd6O4v7OkoedZcN996dHKidfdYxP9v337P9+tfK2Ym2gRZpaUb8hf1ODp8TLSlLbCjY3ThjWzLJxdzs0JbvDm75ym/jaq/1K9xXUl3Myc7mZPeVpt6frzn43dfntm+Ps6UluO1N8gxI9gxO8zmQ4XngutfBGz6HrnsduO4dkgmu+BxI8w1J9d2f4ruf5xfICw7Ip4cWXY0pZsYWsaKhNLMjZewoKTMShs0QcxhSbkwRL7YkKZ51zDfa2yHGyzHa0xHYc/Rex6i9tMi99hFAoN3t6G42dHdL4aUzJTyGiEXPSQhX1su0U4PaqaHC5KuOG9dbEgg7CViPn79tqa1CR9qhoKD8gaACjYKC8n8DjXq2vaH6hLvdDqrxr8Rl20wx1ptX0g/vKZemPu6tmnqmmFc/mpt9qH6pnJpsezXe/Gq88c2TxqlnLbOv2nVTnfMz3ZqX7ZO95Q0CbqyPneMaMs0Ub2eCtaIa0VZQju3YKbuY2C+91yOpU0qaVJLmXmFzn6AJpEfQoOI3IgEn9UjqlAupVQpqFfwaJQhy8n7gT/m1vYL6HkGdQlCjENYoRHUKUX23sL5H0tgnrVcUlicdOB383U82RBMrHN4Wa2yHW+a/aZUkIWJSdXf2Rbtao5ybVU5Ptkw8qGi9d/ueNKksP7H49lX5jcuy61fk6ZeLrl+5c/NKRXZCZQG7Vp7W1yp5NlSnfdEx/7LrzePahw2F+VdOBmz93MpkmRXJ2IaIoxFxbqaUw99tDtv564mffjjx04/AmKOtbOPtnS47uzE9vLie/inewak+ISleB1O9D6V5HUz3PHjd6zBwaBjY8RySBtTZLzjJLygpICj9yMH86DPyxOgidowMLhxkwLWDLLoUaDQzSsaMkkCBjhazGXJubDEvLjvudIwPkGa7aE8HmL32iEDTIjxo4UCgPWwu+DmIL4eWcmEZO//aOXHaxSeP7+u1o+MDbWfcHGwpJrsJuO1mxMtnTzyffIIWoVFQUP4oUIFGQUH5P8CcXj/4oDfuqL/FSsKvxD9tpSxx+PO69KthD1R3Z6ZVWnWfbrb/xVhzX5ustSKrQZZWL+Y1iDjNEt79orSuituD98XPessfNfJvxR+J8rLy3bLWeTnRhUpwomDsqctophgHc+qJXRZVvMw+WbVK1qCQNCjFDb2ihh5BvUpYrwIODVMPw69TCeqALi+mZjEfXlEJa0F6BXU94KKwVgEiqleI67sFtf2yxh5BRdrxcLd1X9iSiNY4jDXWyJ5gZIP9L9cVuGhPm4fNUt20akajGn5Q0ViSUZpzhZ8SmcM8l8cMz0+IKEiI5CcwBAnRggSGMCFCmBhRwIzI40SIMmLu5F9rr7g50iHTDtfrhxvGGgV3kqIDf/7C0sTIhoR1oBBcqCTvtauZe/exPf243vtTfA+m+x/JCDiW7g9yNM33SKrPYaDOqd6H030Pp3gdSAUO7QVM+kA63CclJNU3ONU/OMk/ICk4KOvMSfGFqCJWTBEHmbnBiYIT62ADNB06NDNKahBoJFJOjIwbJ2XFpITuZ3jSovbaMvbZMfbYRu2xpe+xoe+lhblbR3vapZ0OKEoIL2XT5Sz477p1ObSm+NbU6wd69WjxjSSn1at2EfDbyThYhK6p1GrRIjQKCsofAyrQKCgonzrz8/PPJsaSY8McNppvI/3pF8pnHr98Ici8OD5Yr5vp1UyrXo43KxoFd/ms4puXZGlx8pToYpCkqNIURnl6/L2bV1oKec357CsHXDz/vNrpc5Id3I8a771uuecacwcKhkbB2pkQnVetojt4NNwQ9MjqgUB3SxoU4jqFCFgv1F9DYBUZ1pKr30YlqFbx/1IE1T2CGhghMOkahaimSwxS1yWpU4hrlKKK5KOhezZ9bUHE2uKNbHBL7EAwf6Jh/2SF/X80c0ykN+1hc9HIg5ryQrY4NYbPoRcygTdH8BPogoQoYQJDnBAjTogFR0kiQ5QQKUiM5LOARocVciIkSfQ7meebC1lKWdqju1kP7+aKrpw7sP1bayr4ZxKcTMmu5ubn7V0ygk6kB4VmBICczvA/le53Ms33ZKrPsRTvoyneh5K9Dqb4HEz2DknxOZDqCwJXCqbATVKCUoKDbp44IoylFyfElbLPy7nRwJsXB24gqwZZwKEjJUwGiJgVLUIiZsdIObHAoUWJkWln918IcGbstYn0sIraYxXhYRkOTrztk08HSq6eK+VElrAj5MxwcWJEzuXQm4nhD1VVTgFB1QAAgABJREFUupmhif62MDcnSzPqdgp+53ISJzoM7YRGQUH5o0AFGgUF5VNnZnrqrjB/348bd1CWbiX9l/Vmag434tVEi3ZaoXvTPdZT1iBLll+PE/GixFy4ak3OjSriMYp4UXeSY8tTzlekX6xIib8S5OTxjbnDWhxtFdZhNX7/T5syjwelHfQ7sOVrODjZhGhPNXFbu5Fz4EyvpK5bDLcK7xIDk65XiGu7RTWGdAmru4E3C97LBw/fXa9RGiJasOdOcW2HuK5DXKuQVJdxb3h8+bWVCdmKZGxLWOpMxZ746evjWza5mmDt8H+yxP4XbRWRddinVXxTwouBi/DYUWJmpDgxUnSNLr4WJUmIlibGSBNjJYmxUuDQwKcTo8QscA9dyIwQJp4TJJyVsMJKkqLuZpyvzU5syGGLr4QH/LTRzhzvtILiusL85C87UgOOp/ifSfMPTfc/neZ3Ctqz78kU32MpPkeTvQ8leR9M9glJ9g3h+QYlBQQnBwQlBQamhgRnHjskYJwruhpTwoor5Z0v4kRLOZHQntmGRIpYIODNQHV+a88wbOjQEliHjhFei8iKPpp8yp95aO/VYNeEgx7s496ZkYeEV8OK2PQSDh0IdBErQpJIL7h67vqFkyW57Jlnffo3I6KURMevNgCB3k7BBln91tPRqtfpPvy4oKCgoPz7QQUaBQXlkwYY0gNFZ+g+J0tz7HaTpdabqImRweMPKnVvOmeftwx1Sur4CfJkuoxHl7AjgDrLOYwiEF60nBddlBRTmhxbwotJPenr9e1K53VE17V45zU4/y1r8+hH7mdxm29zxbFhB378imZi7GhKsDc19f92a2lCpkoEO6GVkkaFqF4J69B13SDC2m5BreJdYBs0uNgF/BimFsnCebcYWHitQlyvNLRtiOu7JI2d4AUlDa05pTEeAbam5jYknB0F67bGNGW/tzwurCQ+PCVor8dKoh1hiS3ZaM96s8LIk8WsaBmXIWNHSZiR0sRISUKEOCFSkggeMkRMhpAZLWYCjY4RM2MkQFiZUKNFTLogMVzIghGx6bKk6DupF+6mXbxNP3Tc4gf3z03d15iH7tiVFngkyedoqt+xFL+jKb5HUnyPJoP4HE7yOZTkczDJ9wDPJxjYMzcwMPlAUNrhkJsnjwoYZ+WXGKWs2FJunBxRZ2jPbLoEyC7StgEsH9iziMV4582LEbKBQ8NeDhGyslCaSBdeDuXHnyo4f6wg/gT/SqiYGSHjRMo59GJORDErXM4E/1I6/2pEzqXTOZdD+xqLda8GhlUN++127jQj7iBjrdaYFqYnT7958+EnBgUFBeXfDyrQKCgonzQz01OCjCSHL1bsoBpbrCPFHt/3SHFHP6VQTzYOtORX5VwsSoqQccOLuPQibmQxJwraMydGzgXeGSPnxZRwo3MYhw/8+qXLarzHasKe1fiAr5bfOO7blcvt5qd2C9La85Lz6Ye9v6Q6mRo5UPFO5iujXbw780p7xHUqcQPQX5UIHBsUwgbEmOvfS4OqsAGcKAQgdchxIUphgyEqUWOPqEkphoHDPSTNCnFjacJNn80/21NMHckEp+XkhEDP+gxOS1bK/Vu8upRriT7OriuINPIyR4pxlNWvssthEuCpsLIOe4tFrAgRM0LIogvYUXxOZCEnis+O4bNiBKwYETsGUVWGmAXEms4HGs2mi9hRYriwL7oI+VPkRh255G0f5bjryl7X1KD9Sb4hSbDGHLyY/VwkPD+QoOSA/ZmHj+aEncqLOiOMC5ddYhQnxJSyY4vYUXJ2FHhLYna4hEOXsiKkTGjPiwK9YM/QmN/r3xCxwRUGeD9AoCUs8GUgQs6kFzHpcmaYnBkug0OjkeF3MOFy8JqJEaIEuvAavfByaH78qZLrV18Md2hfD6RfCLdea7aLDL5NYU/scRp+9GB+fu7DDw0KCgrKvxlUoFFQUD5dgBuNDjw87WpvZYrftYLgZfvD/QaBZkqled45UF9wL+uinEeXc0EiYfGSG1XEZRRxo+Vc2Ccg58UW8WKlV8IYrjudV+HcVxP2riZ6ridH2m3tvM1W8VMV/NQufkoHP6XxRsKVvXau5gRnE7yDCXnvF5vKWOm90joFUGcJcN96JTBpIdDiOqXBj98KNB8INBDrt2lUgghhFOAoAmlSCZuBQ/cg512S5g5RbdKxCHuzVXBDRDLx6NYtd5Ov3c9Nb85Oas7mtdzmVXEvnrP6lUY2cjXBBqxfnhd2SMKMkHKiROxIMTjCkygxGx6FnCgBCJch4DD4bIYQGmq0EGmWELKiBKxIITsS3Ias7WOAyMG3C3Db5bOFsadyGSdunj2afCiYFxLIC/bnBvlzgvy44CQkEFzMOH7o9tnjBVGh4gt02bUoWSKjiBVTDNSZxQD2LGPDQXULteeF8vNCBRo6NOwkYYiZiMojJwvV8QW5j5LA0ME/Ssaky1gRMlY4VPD3XgFuwgJvoIsTI8WJdNHVc4LLobmXQjur+NoXDxQ18r1bv9luittBxTtuWl8hEWlmZz/83KCgoKD8m0EFGgUF5dMFuFGlWOC2ca0NlWC70fxyzKGXLxXa6d7x7vKqG5eKk6LkPNjuLOfCwFYHYM+8GBkvFgQINDDpvKijft+utjdd5rGSsHctyedLs+zQ4H7RdaUgtZuf0lmY3MZPactLFkef3bdmhYsJ0Z5MsDM1TT12pr+4TiFpUsCacd3b1YSwl0MImzfey2LhWVgPq9SiBjhqQ9TQDSJuUIihN/cKG/qEsJLdKW1uEVQetba3phCdyTg3CoHtt/d+fkZzXkpzDq85m9OSzbuflZwfcdKWZOxigttjimf6OBezwL8uGnozN1qCRAbbJ6IlnGg4IY4LrRop7jJgERrWoRlIH4XBud9FAnupGVI2MOloOSdGkhjFvxzGjw/jx5wriDlbEBtaGHuWHw9sNVx8NUKaCGc5y9mwJQYZTgfbSIA6I3t0IwL9LgvF40X9he0lEuDNiYzFwHNwRcJiIPaMCPSiK793bohhiAc4wrZvCTNSnBAmuHI259IZSXr8s4fNrwbao4L37FhF3m6Kt1xuwokMf/H0CbqzNwoKyn8YVKBRUFA+UZDhG+PsiDM2yynW5kT3rV9Wld7UqB+8Gm2pL+SVQm8GAo20O8Oqs0GdF+xZyo2VcWOBLKYe93FYbuxoZuS2HLdvLTnkz+vrUy+q+GkKQWpXYXJ7QVJrYVJ7fkoN98rBP3/jRCXRKARrE/Ipa/t+eY0SCLSo0dADDey5ezFwIB2St9M5kNSBIN3StbBhWoRot6S+W9LYI6rvFdWqxPWdsqbGgjs2az+3NSU4mRi7mhGKL0S1FmQ05Sbdz0tuyeHcByfZqQ1pLLfVVGcqzt0Ee/yXr0tZ0UVwBR7DINBSbgwssSMCDcOFBWn4U+jTsWJ2jJgdLWRGghgEGtywGAa4Hwo0sq0JDDjhxBWz44tAwAnnfBE3DlbugaPzoqU8hvQv6PKHkXFgpIvT6xYF+q09LwRe/FsCjQzuWIjhnijY0p1IlyZGCK+FFVw7l33tXGtZ7sxwVyH3gt3m1duouB0U/H7rnX1dHXq9/sNPDwoKCsq/E1SgUVBQPlHm9PqHyu7DtN2W5kSr1eSDLjsmh5tnX6uUNYWlSTHFrEgZN0oKNRoKJQxU5zgZ7zw4SrkwEnb01QBnG5PPHE2NXEyN964hnbP8oSOLrRKmdfNToEDn81rzee15Kc0ZnEh7KzsTgp0J0YpC9Ppmi6LwjkpUrxI3gqNSVGcY5PzWoRdMGk64q1EJq5UiOG1DBY7iGsVilJJapbReIW3skdT1Sep6pPXdssbKTMGvJIqtKd7RzNh9Nbn1dnJbwfXW/NTWvOT7eTxwbM1Nu3875cCPXzmZ4t2o2D1rKUVX6MVMIL6GkjOUYFiBRnb4gw/hCLmFWcsSTqwEOnS0iBUFBZr1FwQaPNfg3zDcGOSbxnnkj4b83eB3Dyjl0MtBEDN+T47pHws0Un5+dw+cFsI0uO/vHRq5+JFAv7Xntz9aDKLgEvCUBCDQ4QImPetyqCTt4vO+xq67Qq9fv91hTthBxtqsX1EpRbs4UFBQ/tOgAo2CgvKJotVomipK7Tcst1hOsNpgeiHUXzfdP/m4oezG5RJmVAkzEtizmAtXyEmhC7615/OypHgp77yUFy9lx8bvs7OlLHGgLnOiLnNfiY912tmZzVEJ0rqQ/o32/KTWXG5rblLzzST2ft/dZKwVlWBBIbh+vrE2JbdXXNsrauwRNqhABHD/FIXwd1EiW6WogEOLat+PUlyrEteppPUqWYNS3tQja+yX1ffJG5SyRtGV1G0EMo2KdzbH+H61Rim4BQS6vSCtNS+pDbyZ/JQWINBZKRF2O53MCS6mWAdTY370qZJEhhwINLIID4qyYXcSDkP0e4FGys+wAr3QwsGKFLEXxzPDwOcC8zb4NzRpoMu8OAnvvAQeYyW8GEOF+61zi981ZrzLe7XnKMO+g++rMCLQhiAObZBpmIXri00af82ekVr1+00gCXRRIp2fEJF3LSzrSmjvPeGL7rrTrla7VhB3mOC2m+LTLsZOvXr54acHBQUF5d8JKtAoKCifKDNTbyQ3UndTsbuX4+2+XlmQcUE73a+o5QPrKk2MLGXB8rMYLo+LQZoZYqVcKNBQnZNA4mW8C1J23Pm9QKCXQoE2WeayHBPvaqHIS1by07r5qe15vPZ8XlseItBZKdmRZ7ZTjHeZYHeT8Y5r18kucnvF1T3C+h5ho0oA0rBg0u9HUNcjrOsR1cHdCuG8jvoeMYxKUt8jaeiRNiqlTSp5S6+8uV/e0C9v7JU3ZdOv7cCR7U0ILstxh37+WinIai/IBALdlp/Smo80cuSlt9xOueztYm+KczbFAIG+dTq4OCGyCG7mBxQZaWVGAv7tIi4DMWNkPBw05reDLwwCTYcC/S6RcIUf+LtxoIsj3zpiEG+Ok3JjJdCbY6TItxEpYsZS2DMNVwqKWYtPR44S2E4NYxhj9/tq9NsmDUMV+XfqLGbSQT4oYBve0ntZGCANlyEaitBwZl+UIBFuJZNzJbTyNvO1opZzMshqDWUHFfsbBXPCw/Hp2OiHnx4UFBSUfyeoQKOgoHyazL98Npl49qiVCc5iBcHxz2vb7hVMP+2syGNKEsOBQBfD/oQoCQ9WTJFAgZYCF4T2fF6WfEGWdEHGOX/Ry8GOusyBauxoYuRijr3kYa3KT1UK0rsLEYEG9pzDAQLdlJUquhy90xS3ywRjYUKwX70qN/J8r+werChDh0bsWdTYC+dpNEGlFsL5dODEYNVKZI2gStzYI4FRgqOsqbeopQemta+45UFxY39RU6+8MfNM/G6ciROZ4ELFhe76RcG/3V5wvS0/FQp0Hu9+bhIU6KwU7gEfINAuZlhHM0zqYa/iaxHI+AtY7l1QTyjQC10Whh7o9wR6cREhCyrvB7VecN1QwF5soUaCnEOlRmbeLSwfZEfKwFPYkUJWxNtK9u+NHOaD9uX3dPnjAIH+cNWgGNl45b28myEtRGZdI2VscBLFZ9ILEsPB//ijKqGUFWP3uel2KmY7BeP67RfK+43ojiooKCj/SVCBRkFB+UR5MjJ03NXamoq3WI5327rhcXf5aG+lNDVaxoooYUYWwUoq0gTMeefQEl4sYs/x8pQLwKHl3PMJQe62pkb2phgHE2OX5bgre+168lNVQKALUjtyee3Z3LZsTktOUmN2ijThvOUK0m4TrAUFZ79qxfUzYUrZXYW0WiGuUUnq4FJCOBm6fjFQl5Ep0fU9QJ1FDUox9GaVtLFH2qSSNvXIm3uLW0B6ilv6SpsflDb2lTb1FDVkno3fhSU7kwguFFzozl+VhVnt+VCgYQ90Lrclh3c/B7ZwpBzydzQnuJrjnc0wSfs9oECzIqWIPUOHRk4WZmvAIjEs9yLz42DhFg6PW6jm/oVmibequtA2DWN4EaQrA9F0xJ6j5Ky/INAfBr6f3/Uu/yVpfpuIjwPL5H/BoaFGC+FOMYYhHtEipAjNZ4YLWfT6XO69zIQ9363bQcX8Rja2XGUiz74+Oz314QcIBQUF5d8GKtAoKCifIvPz86OP+n1++96airMwx3lv/2qou1xRky/hAc+LkLHocC8PqIBRsA7NjZbCqRHREl6MNClOlnxenhIPj0lxKSf8bYBAm2HsTYyAQF8FAp2XoipMU+SndObwQNpyuM3ZSQ3ZKXLWxd3mRAsg0CSM3Uqz1NNnlKUVnSVVnUWVHbKKTllll/xel6y6GwRYtbRWKa1TSGqVklqg1ypJvUraoASRNajkDT3yxp4ioMuNquJGZUmD6k5dT1mNsrxeWdZwO/rKdgzegYhxIWMPbvmmV5gDBTovtTU36X4OpyWb25Kd2nIzKTnExxkINBXrYoZJObAXCLScSZci/Q8Swwmyd4loocC8aLHMaCRv+yj+lkAvaPTv7zGoORxXh5SfwUNgyX9LoOH2Ln9XoD+U5t8LNNwXRgRHViNhIfNDEI0WMqMQgY4BEcHzSGFiuIgZUZp8virj6hHrn3eaYYFAb6diOVGhL58++fAzhIKCgvJvAxVoFBSUT5H5ubnBftXenzZbUbEW5ljf3zY/bJLV87liboSEA/d8RjwPaQuGGocseuMxJNCho6VJsbJkoNFx8uS4rMgjTquJNKoxDbZw4M47W6hyU1QFqV25SR1Z3I5sbms2ItBZKeKrcTtg+RlrRcbSVpnmxMVMKnuGu7oH29oeNDb21dX3VNcrK2q771R1Fld1yquAT3cXVStl1UppjVJWq5LVqeR1qqK6nuJ6EFVxnbKoVlFS111araqo7qupe9h8f7C16+6NrG04jD3JyIlktHft8h5BdlteRmtuyv0cXks2uzmL03Qzqek696qns6s50ZWCcTbH3DzpX3Q1XJYAN/yDO4wkwi1IDA4tfs+M/4cCvdjs8U6gP2zJeC/wyt8UaLhLC7Iw8W1+79MGew5H8qE6GyKEAh1u+BUgQKaRQI1GwhABe4aBe4CLkQ4QKSuyIv1yrI+D1WrSbyaYbWRMZKDn2ODA3NzCloTgwzM79ebFk7HJkcGXkxNajRodFI2CgvKvBRVoFBSUTxHgQAO93e4/bARGa0HFeP24QVWeW55+XooINFzExo6SIqYIF7cZTI7LgEVocEQEWpoMj/wLof5bPrcxWQYE2skUc2rbd20Ziaq81K7spM6spPbb3NbbSc3ZyfW3eDfCT2wnYawpeEsSxmn9SgkncXZ8TPNicvb58NSTx28mBl6NDrwYfvj88YNnD/uf9fc97emdVKomO5VPOhQT7YqJtu6J9m5w/qRTOdmlAnmm7H3R++DZg74XA32vRh++nng8NTk61NZstdyERjJ2IC51NCXUJCfez01ryU5uzuY23GY13mI3ZHLqUhLP7PjR2Qznaop1NscV0o8WX6VLr0FvhrsSvleBhsv7kDbixSC7AC7UlT8WaLhNINxMGwR2TSBBtPV3QQrbbyOGVeEFk/7Inv8HAs36OwItgl0ZMHCXcvjbDUodIWTSEYGOEjKjhYnRIsNADxYswIM/QmlSXPKpQIcvzH8zwf5Kwhy03fVQ2TXz5tVgT3eFKC8lJuLi4SCG7166t1t0oOelkwf56dze9paZN69Rk0ZBQfmXgAo0CgrKp8jc3NzjXqXbj5t2m+CAQ+/5alUHP7UE7tkRIeXQoT2zoqWJMXBaMBA1pJ0DGWxsSAxwaCjQKXHia5FnadttTI3tTOBSQq/1ZrKoUz05aV23UzqyUtpuJbfdSm25nVSbmRjpYbeLgremkKzIeJcv15bdTH0x+HBO/VynGdNpRrUg6hHt7IhmdkwzM6aZHtVOjWhej2hegQyrQV4Mq18iMTx8Nax5A+4Z1U4P62aGNbMjs+rR2dnx12N9x2122BEwjnhjGhmXdiSoNTutISupPotXc5PdcIvbkMEsuUDfs9bEyRzjYIrZt8FcHh9eeo0hu0KXJ0aKE+iSRCCRERKk+WExiPUuBPquQXwXhmYgGm2YpCGCDc2wxCuCXgsCnwLLvUjgosOPYngu9O+FsvRCw7ShZ3phXgf8+78NvL64phD+onf5yJ4liQaHXvwR8q4MD5HQRcxIETMK2jOynSEsmSPfHGTsqNy40+7frN1ugv2NZOz65TpJekohJzHa2z3o52+cVpvaUvFWRAwMCW9FJXp+u/Gcu73kevLLyYn5xUI1CgoKyv8aVKBRUFA+Rebn54cf9nn+tmWXCW43BeO8nlrGjimGrc+IQBtab5nIfAY2XDBn2KR6cXOQGCkvBgi0NCVOzolNPh7gtJ5iSzWimSxzNsXQLbfeS4jtuMFru53cfCO5JTO58TpbEH/G87t1lkCgySTg0MG//dwgzB9/0KNTT2p0wxrdkFoLMohk2BANzMjfy7Ba81irfQyePqMdmtaMzL58lHuZQTMh2eMwNCLu8NYtd1kX6m9w6m5xa29y6q6z7rEvxLtY0UyMHM0xjstx4bRtxdfoRQmRMqjOEXBr68U1eYhf0t/TzXeBJrogvpFSJvhDQZ2F7cUwC7YKXy0RSupis8RC8/HvS8iwivx+PhhC99fy9v53FeW/LtB/L5GixChRAnRoOJQDjppGesETo4K2fbeTit1BNAJfsQJ/3uL19QaaKc4Kv8Qat8QKt9QSu2Q35rNdxkt3Y5ZZ4JbammD9f/o6Iz5qqL8XHdmBgoLyT4IKNAoKyifKk5GhQ86WO0yMd1OM7VeT0477lXGi5Wxgz3QxBymyIgVXWDo1ODQLaScwjGbjxUhgETquKOm86ErEcasfrUyX2VGX2lON3FYSGbQdZZcZrTd4LZm8+9eTKjkXGa4WtsuxNmSMDQlvb2bKOnSwtUj6dPCBZnYC2DMi0AZ7fifQ/8PMah9rtIMa7dCsdngaOPfMUFupYO/mz+0IWHsCzsmUdHGPY1MGp/46C6QuLYEXuG/PGhNHKsbJHOe+lpJ+wlfGDJOxwiSscBEzDFaRWeGwCpsYuZgFFf4wsEqNdHogtxmW9IkSoXMb/FuSCANOBO8F6TN+Wz9eqCL/Qw79wc3/CoGmixIjRQlwWxahoYsDvoeoIk5cqLOlhSlhJ95oF36ZBWGZFXGpBf6/rAh/Av/FAV+tOfzz5pAtX3isNbUiAJn+L2v8EivSUvdNa5IZYU/HRtA6NAoKyj8DKtAoKCifKK+eP70Sevg38hIg0HbLieH2O8tYscUshhR28dKF7HARsvhMgDQhGDp6YfsvG+6uIuZFS5JgEbooKa6UG5d2KsDlc7KNyRKayTIaZdmetdQI621ixpl7rAvlV2OYfh7u681sTJbZkZbQSBj/r78u4yS1lZS+Gh/UqMf/GYGe1Q3P6OCztNohDSLQs+rhyYetp91sLIkYOxyGhjPeu3759SPB91gXa7iXs04f9PlytR3JyNEE62iCO/zTV+KLZyScMCk3TMQ6J2KFCWFgPzGiv39ToN+FLk6Em/l9EHECvC5MjOAnhhsiYIYL36rtR978dx3649sk/wqBFiVGwDecAB1aiBTgkTcQJWfFXAraa2lO3EUwssAvsyQspZkaB3yzOt511/XD+7LP+BfSD/DpB2+fDIh3tfDeaEYjLbHGf2ZDMvb8ZqPsRjrcvBDth0ZBQfnfggo0CgrKJ8rM9BvBdd5vpKUWZIwtlRDw7aa88FPyK9GyhGi4dhCWUcOEzHABMgdtobUXLiiEg+2AQ0t40bKkmGJeXCknVnQhNMxum70ZBtizPRnqqcdKyolfvrvoZhNJ2+61cbUtcHTSEnvSn5xNCZc89rXniTvLK988HdZq/2mB1g+qdVCgtZrhGe3QlGZodmpAnJGw0wRni8PY4zC2BOPAzZ9fdLVN2OsY/O0GGtnYgYR1JOMcTQgJe13L2XFyXpSMixSe2RECJhRopAj9dlme4fyvJzFc9C4GH30XQWIY/70IF1/2YxX+IP8TgYb6+y8Q6PDfCTTysjJOlJwdm3wyxGY5ZTfBeDfs0DCm2/6afdq/5NKpisRz5YlnK9jnqrgRVdzIO1dDU0Lc/DetsCcZ2YHvLWR8mLvTw+5OvR5t5EBBQflfggo0CgrKJ4pWo26suOOwYaUFCWtNIrivWpWwz7Mg/FwhI0J8iSG9ypAnMsQJhnVmhm5gZNEbG64plBh21ONEF7FiZJcjBdFn0g76nvj1eycq3omMcabg3KgEVyrecy3VbQ2RZoKxh9q6zJG81H/j+rvXOB2CElVNw8yLEa129J8VaN3QrA7as0Y9NKsZegOboYdH+huPO1laEbF2OIwdAWNPwu5ZaeK5xtSeZGxPxDhS8PYkQtCmL6/v3y+NiyxKjCllny9ixUrhNtdITZcNAkz6nJAVJkJ8GoYJI2SGiZjIReQc+LEw8ZyQuRhEkYXwi4fhR/BYmHDOED7y0KDaC4L7kRN/nL9mz4Z8LNCG6wuvD1tNFu78WJ3fE2ikCJ0Iu7QNFWg5+P9lx96KOGG/ytQCb7wLu4Rmirl5wu8uM/wu62w58/SdxJOlzJMlzFOl7DPl3LDia6dZfg5e68FfGGuLx7itW1mSdWNm6s2HnzkUFBSU/xmoQKOgoHyizOn1j3tVJ5zsdpPw1kSSA9ksbIfV7aOnsk6ezg07J4imSy9Ey65GyxKjpcxoGUwMCDiHDxOjZQlAsqMkFyLzI85knz6adfxwSoDPqa0/eJhRXEg4NxM8iLOJsSN1mQMF2LMxEGtXUxLLy7s7X9ImKutvbtFOj2s0g/+MQIPM6KBGa7RD4KXUmsEp7SBw6OnpR/cEmV7fbrTEGduR8DZ48AYwi8E5Ukje69ZfcfG4EXzk1uETeWHnpHGxxVcvFCXGy5ixEhbD0MEiYJ8VcsJ+N+ZiwVPDoSXDrowwPtTic9ChEZMWJJ5FpPkcDPIj/r9CoD+++DbQ+N9OxHv/uuH1F+357ZWPI1p4S+AcjhAxvAjcLpEVmxt91nX9KksCBgi0LdUoKzSwLPFcGfPMHdbJEtaJYubxosTjRcyTcqjRZ6UXTp7escWJSqARcdYkzOWjwc8mxv77v9EuDhQUlP/P3nu/NX3v////wvtz6oCQxXJXbWuH3VVxoCBTRVyAQBICBLI3YSM7DK0DMlkyMhlq3XvVLUOtyNJWT1sHZMH3+3y+gojQ9vT0nPbU63rervv1ul6EJKbvd3648TiP5+PxR0ACjUAg/r78/ORx5Y5Mf2/3tSRiEMGd8s6HFbGJ1Ux+NUdYyxPtF0rqU8QN6aLGLKkuR6bfkQoCbnTZKU0ZkoZUYZ2EX8PnaVlsLZOlTWJWJSVXUCk5gQG0dxZsnekZ7knY6IHb4D5tPWnqeuK0jR5E9ldLTpRXXGs8dKX5aH/HLbtlwGLt/g8FemjUoeE7WK3dg/aep9j1x/6bpl35oXNnrgECTXADVreO7BZKct3gSYp5592CsC1V8dyqOL46jquK52qZwnqxrCk9Xbcj3VAIB7rBQ4GYMZvL0s2lMHB/ijMlafDUXbFMXyzTFafo5FJ9MYyhSGIoFhuKwVWiLxaD6OQi3Ut7BtGVSnSlo80eYy0ik5343wo2O+9XBdo5zfq1508UaCkm0BLsHo4QwT5SCrB2INAN2ZJt7y/wJ7iuxr211n1qJSvyYIngYBn/QDm3rYzbWsppLeG0lHBby/itpYIDJeLi7aHhs0jBRNcAkmv8mqU9dztGRtBRQgQC8UdAAo1AIP6+2G3Wb08d3/L5h6vJ+LUE4noP73S/kBqmoJopqkoSViWLNEyehs3VcnlVfL6WL9CCK4+n5cAH1Uy2KpGpSmCpEzkgmkS2JpFVw+ICjd61PSIjcA3j0/fDvQgbyNM3EKeEubtEzJvdIEq/sf/gpaaj3x488eKHHrul12r7TwXaijVyvHD0DMFOaNgM/dza/dzeM/TiwY/3r+8WsgJmefuR8IFEtxASLojoyvNZUkmPr2WJahnimjixhipU0gTKeIGKIVCzBBqeoEoiqksT12dKGnLEjTskhvx0I0hBBoipMBPEjF1N4EfwYGGGoTDNUJBqzE815aeaC2SmfKkpX2IskJiKpEYg1nJJo1wE0lQCBRp2gIwK62gL9WQn/rfyrwUa2/U94fHxAm0sdX4YcC/DBFo6JtCNOdLtHy/yI7quxk/xd5+yM2Fjm5x/sFx4YCdwaH5bKb+thN8q5x8oE7bI+a3FQhUnZss89xCiSxDJNfKz925fOofm2SEQiD8GEmgEAvH3ZWRk5Mn3j/L5SSu8cGtIbgEEQuTb75RFUKqSxVXJUm2iRMsQa5KEIOpkgTpJoEoSqBl8VSJPlcBTx/PUdK6KzlUn8FUJfHUiT83gaZm8aja3hsuuTKQmffVRqLtrKGHaBtKULTPxhZs2XtMYrjeeOq8/cfvsRfuLh3brg/9QoK3WXpu1Dwj08+GeIccD8IY2S7cF/GjrGbL2Wp/1dJ8/nhG1zd/LI4BECCLhAgmu8Z8uVicz69iSWkZKTZxMS5Oo6CKYBKEyUaBM4iuYPBWLp2JzNRyOlsetEvJBqkWCGrGwViKCV7EI3DhTA5IirJEIasX8Ogl/vxRcubUS1n4ZR5ctNBekAIf+DwV6vP5Ozu8QaGdReeKvXgl02ZhAwwYVI7RnuM27uSyrKVdG+eKjNUQXX8Jba9z/UUwJBrp8aJfoIEi56ECp6ECJ6JBcckguNhdwddlMDTcmcqHXOpJLMNFl86J5Z79ps1qGJn7nEAgE4neABBqBQPytAYpzos246YtFq8iuq91cA4ik+E++qIhjAoeuTpZUJUm0yRJtklibDExarGaINAyROl6oiRdq6UJNnEBNF6jiheoEkRJcE4UapkDL5lZxmPmb1m+e6xlEmLKOOG092YXz5ecn5btv1R/5tunkedOx/s4Ox9CAHeoy3IGC2bBzl4rz/vfGagMC7axA9w46emy2HrsFvGfPC+wooXWw50Vfx4lqNW3ZEn8yOYhMDMDjQj3JjM8/3x1Dr2FIq+lp2vhUZbxYSRcr44FDi5VOjU7kKxO5qni2KoGtYDArGSwFDAekMpFVmQD+PGArQBJYFQnMfYnJ+xIYlfEMZXyiCiQxQZEYp2TSgUab86FAY53QYuxMIeycntDCMSGTNXeyNE/Iy33jEx937lMc3wY9+vyJ/+jYh4FbY0xlzn8xtbk8qyk/le7zqR95+ir8/60h/19+pP8huejorpTDO2WHy2VHymSHS1IOF8haMgT7xQw1l6JI2h773pz1JFwIyTVs4cxjJp1laHDiFw6BQCB+B0igEQjE35qRkZFHfT1lqcLAuZ6r8C6r8bhgTy/OshWKeGYNS1TNlFQxpcCh1UlAoCUahkTLkGgSJNoESVW8REMXA5lWwYg1CVJNogRWqZNZRVs3URbNDyFMC8FPCSFNi1rwdqMoo732m6v7j13WHb16+PjzH7od1j547A9OcZ6oxf9W4DJCrIsD5OWPcKkKiMXSM/TkXueJw1UZGVsXLQ4keQQTiUEEl1B3t/jFHxeHR2voMk2CTJkgUcZLVIkpwKRVCRKg0ep48EeCQBXHUdM5ini2Ip6joHMVcbzKOF4FjVtB5eyjsCspnEoKax81eQ+VsZfCqIxJVEQnKKPjlbFxlVTqXnpsrZRtKpQZ5CnjvXkskyz2NYee8OMfzuSXT/7nxuwZ2wUDfzQ5R3+UZTUWpCWs/MLfw8UXCDTh/1KDlulTkg/mSr/JTzuUn9qyQ6xPZTfx2HWJSao4WkVcTAUtOm7ROxtIhGAibtP7c0+0GpFAIxCIPwYSaAQC8XfHZrXeuHhesDXM191tBX76agIu2MuDv3KVgp5cw5ZWsVK0TKkmWQIFOhFErEmUahNTqhJTgEmDH9UJIhVdqKKL1ImCfXGMrHUhMYvmh5JdQvBvhRKmhs3yLImKvaY13dh/7ErjsUvGb+5cOmd71muzAs0FAv3vlZz/rQxZe2zPerq/PXehUbcrWRDiNS+I6B5EdA0mTgshuUUveDcneAvQYmWCSJkoBhqtTkxRxEuUCVIVXaJOEKvoAhWdr0zgKOO5SvA0LAoar5LKqYhlV8ayKmOZFbHJ+yjJFTFJiu0MRWS8IopeuZ26LzZ2Dz1GlyU2FUGBnqDOv8ehx2fMeif78b/M5FdNfv8JAg0+GNYDnYYJdHriqiVr3fFrcNP8cNMEPksUVEoNg1XP4u9n8aqTWZpEhiY2URvNqIymV1Bou7dHUd9ZGEYmgf8jb/v4ncsnj9islonfNgQCgfgdIIFGIBB/d0ZGRgafPztibKL6Llnp7rqCMH0V3mX9jBmsL5eVRdK0THE1GxahYQtHokjDkGgY4tFSdKJYlSjQMAQKOndPLCM3bAt76ZJtC2eFeEwPJr0VSpoaNoOcFb759F7tbf3RbxuOXNAdvtT2zePu2/ahXqv9waCtGzr0JPH9L8Y+9PDxdx1X2w6d0Tblb6OHz3onkEgMIrkGEqcEEqZGzZsn8fXfHctQJPDgOUIgzbAULVHGS5XApOOdfR0CVTxm0nFYqDwFhaOgsBUUloLCrIyBUUQnK6KSKiPjK6Li9m6P/Tpmu5bHMBemGeWp2JLCier8BzR6Qia78i9m8gt/KWMCDZ9vKJE4Bbq5PFtfmJW0avlaEsnP1c1/uhv/S5+9EXGq7SxNNE8dzVNFs1XRLHUkWxPFqYhiVMTEl2/ZFjlndggBF0TGxfp8fOfm1eFhx8RvGwKBQPwOkEAjEIg3gJHh4Z+e/GDQVEYu+3i5+9SVxOlriG7B7h6UDz5JCwrbS0uqShZWsYTaJIEmia9m8NVJfHCjYfAVCczdFHpWaBhrydLt7y3cMJMU4j41xGNKMHnqOk833qqVJ/Zqr+sOXzMev6g7ct506NrJY5afH9itPRZ7NybQf2IF2gI7pAeGfuy/dvT4NfPRs5W68ljuhhlv++PdAklTAwj/L5gwZYOXe/IXX2WFbKigJmkZfE2iEPxJoGaIsbI0DCy6x0vUdLEqTqiKE6iofBWVp6RylVSOEmh0DEuxnaWISq6MZFRExO2NpO6Ojt5LpxiypS0lGcaSVEOZDFutMtGbJwv0Lz44/rcTHpmsy5Mz+X0mxzSxGxurQJelN5ft0OdnM5YvW0sk+Lni1k53E3y+vGJrvCaSq40QwkSC8DXbhOpIoSKKXbE9Pjd43SZvrxASLtDdhbvBr7/73gja5o1AIP4QSKARCMSbwfCw48mjhwbNPpr/V77err4kFz8Cfi2RGD53Dv2TT/grVqYGBuasX5e3MbwgfFN+eHjOhvXpQcEi35VJX366fdHCsNmeoZ64UI9poe5TQshTN8/xFKxa3ryj6JbhxFX9ycuG4+eN35xvbevt+NZhAV7bbbXdx8rPf45A27HA+37L4MO7V65caT3RbjpzSdVawZCyffxCvT0CiFODYB162joPQuT8uezPP8/wDyjauGXXdooynqlK5GiSeBrwB0OCuCpBoo0Xa+lCNV2gjuOpaTwVjauMZVdGMyuAOkckVUYw9kXE74mg7I6K3k2JrpNwzEVpzaUZOjmw5xRdqVSHLV6ZbM+/JtCTdXnyI5N1eXImvOQX87pAwwOF4IXm0oyW0lxdbnb80i/8iC6rXaf4u0wTfOlTuS1eEwEEWlQVIa6OFFUBh94mVkWIKyM5FdsT+EuXbfAkB5FdArxcd6cJwJ9kE79kCAQC8ftAAo1AIN4YRkZgHfqosYG7OXC1t9tqgusagos/aXqAu+s6b+KmuZ6RC2fFLppH/WA+5f350e/NjVo4e8s8z42zSetmuIV649Z5uqxzn7qePC1m4dzUgAA1m3+r4cAN47krhjMXDcfONR+8efrYi8d3HNZuu+07m+2+1fbA+q8E2mrv++1YxsV5lPD19A1ZB5703b929PStlgudxks3ao8eLdUWbqNEL3p/LcE1GC73nrqONH2ju1vkLG/awvmMxR9IV63ICQku2QpkOmZvTIKSxlTHMVW0pIoY+u4ISml4ZOG6LQWhW+Qbor7eTN2zOX7v1vjdEdRdkTG7YqK0XEZLQbqxSGYqTW8qTgECDRcWlsAVKuNGcKQYS1KMcinImDHr5ZLx+UWNfmW9k1x5gjT/2uOTM1mgzWWy5jIg0HlN2VnbP/7AlzhlFe7/fF3eEi1bWRmZoInia6PE2kixNkqkjRKoI0TKCGFFBLMgdPP2BfNDPPCBHi7RX71/5oDJOoRm2CEQiD8IEmgEAvEmMTIy8uLpz+ePHkiJ2uTvRVhNmuZL+n/+5ClB7tNCPKdv8HIJ83YNn4ED2Yhdw2fiNni7rgf27IUL83LbPtdLtOTzwvVhFXHJLbk72w2nrpsuXTGeu2A8evHgoUd3rw8PPnBYv7Pb7gGBtv1XBNrxKpPsufeFvecFcOjnD7+7ev1627n2lst3TN926s9fUhkbpLkS/5DwWTOC8VPXEaevJ07fSHYNJ7tu8nCLmuNJfWdOwuJ3kj/7kPPV5yKfpUKfL4U+nwuWfsr78mPWZx8xP/5Q4uOTH7yuPBw4NO3rbdSdwJ5jY1ScRGOutEWeZigGMpqmk6fonBu/sbwS6BKoztCeiyWjN3K4v3BshSG8B4+M0+tfEN9JivzHBBp+GCxQ4rGlKqZSWXNpZos8r0osCVvw9krClJW4t3xdpktXrlVEsbQxEs12GYgqSqzeLlBtFygiOaUbohM+WBzqTlhLmh44061EkPTwwf2RYbSGEIFA/EGQQCMQiDeNkZHBZ0+/aagNe3eeLxEI9Ft+pCmB5KnrPFw2euHCvXCbvd02e4Mb103g3gu30cNt8ywP6qKF4mVLioJDKiOj1dQkFUN4pLyqo/n8VePFy8YzF1oOd108a/mxe9j6wA7V+Tu4QuV1gZ4sx78n/0KgHT3P7A+s1oc/9nXfOHL2Vtul9uYrt/QXOw3nb9UfO1aq3kVJ2L5g/joyKZSA20jGbyThNoP/HE/w34jbMhO/dQ5x61xi5NvkqPnk6AWk6IWkmIUeMQu84t6dI1n2VVFo6K4tUbu2UnZFUXfGxGh4ScYdUnOxDDpxicwglxlKYAtHY4lkdJX3WHV5TJeLRld/O+/H59XjWDV6ovW+tOTJD4796l8K9KidOz8P+GAlEl2JGFyNJSnmkkxTQc7uJFbwzFkr3aavdJ2+2gWf7hemjBFoY1O1Memq6FRltAT8WBGVvCMgLOGDj9e7kwII09Z6TGOsXXr5xDeo/IxAIP4TkEAjEIg3D4fddvPC2YjPPlpJdFlJmLYaPy1m0QLqu/O3z525fbZ31CwvkOg53tS3Zyctelf81VeZfmuL12/aty1Wsz2+OpahpbC1TNlZpe5WyzlgzxfNJ26cOPVT3x2HpdcOVw/et8A4h0CPCvRkM/6d+W2BHnTAJYUWa7/t6cMHV27cPHjuhvniTdPlW4ZLt3TnbjWcuKzU1XJlMr9Q6qKPtsyYtdnDfZM7YZMHbhNw6JngDwO3rXPx2+a6Rb1NiJpPiF5IjFngTlk4k/PZR0Wh6/Zs3b43irprO3UPLa5GxDXskDbDsRtSPdw1CMQUmHSaTi4dE+imYrGuWAyF+JeMeXLGBPo3HPrX8tsCPVbYhmsR5WIQPfR7cVOJCNwAgTYVpzdkphXH0IK8Zqx2c1k5fdrq6fi8kAg1RaylpGpiU9WxKYpYYXFYLP+rFdHz315HcgsiTQsgT4n58j2zeu+zH/+Jjg8iEIj/BCTQCATizWN42HH3xrUYny9XEt1W4HFrCPiC8E27tkXmB4Vmr/bPWuWXvcov1y+gOHjdrg1b9m2JUcUkqmOYmmhWVTSrOpqlpXKruRnXdYeutZy6YD5x6eCJh13t9mcDdqDL9vtD9u5BxwNnhl7OgZ5sxs7Ybb0w1pex9dqwJ1vgb/tBflugX4AM9w5ZeocHHz0f6Lt39tur5jPXmy9c11+4CdJ4pr3h5M3qg+aM8oJwSvqadZzPvkpY9D5l/pzI2Z6bZxLDvfHh3oTNMwnbZpMi5pJp785OXrxIumxZQcj6vRG0yu1Je6MT99DodWK+uSDdLE81wWV+Eh3c1y01FKcYimQ6eUqDXAxTLGoqFumcDu30Y5BC0WRvHm/P4wX613o5fjG/R6BH+61h0wj4YDBNcng1yFN0+bJqiWjH5qggT28/t+m+094KJpD2bqfXJUrr4mWqWGH5Jnq63wbqosUbvNyD4HHMfwSS/rH1/Zm1JTu+73sw7EDT6xAIxH8EEmgEAvHmMTI83PfdXbr/qpUk/EoCfg2eWLI1qpElrqayNdsZmshEVUSCOipBG51YHZNYFZOkjWWrYznqGLY2hg00WknjVguzuw6evdx67Pw3R+5e/9byc7/D0m+Dm1OAQEOHHrKP2rPVirVw2HtfqTCcoTFqz8PP7lkfXH5+4/jzq0de3Dhu6f3W9vyuFT5twGIbsNkGftuhB2H6hoB5D/U7nj962nv/9vFzV1tOXzecu2W4fLvh0s39Zzvqz1xVHtQysiqiBTvDafL1EfnB67PXBqevWZu22l/muyZttV+GX0DW2qCC4DD5+q3lm2K+jojbHZm4Jzp5Hz25Rsxtzk9rkaebSqCnGsqwCrQca24uBpIKe6AboZtiJV6nqhaJ9IUiI0iBENyAHyfH2QwN+6FfVYv/iECby1P/hUBjn6qpSAgC/2ng9IUp+zPEah4/NWRjkLuXn9u01a5vBRJxopUrUlb5i77yZS5eRnv3o82z5wSR8UGEaUGEf4R6TN3+yXzljpT+7+447PaJ3ycEAoH4N0ECjUAg3jxGRkZ+GOjnbApd4e62koj3dSPI1gQ3sWR1ccLaWEFNNK8qmgtdOYaljWaCaGLZKgpHFctSxzKVFOY+Okcryf7u5KVrx0991/7tsx+7gb/arb02W7fF9p3F/h2m0UCgoTrbMIGG9+MkGCiyzd7nGOwevHXq6YH9L4yaF42KZwbVD4fqHl/9xv78vs0O1PmRxT4w3p4nC7TToeEbwjJ2v2Pw4T+777afOHfNfOam4eLtpis3Gy7crD3TUXe2RaZQxqapY8SaGL4qlq2MYSlj2IoYdiWFqaCwwH+dmsJVx3CV0ey9Ucl7opN2RifsoTPrZGJTgay5JNUklxlKZUYg0HDaBuwnhg6N9XJg3oypc4kEaHSTXNRUDFRVqCsEEcCbX4q+WDSaP6cC7XxbHfbBGouF4CM1FgmgPRdImnIk1WKBksXlrwoIIgOBdvHDT13t9laIJ36dJzGURAzG4wPxbmsJLv7EaYGEKeu93Zh+S/bvLOy912VH9oxAIP4bIIFGIBBvICMjPz15nBYfs8IDt4KEW+nmFr/4ywZmSh1dXEsRV8cIqmP4VbHAoWE0MVxVLFwsoqCylNQkRVzSXkZybXbOT51djx/cG3zaa7cM2K19Nku37VUDtLMC/QsC7byxDvcDgbb8s/PxwcbB2kp77V579W5r7e5/7t/bb9QM3b8ybO23DD98Ntw/NPyr6jwq0I4ekCHHA6u9x27rt7949GNP990zV260nrumP3et8dz1urO3as6ckRvVtB3qWJkmVqKNFWhjhZpYEYiaKnRGQxGqYwTgv3RfDHMPlVHBYNZKxOaiTHNpqgkoaWmKvlymc059BqKM9TobS+ERPdiPIZc2FcEidCPs5RA2yIXwClIkaCr8hbzm0L9vsN3k/E6BbpSLGuVC4NCNhQJ9gUifK6mV8dRctiKZnfDZ0kCypx8eCPS0NfgpawhvrXF7y99tylr8tECiS5AnbsN8T+qSD8t4jFMt+h/6e1HnBgKB+G+BBBqBQLyRPPv5p12ZKT4erstJrivwuM1z36lKENTGi2tpkmqKqCpWUEXha2J5mliBJlaoovIVcVwFnVlJT6hIoFdwk0xfFw3/1Gd/8dBhfYjZc4/N+sBmu2+xQXu22GD/xpCtz2Lrm1yBdsYp0A9baodqKxzVe0eq9gxrv35Rs/dhg2Ko68KIpXfI0fd0pG/o12vPWIA9P3gx3A0y5Oi2OIBDP7QPfv/sUX/vjdtXD52+bDh5tf7U1doTF/cdrGYWKimpamqKliLSUsTaWBCJhipRg1BEqliBMpZXQWHuoyWpmMyGNElzQXpLaQasOoOUy/RlcOoznFUHrnAUnbghl1clTVDzqfvY0ZUCSm0ms6kQSrPTnutBiqC2Nhbwx2e8Q8NgLj6hDv3vFqTHZ6x/A2vIdtqzoBGqvFCfL2rMEqj5yQpm8r54xvb3PlpLJK92m76GMM2PPM3Pfao/eUqgl8vG+d7xyz/Lomyrlu842azvvddlGXwxMoKG1iEQiP8aSKARCMQbydDgC1O1cpmnqw/JZQXRLcR7VnlEXE2CpCZOUk0TaalCLZWvpmJr+eL4lXHcfXRWZSIwy8QqIaM2i/dNden/N9QDx25Y+2DzBrTnB7D8DLs4nMM3+oZs/b8m0LCFw9Fvf3H/6fWjTwyqZ3V7LdqvbdV7fqzf9+ib/fYfbjpsvc8dD54PY+VqeKZw4gBpZ15WoB+8cNwfdNwfGu4GT7bZBhzWJ5an3w/c6Ww/eeGK6dS3umMXtAfqZeUV8SmqeIkmTqilCTU0kYYmVtOE6jiRMk6gpPEU8WwFg6XlcZsyJc1F6S0lqebyVGN5irEMSwmcoGwsltTncCu4MQUx61LXrZT4fSn0WcxZ8j53+UfitV8qebHGAqGxSKSHjc6jXRxOY54g0K8c+uXsjj8q0HA3yvjAyRslsPX5pUDzG4t5TUV8PfgwO4TVEraClVjJYJRGxWyd/64fgbjKbXrYwtml/GR1Xro6L6OuNM+k3HOqxdB17fI/v39os1rQwA0EAvFfBwk0AoF4I7HZrBeOH169wMvH3WUF2c3fwzMtMKwqUVQVL66iCzVxfHUcV0XnKOOZykRmZTJTyWZWi9iNaTxdDq+xUPBNnXzEcs9u67bZerA8sMIThGP23DtZoMeCCTRs4XBYe4d/6njefvzHE03PDtQ8P1T34xnTi+/OOyzd4GnPh3teOHp+TZ3HOzSsdtsfYBVocO2xDfdbbQ/tth+sL75/OtD7fcedB9/euHvq4oWmluqULA1PUsXiVyXzNYk8dSJPlchRJ/M0TH4VV1ArEdWnifW5smZ4ZDDFVCYFMQArLZGYS6WtJSn1maxS2sa0dSvZSz+M/3g+9d3ZtPne8fO9qHM9Yud7Rr5Nzlq/6kChuK1IYi4Sm4pEmElDS57cxTFBoMc0erJD/yuT/g2Bdk7eEDQV88HHMOSL96dyVRxGZVKigpGYvT5s45x5vgTCCqIrZ0NA++ULP/3w/U+Pf3j645PBZ0+tFgvak4JAIP48kEAjEIg3kuHh4bvtN6lBK5Z5AIHGrSaTkpcsB0KpZQg1iXxNEl+dxFEls7TcpBoxa38aryFLYMgVmgqEhkJeQzH3YH2hw3rX7ui223usWDB1duaVQFt/SaChQ7+cwuGwPnA877I8umJ5cNbac8H6+Mbwi+8cdvBaOF5jcJIuT0qfxQo1Hd6Dz+CAgUM87H3YEI9HDssj+4tHlp8Gnv/Q83P/d2caqupz0hozpE2pknqpaL9UXC8TNqSJmzKlupwUQ77MWJwKN6SUykzlKYYyCXRoubRZLm3MZpdSNkgCvkr8dD71vVnU+TPi5s+gvz0jYf6MxHdnJrw3K2nxfMHyxfsStn5TktomT2mWS8xyidE5Qu6lQ78y6fEHCsfZ8y8K9CRjHs3L374ebPAzsGc9NnlDB3ushYZikalQ0pQp1PKZymRGRUICiHCNX5C39wqim487Lp+X+PhhP6o0IxCIvwwk0AgE4s1kZOTxo4F8QdJyb9xykusqEiFq0QdVLF6DKKWWL6oVCGrFgvpUgS6HZ8jnGQqBhIlNxUIjrGVyG+Tctv1FDvt9m73HNlGgx1YPwgboXxdoOOzZDn4LBz/D3o8h2x2L7Y7N3u2w9Q5b++0WEPBa8A6Tpfk1gbZa+62jDu1cvDJ+Xl4/NlW61+oYAJ5ttw7cv3asqSzDVCQz5wNdlhoKUowFEmOh1FiUYiiWwt3aZSmNxSJDeYq+RAwcurlEos/mlceFiwO/oi2eu32hZ/Q8d+oCr7iFQKC92R/Ol638PC9sza7YMA2XUi9LapWnHNyV3lwuM8GuD3jc0Omy2Gw7qLMvpfnlYOYimAm1539VYB4LFG4j3Cz4WqBAY8cTddg5RfD/ODP4r9shqRGxVclJioSkfXGJu6hxcV987ksm+JBwy2eSVCW5z376ceI3BIFAIP40kEAjEIg3laEXzw2aSv+3PZeTXVeS3EJnzdyXGN+6I9uck2HKTTXly0yFUijNcoGhRKgvERlgLZOnL+Y1lgpba4qGrQ+sUE+xui9sougZZ8+jsY6bwjHRobGdKRb4274hR8/gMNbEbH8Axdo64LD0jwz1DQ+9HCP9W4Hq7Kxqj2+zdv4rVtghff+F48HQMJDsnsc9l00VO+AI5yKxES4LlBiLRIYiuJ8PzkuGy66hlZrLZGZgtPnCPcnb0tetoH88L2Khx5Y5hMi3ybHveLM+fzczcFnJliBVQkS1IA78jWEukhzanXVwT3br1xnNu9NMu1INu2T6nSm6MthN4Wyo+MVM7tyYVGmeLNCvvZtz0eCEjM3IA/ZsLJLqcsS1Yg6wZ2V8koKWvI+aKI+K3rjg7eVE12VkV793Zp48YLZa0GpuBALx14EEGoFAvKk47Pb2by9FLftkhbvrKpLrWk9SamhAa37WgeLM1pK05lKpqVQE1FknFzbJhY1yEbjRFwtAmkrFzdoi2/PvbLDo24sVfV8zYyzQp622nt8QaCDHQ1ZMfOHUju+w4Xc98Le2fht2NtFu7fntCvQQdohw9Ao+w/DLOEYPF8K1iMPdz4Z7no/0D9p7Xzy5faimFDgrXBNYJNEBjS6SgHu9cyMgHF4hNZfKWuQpdWlJWZvWxH+2IGq+x7bZxG1zSVvnEOMWz80NX6PhxDSmM035ogNlaW3laa27Mpp3pbXuyTR/nW7enW76OhUItGmnDJ4+HGe9v5YJbRu/JtDjnu8079Ea9qt50k5jHqfRsBpdJG7KEVaJWGpWUiU9UUljKqmsClpSRuiGtV4ePqTpS0jTw79a/F3nbdTxjEAg/kqQQCMQiDeYH3/4vojPXOWJW+2O83fH0z79sDFV1JKf1lqSai4TG0r4QKCbikX1xaIGOdzH4ezibSyRGFUFL/7ZabO93LZtfzVm7qXdwo4OINDOEvJke7Y4i9NWWKW2wmJ2t83+YAiaNBBo57v1WOwPJkvz6wINLXl0bTh06J6hYRjncGinQIMHXwz3PR8eGHL0W59+d0xXoZOnGItT9IUSHVymnaIvkuqKQVIM8hSzXNZaLKuVJAj9voh8x3PzLPzWmYSts4lR8z1T1i7Zl7jNkMM7WJ52YHdGy+70ZpCv01u+zmjemQaupp1pzV+nmXemNoOUyZpLU0DMZaMS7NTfSUIMjfm3BfrX1HmSQGMNG5g3w8glJrm0KVdYLWapWAwlI0kZl6SEk7yBQCcnLfHx9SD6kKcvIU8TU7Y+efRw4jcDgUAg/kyQQCMQiDcYm2XoqKEhYL7nag8XfzJu87w5X1MojSlic25qc7HMJBeBNBUJ64sF9SWCBjhOGA5iaygSGypzn/RdgxOgMYcesvePnfnDhBjcYE0dvzlDY1x1GdaqrVjRetSMncGWgf92sKL1y39rrBz+Mlh7CSxyD2Ef0jrUc+ZATWNxKjwsWJgCvBnYc1OxpFEuaSyWmuD5vzQthyZe/UXEPPdNM/Gb5xA3zsLTP1tQEBHcmMk5UJratiu9ZRcQ5XToyl+nNe9Ka9mVDgT6tZSnwpTJzGUy06QejEmZaMym8QFKLYfrWmCKJfpxIztgisR6ZwsK+NumWAD/J4ISEbBn8CpTsUyfJ62WcFTMZGVispLOVMYlV1KT9lEYO6Np2957b5U7wYfs4jPDtWpn4YtnP0/8ZiAQCMSfCRJoBALxBmMZGjwyTqBDPTzFK/1VSexaoaAxXWTMk5oLpYYiuF2vrphfX8hrLOA15fPrC0S6PTkP2k8N2/pfCnTfoL3XKdA2OBbaqbbjC9J/Vca1QcNOaMfYacW+Iex6+YS+QZ5mLE4zFsn0xVIdrENLm+QwZrmsShTPXbY4ap7H1pnEzTMJW952T/L5oJIdbSoQH/o6sxWqc5p5F2zSaN6Z2gKLza+r8840czmcHg3yckfgqzaMX8lvCbS5BI4BAeqMdTa/PB348gCiDthzodAADwvCWXU6uQC2qsOXyPS5KTVSnoKZpEhkKuhMRVyygppcQUncS03ICN0QOmf2Snf8MrJL4PuzTh1qtlosE78ZCAQC8WeCBBqBQLypOOz2jqvfSqK3+nrjfckufiRcAJEc+fai0giqIpGl5nBqJfymDLE+T9pUmFJfKG7IFzTlCXR5goY8YUNpWvv5lhFLr9UG+zcGHVCggS5bMXt2CrTzkYmC+2dnokDDK9ar3TeEzc67fr61Xp5mKMIq0EUSfRH4C0FmKJYBn66SMtgrPtk6h7R1NmnzLMLmOURp8DKNiH6wNO1AeXrbrnRzuQyos3GnzLRTBu6by2Vjujwh45Zsp/wrh/4tgYa1ZFh+fnU0cHQoHgiUZoG+CISvK+JDgYYd6mJgz8YCWa2Uj9mzs/bMUtCYCkpyBTVpT2x80ldL/Tw9VpDdlrnj2FtCvuu8PTyMdnQjEIi/FCTQCATijWR4ePhRX0+ZTBAwb8YqkstqkssaIs6fQAwieQtXBlbEsSoTOEoGR8PmVEuEdemS/VnihmyxPkesyxY17RDvzxdfaqu2P/3OAruQe18MA4f+BYEe/HsItBVT5yF409tx5TAm0FgFuijFWJRqLEozF6bps8UCvyWb5pCBQG+ZTdy20EMWvKwhnQXU+eCuzNadsLnZtBPWnoFAG39doMep8yuB/k2H/lWBdrYyG0fLz6ONzroige6lMTcV8XQghZymQq4OThgUGcHfA3kp+2VCNYsFa89xTCWNpaKxFVRmJZUJNFq+dXv42wtWEvHLSK6rZ3uoS/N//vEJmgCNQCD+YpBAIxCIN5KhwRdt+zWbP164huy2huTqR3ZdTXBZQ8D7Edwj5n9QFkGvoHEVdJ4inqNI5qo4fI2QXysRNMiEjanChjRhXZbwG1XJ84GbVrgCsGdw2DkNAx4ZBPYMx2v8zQTaeQ8E+t7NE/uL0/UFaabCNEMhuGaaCzNMO2TFkRu3zPXcNAMPK9DzSGnrVjRlcQ6Up7XtymjZmd68Kx3YsxFr3vjtCvQkgX5l0pNc+Rczzp5LRmvPLwUatmpg9gy9uamI2wTVGYQNfgS/NRRK9DskdSkC8GePisFW0jkKKltBYSuprEoKs4KSXBnHFK0O8Hf3WI7HLSW7bPr8g4snj9ps1olfDgQCgfiTQQKNQCDePIYdju/ab4oj1gV4u60l40JnkOmff7R+tpcvAbeGQAxynyFdHbo3hqWkCRRxfAWdX5nAUybztGxeDY+3H5i0iFcj4+kL0nu+PeqwYIf/YPkZHtd71QD9PxJo2DTyukBj3uy8h/vDu9tP7wfqnJdhzMsw5GeYC7Jb8rOq+cn0xe9t9iZsmUHYPJvA9/20IYN1YGdG6670lq+hOpt3phl3jtaeX6tAT7Tkf5FJujwxcBDHuJUor3duwG4N2LNRyNMXcnWFHH0RV1fE0RVy9YUCI5xYJ6qV8rQcjprBUcdzVVSOisJVUjkKChTofZTk8u20iHc/WEkkLiO4Lvdyy2LSv+/vGxlBA+wQCMRfDRJoBALxhjEyMvL86U8Ne0vD3p0R7IkL8XCjLX5vDz2Ws3LZaiLOF4/zI5K2v/Nh6VaaMk6goAkraQJlvFCZwFcz+FVMXjWHX8XlVot4dWmSM3WKocddDlu/HWsyttnh7u6x1Sf/k0OEvy3QdvvA/Vun6vMzDDmZppwsY26WKTezZUdGRrD/llnuW2cAgcYnfL6wWkg/uDPdWXg270oz7XLaMxRoQ3kKHPBcDrsyzLA3Y6Ii/3YmG/OEJ4wJ9OuFZ6c9A3UG4RsKBQZ45RqASRfwjAUCQ75QnyOqk/I0bLY6ia1O4KppXDWFo4rlKCnsSgprX2zSPmqyLBD8yTTDh+i2lOwS/OG8b4yNlqHBid8PBAKB+PNBAo1AIN4whh2O7s7bwk2BQV4uoZ6uW+Z55oaFNElEZdHbw+bO9iW4rsG7Bbt7CZb7VcZxlHSRMk6oogvV8QJtokjLEGiZwiqOoJovrJVIDYW53ReO2P753Yj1od3Wb3MMQFWdJLV/ZX5NoOEHswPRf9h58UhDXrYhK8eclWvM3mHKyVAmx0cvnLPZm7DZ223bPNJexraDJamtO9NadmWYdqaP2nM5UGdoz1CgX7Y1Y5moyL+Wyer8i4OfsQdfa3rG2jZg5wa05wKBLp+vL3iZfL4xX2TMFTdlCOvEXC0Hs+dEjprOUVOBPbNVsazK2ORKKhPY886Y+NjFn60kk5YQXZZ4uvCjwx/c7RpG+1MQCMT/AiTQCATiDcMyNHjUUB++aGawh+sGL7fEz96v5bGaJFItk5u8ZJkvztWP4OZPJG55e2HexghVgkCdINLEi7TxoqoEINBibbK4miOt4kjqBLKG1IzzNeqHV85Y/9ntsD6y2gYsjn64WRDT6JejnSc67p+ayQJtwaZwYOP2BhyWR1ePtjTl5pqz8pszCk0Z+Q0pIoHvsjBPYM/4zTPdMkJ8WoskbWWpLXAmXXrzrgzzzjQT1tlshHnNnmEpepIo/4YxTxLlX8wre3a2bTiPDMK2DSjNUKCb8vi6PIE+X6DPExpyJE1pwjohT8tma5LZGgZXHc9RxbFVVJaKwlTGMivh8A1mRRwzfV144IxZS4luX5Cm+S+aaahWPH/6Mzo+iEAg/icggUYgEG8UIyM/Pf6hgEMP8saFuuM2zyLnbgzWp0j38yU1bHH+xogQT28/An4NAR9Ado/79Ms9lOQqIM0JohqGRBsv1DKkmiRJFSuliiWr46btF6YfkpfcNhv6rp4f+qnHZns0ZB91aCscCA03EU523D81vybQsEAO/P5Z32lTgz63qCWzuDW9tDmzWB61ddNcrzAv/KYZbomfztelJbcBOS6VNu9KM5djDg1XoqSaS2Uwo20bo8Gq0RO9+TfseazePEmaXwWuGxy3X3CcQEN7dgo0tOdcoS5X0JDFr5fya3ncahZHk8TRJHA08Tw1nauisZXUZAWVoaAkjZWfYxZ/toJE/Iro+oX7dHbk+vtd7aj8jEAg/lcggUYgEG8Sw8OO++03432/CPbErfckUt9foGLENYgENWxhNUu8j5ac/KWPP5HkR8SDhM6YKVodqEkSaBmimmSpJlGsTUrRgDBlINXs1BpuqiF9x5Wa+hutrb3XLw/+2Ge1fm+1DViBRsPu5wdWO9xjYrX1DVmdJu3cNQiDbRmED8LNhWPBJng4S9fOxYSvFg2Oe+3rgTvDx94Ta7zGSuCjAt07NAw+A5D7Pof14dOH976p0rbk72zLLG/L2NmcXkT/aNF6T1yYF27jTNev48IPQlFOMZbL4MHBstSWsjTnSUHnau7R+RhYDGVSfZkUK0hPtOfxAm3AnglTKtWXwKvzBt6PGrPkZV5u6oaFZ2DPzh5oIRzz/LL8DHud84RwmGCWcH8qr1rMruaytEy21mnPdK6GzlPHcVVw+EaSipZUSUmspCXtoSaK/YPXes9YSnT7kuwS+OE8U6168PmziV8OBAKB+KtAAo1AIN4kbJahMy2GqPffXu9B2DjTU7Jm+X4es5bLqmbztCy+IpFdsCUy6t1FfkQ3fxLOn+S2ed78zJAwFYNbzZJWMYE9yzTJqRoWFGgNK0XLltUKMs/uq7mha7vVdvj+xcs/PrhnffYIK0X3YYPt4KYVm73fac9D1gdD9m4sDwYdD359Uzd0Yit2Bc8ci8XudOVXscJ0jz0TvCfc3gJ3u/Q7M2jvGRx+YHE8sNv7HC/6+65e/maP+mDuvoOZu9uyyivjuRvd8eEeLhu8pycve7+lUNIC3LccC7aIG3rzTllzeYq5VIoFOrRToPW/ItATqs7Y0yT6cgm40ZVKXqXkpTeP7Rd0rkcpgisGnVsGdfBxgaEIztxwNmzod4j0WeKmNFG9mF/D42jZLA2TrUliaxLZmni2Jo6jpnHUVLaSwlJRmYrYRAWVUUFLzN24efM77y0nEr4iuvrMImVzE3rv30PlZwQC8T8ECTQCgXhjGBkZefHzzw3lxZtne2wg4bfNm120JayBz6phJ1exWCoGszKBuZuWkBYUumne3AAyfi3JLYBM3Dp/YWboxmqOpIolrWanVbHStGyQVGDPIFXs9LYduzsaD93Wf3PN9M3tIyd6blx59rgbOLQVKiwsBmMH+HqGbN1DtvtD9vsWWzfmu9Ceh7AN268C9wXCiXjYULzJxeYeq/W12EbTC+6dr3LOznOeHXQGOLTF0eOwDTwbuHtZ33x0Z/XRPNXhrL0HMkrEqwI3euDDvFy2zCfvSYo4UJ4Ga8bYeUFYhAZCXJ5qwqY+Q2kug+VkWHt+ecVuJgr0BIc2jBWhgUzDwrNkNHKprtgZsa4IZNSbGwuhQ2N1aHh2EM7cKOAZCuBhQcMOUVOGcL+UX8PnVrHYWtjxDKNOZKsTsIODNDawZxWFpYwF9pwEQ2WUR8VQF3/iSyItI7h9RcZt91t28eQRq2Vo4pcDgUAg/kKQQCMQiDeHkZGffvh+j4S7wcNtI4mwff68fdTtDTx2LRRopjoJCDRjDy2+PJoiWu23cc5sYM9rifgAEjHynfeKt0VXsyW13LRqTloVFGgYcFPFTG0U5l1VGbp0R27qvrlmOHil9WDX+TP/fNBle/7QbntowYTYYn+ACXQ3Zs9jhWeoy07lde79Ho2tz4Jlol7bYDfIa7H2OSz9dsuAzdoPX4KtGxwa7h0a7hnEMuTot1gf2mwDz5/c7zp3+qSq4WTZ/lMFVcezK8zC7Pj3P97ojQ+bhaN/tqAlX9xWItMVCOvzeA15/KYCgbFYYi5L1Zel6MtT9LDknKID9zBQiJ0bT5yW/GsCDZueS2SvIk/RF0vHoiuSgDSBFIKrGKZQ1FQIN3XrgT0XwoODhkIhVOdckT5L2CDjVQs5Wg5Lw2SpGSzgzZpEjhb2PXM0wJ6x8rOKAsvPilhmRQyjkpq0N4bOW7EqwN3Dx811KQnnv3B29dclT3/8J/gqTPxuIBAIxF8IEmgEAvHGMDIy/PDB/RzK1o0euHASPnbhvJrkBBWduitq267tkXuplMqE+L1xcbuptJLIaI7PinVe3oFkINBuQe7kmPc/lEdQ6nipwKFrgENz0kGq2enVzNQ6dubhvL1d+w92NR29rTt8XX/wqvnArSPHBm7eeP6kx2pxzofGWpxhRwcM7JB+mTFvtsCGaedzoBmDWKxQmgftrzLBp4E0A3W2WQesNqxnw1l1Bt4M88Di6LHbHtmfP3r+/YOOc6cvGtpOVxrO7TScK6w7lb1vfyI/5u0F4UCgZ7imBixtFDNKo9enBPuwfT9mr/pYGupTTNlQLWMY5FIT0OhSoNEyXfmoQ08Q6PEOPabOzv5mgzzFKAfqLDMUp4Doi6T6IokeU2ddISbNTocuEoMfdYUiXQGIAHgzTAFfnytsyhTWy3g1QraGw1QmJ6sYyWpYdeaoE7iaBJ6GztXGcTU0jobKgYOfKRwFHF3H3EdhgGQGbwibPWelG26p2/TlXgQxZdv9zvZhh2PiNwOBQCD+WpBAIxCINwaHw3H35jWW39Iwkms4yY2yYG5RWCjni0/j3n837qP3Ej/7SLTap2Bz2K6Y6D1UWtGWbQmffhriSQxyxwONDiSTqR99WhpFwxw6vYaTXsPOqGVn1LDSa1npTYLcC1/X3Ws82tV4tL3pyE3D4WuGwzcPHL936eIPD9ptzwYcQ48cVpABuxWuA7Q6eoccPSBWbL221d4Dz/nZe+zO2Prs1j47MG8LHIc3NC7w0KHzoCEW+NsxBX85c8PiwCzc0Wu39dp/Hnjc0X7n9JlL+rbL+w9crGy9uKv5grzx5I6KPRGUiJkzNnvhw9yn8778ULzs09gFM7bMIK13nw6yeRYh5r1ZnJWfFFPCDHmilrL05rJ0Q6kMq0ADgX6t0XnMocerM4gO9jdLoTq/rD3riuGDo4H27OzcgC0c+kKxoVBiKJTq88WGPLE+V9SQwauVcqr5HKDOquRkJSNZmchUJbBV8XDRoIbOV8fxNTQeiJbK1WD2DNemxDIrqMy9lMSCTRFR773vi3db7uayhDAtcvlnJ9vMlkG0OQWBQPzvQQKNQCDeGBx22/WzJyM/mBtGdNlIdNvs7R69cG6YJymEjAt2xwV7uK6fSYxeNI/j82XO+pCvY6ILN4VHvft2IBmH1aHxIR6elA8/Ltoas1+Qvp+fUcfNqONl1nIzqplpNawMk0x+U918r/H4Hd2Jdt2x26aTN0zHr7cdaz9xqvfa1X9+d2foSb/jxQ/D1u+H7Q+tsNeixzLsFGinQ4M8sIE4wLXXOXjODoc399owt7bZYOx2TIttPQ5rj8MGO0NejHS/GO4eHO4eGoY1bBvcljIATH3Y8uj5w7sDV690Hjp5XX/weuM3N2oOX1MdvrS77eJOw6lChXjlmvAZHuEebusIU7fNIG/xIm0i4ze5E8PJ+HAP/EZPtzBPXPgMoNGz00JWKViU+nSOoUBiKgGWDGMoA8FanMctQxmz51eWDO7l0ia5pKlYDNJYLAJpko8GOyYIzwvqi6A9GwukxjxZU7Zkfyq/RszV8lhqFkudDNvTx9RZBQfV8TRAneMEWPhqKk9D5aliR8vPCiqrgsYsiYyhffLZaiJxmds0H8J0//lempL8n548Rs0bCATi7wASaAQC8cZgtQydbjWsn0PeQHDZQHANJeFCyPh1HsT1XqR1XsRQL7cgD1e4XWUGKfq9+cKVy4o2haWs9Q2f4x1AwgW5EwKI+CB399gPFhdtja7lpuznQ42u5WXUsGE1uo6bczi3oqvu8D3dyS79qXbjqdvm07eaT91sPnGr7WTXsbPdl6487Lj908B9y9N+mxU4dD+wZ5vjIYjV8XC0cgzbl3uHHL0WR//Q8ADsYHbAcjUMJtk2+JI+YNh2e58d/Gq4Z3Cke9DRPeR4AN/N1u8YHHC8eDT4qPvJndv3z51rbz16W3f0duORjvqj7bXHbmqPf1t56Pxu46G8PVvnL1zvTQ4huwQRpoW648O8yLRF7+SEBOZvCJH4+kQtnBM2kxTmRdjo7rZtlgfjk0WiNV+lrV9dwaYYCyTm0jRjeZq+FNuuMs6ex2bSOe0ZVpfl4ka5uKFYBNI46s3QpJ3Ry8XGYqDOYkOBSLdD1JQp2i8TVgm4KhZTkcxSMljKRLYqgaWMZ4Oo6BwVnaei89V0gXrUngVqGl9D46uAQFO4SiqnksKqpCXvpSXyVq32d3df5jrtK7e3Vs0iZCVTUfMGAoH4+4AEGoFAvDEMvXhhUu8L8savJ7iuw7sAawyfPSPpi89Fq1dxly+lf/Lhprkz1s0AMk1Y703cPNsz8ZP3s0IDxKtXbJjpEeSOX0vEBZDwQWRy9KIPirdFNwjTgEMDga7lZNRxMmvYmfW83DNltfd0J+4aT3eYTrebT3c0n+0wg5y53XzqVtup20dOd5290H396sDd20/67zz7scfy4pHN+thuf2JzPIImPfwQeLMFXh8NOh4NDj96MTIwONw/FqDUMMP9luEBq2PA5oANITb7gN06YHna++Jx90/ddx7evtl97sKdo6faW4+1G491NB3vbDx2p+FYV92x29XHr2mOXKgwKVmyQC/vYC9iANnVn+SyfraXJNBPzWMdkhceLZe35GVVsOJTQv2i3p0X7kna4kXeBK4zyFtmeyR+8X4FM7a1JN1clmYoe7mkEBPo0Z6NceVnOFUDqrOwoUjYCGQaPigxFEuxTugUfaFUXyAx5El02cL6dF6NhKPhs5TMZEVicmUCU5HAUdC5MHFsRRxHCdeqc4E9O+N0aCx84NBKKlcVx6+ksCtprH00Rua6sA1z5/q4uSzBTVnqMZUXEXr1/CmrxTLxC4FAIBD/I5BAIxCIN4bnz55q5LlrPXGhBJgt82Zlb9igYXJrBWItm7ebFpceHEz5cNGmOd5hM0hh3oRNM0mJn3yYF7ZesNJnnTc5kIxbS3QNILoFkoixHy4uiYzF6tCZ9dzMek5WPTerlpmplxRfU5nvGk52ms+0N5/ubD53x3y+y3Su03yuo+XcrZYzN1pP3zhw6uaR052nz9+79O39q9f6Om4/7r7z9FH30E+91hcD1qGHNssPVstjEIvlhyHroyHrQxCLBYv1odV5P9Q/9KLP8nPv0PfdP/bc/aHrdt/1K92XLt09cbbj0KnOthNdLSe7TKc6DKfa9Sc7m47fbTzaVX+0ve7YjZoj32paUtdHBXh4BboT1pJcAz0IOZs3NmTIju7ZdXTv7mMVe05W7j2t3N1SnLM3IZa79IuI2TO2ents8iCGuxM2ehGYSz8Gyttalm4uTzeVvRJoQwk2k26cPY9OpsMmbOgKJYaiFEORzFAg0+el6HKkjVmi/amCWgm/is9Ws5MVyUmVjKTKeIaCnlwZD6QZ2DC4cpV0nhJc43jOjDn0mEkr4/gKGvxVBZVdQWfu2Lh527vvrsC7LHObuow0lRaw7ESbYWjwOdrajUAg/j4ggUYgEG8Mz5/+XJGb4e+BC8K7rnMnCXxXGDOyWnOKzJmFxox8nSy7TiDdGUsRrVq5bd6sMG/iRm/C5lneyZ9/VrRpo2DVsvUzoEMHkt1gKZpMinz3vYzgjVqGpJGX3cDJbAQOzQYanXMod9/1mrau5tPtzac6m8/caT57p/l8F0jLpY6Wi+3NMLebz99qOXur9eytttO3D57qPHLq3qlzPRcv9V379uGta9933vq+q/37ux1P7nY+vnv78Z1br6Xr5vcdNwZuXem9fqn30uXes5fvnrjQdeQM8Ob2tpMdzSc7m0/faT59z3zmrvFMu/H0bSPQ6BN3mo50Nh7uaDh6u+HoZU1z8vLgIPcZQSRiAB7H+OwTc1bGQXlRa4m8BaS0pK2s5OjushN7yo7vLNalivM3bWB+/skWb49wd2I40OhZ5B2bg5oLU8ylaUCgJ7RwYOr8KsCbdYUpunypLlfSmC1uyBTXyQTVYm6VgKPhMmG9mcGqTGBWxgNpBlemgs6sjEuupDGVNKaCCq6cMXWeLNDKeBgFnV9J4wLV3kdj7gjbErXog1UE3DLcFB/i1OgVn7Y1VD39+UfU+oxAIP5WIIFGIBBvDM9//lmRn+VLdvXH40LcySXbtx/IK27OKjalF5nSC42p+aa0PKMsW5PEzgwOiVzw9novUpgXadNMD77P0j2UWK6Pz/oZXoFkvD8J50d0WYOfHjZ7Dnvpmp1RiQ289EZOJtBoINCN4qJDxerr9Yc7ms90tZ7rajlz98CFzpbzXa3fdjZf7mwG12+7mi91mi90ms/DBg/T6XbTidumY7ebj7W3Hes4eKLr8Kmuw6e7jp65e/Ts3SOn7h45OZY7R07dOXyy65sTnQePt7cd6Wg5DnS5swXkDLyaYbpATKfvms7cMZ3uMJ5qN57sNJ3o1B/r0B1rbwI5fkllpH/pG+juFUgiBODdSrZtPZibeyC/oCWvoKWg0JxX0JxX0Jaff6Ag/4i8+Hh5WXNuloqTnBK4duu8eWEenmGepJhFc5Vsmrkow1yaAQ8UOo8VlmCjNuCIOqmuUNpUIGnMB9IsbciQ1slENWJ+lYCr5XJUTJaSkVSZkFRJT6yIS6qksSppnMo4NgyNraCxK6ksTKBZMHFsBd3Zy4HZcxzfGSUMz2nP4FeVcdzKOE5myMbt732wmoDzwf1jBWnKls/eaazY+ePjH1DtGYFA/N1AAo1AIN4YBp8/q99dBgR6DR4X5O5euC3iwI7i1kx5S0axOa3QnF5oSiswpuYZZDl1fEnOxk2b585d7+m2wQO3Zc7MzKB1X8fE8Vf4bn77bX8izp/kssbtLV/c1DVEcsS7HwJ1U8Vzm/iZDbzsekFeg1T+jbz6VtOJu63n77Sdv3PgQlfbxc7Wyx0t33Y0g+ulzpaLnc3nO81n201nOozAoc90mE7BmE91wrr1aUyLnfcgsK7sjPPH0ZhBTnUBTcfitOexQI2GJn2yCwr0yQ7jyXbDqXbdyQ79yStac8JXvmvd3dcS3QJIhH10eltOTltObtuO/NacgpbsfJDW7NyW7NzWnLzmHfnNhfmmorz9GZnpG7dumDF3PZkc5kXgrvjctCOjRZ5jLMkwyNMMxam6wpSmfGlTrrgxR1yfKapJ5VdLeVVCgZYnULM5qmS2MgkeClTCQ4EsRRxTQUtWUJmVVM7LsGGgQ3MUsHnDqc6cyngo0Fj5GaqzmiYYc2igzhXxvAo6dzclKWVt6Nb5C33dXJe7vbWU+H/blry3f7f8h4G+EbSyG4FA/P1AAo1AIN4YrBbLUWOj/yySL94lgERk+yxvzcxrywIOXWyGRegicDWmFRjS8/XpudWCFIGv33ov4np311B3fOSChWWR0btj49ICQ2Pf/yDYg7gGN8UX99Yy3NTluOkh3t6Jn31ZvCW6miXZz8+sE2Q3SIqOlVXfMZ2+d+Di3YOXutoud7Z+CwS6vflyO+zluNDRcq6j+ext6NBAoGEdGqTTPN6DMXueqMW/4Mqv4rRw06tXdZlO3QE/Gk/B9zee6TCAnL61/xBzeYAf2d2PhF9LIuyl01uzc9qALmfltmTlt2TmOdOcscOcscOUkaPLzm7M22EqKm3MLKB/tiyE5B5Kxq3zJlQkJTSkS/dnSurSxXVpwlqZABhztYSrFXLUPI6SzVIwmUrozRzgzYoElgJ4Mx0EyrGSxlbBGrNTl7mj0gy92XlecCywN0MB7JnGU9H4KppATROCG/CjggYLz3viWMVRNJaPb+is2SvxuKW4t5Z7TN22/MP9+0ofP+wbRvaMQCD+liCBRiAQbwwOh6P96mWK71erSNP9CK6b5szZS4tvyypszSxszsAEOqPYmFFsyCzWZRQ2puXvTmBHLlwQSnYLJroGkdwEK5ZrGLB0Kt8SzVmyPMzLy9d16jLcP5bh3vJxneqLd9309nzuitWlUTQtS1zHT68XZZ/YVX235ey9A5fuHbxy58CVzrYrHS2X21sv3W650N5yrr3l7C0z5tDmc+2mM7Aa3QyDue9opbnLBPsxXgvWoeEMMGZnRu+NL4M9Mhrj6ZcCfbbTdL4TXPXHU9ZFrCK6ryER1xDcCrdsacvOac3a0ZaV25y+oyUj35nmtFwQU1q2LiNzf1aWLq/EXPB1/jZasLtnEAnnh58qCfBXsdlqLk/N4cCwORoWCFedzFExgDRzlAkvA6vIzuoyC7Y10zgqKkdN5aiAN8c5g5WcgVhj0qyKx+Icu0Hjq6kCLEIQ4NBKGh84d2Uce09sUua6cOriz4I8PJe7TvPBTVnhMZ3i96W+quLxowFkzwgE4m8LEmgEAvHGMDIy8uT7R7uzpP6ziKvw09YS3RI+/ayKxW/NzG/OKGjOLDJnFhszSwyZJU0ZxU0Z8lpxTop/cDAJH0CYFkiaFrVgrio+uSpRpI0X79uelLY6mPL+B4GexBX46T6uU4BD+7i6+Lu7R7z7Hn/lmoLwbXtpiRpuyqnK+vsHz98/ePnugcudbZc62oBAX77dAs8Rgtw0n7sFc/6W8dwtE5Tp29CkT2PtHCc7TCdfOTH04PHB6soGmEm/gsHs+UznaE53mMHbnuswX+gwngO/Uguylrm5ryKS1hDwtMWLjanpB7JzW9JzWtNzW9PyW9IKmkFS85tT88yybH16Zn1Gdn12cVPOrn1MybpZcwNIbn74aeCFKgZbkyRQJ/HUDJ4Gi5Yh0CbwNfECNV2ojhfCGRpY+7KSxlVQOUogzVSumspTY5ObwT02YQOrOsM4f+Rh856xkc9wUJ1IQxsNLD/HCRRxvK9jGHkbt/GWr4lY8I6fG87XddoqtylrZ+DZG/wPNFT9+OSHkRFkzwgE4u8LEmgEAvEmYbf9/+ydB3QTR7v3773frd93730TuisQQt4UUklCQgppFJveSSjphWIMGPfecO8VU91tcMG9YINt3CTZlnvvuPemrt39ZrXGMbvWSrKNgbzzO/+zR0jPjFa74vg/o2eeEVSw8s/s2bxt5bIdaiv2rV6p9/U3wed0Ui85p9q74wsK7XADHWfnE2vrHW3lfuWkzpG1f9+jtny32uLv1q72PfFr+Fnz0FNWYactAv/Q8z3xm/Wu/X9s2Lhn1UtblVU2KytvVVHeorxiz0urjq17/dTHG3Q1tnucPp/k5l8RndqcXihJhi6uSy2uSS6uTiqqTi6uSmRKxKpKYFUmMKuAjcZVWBOPV8+oAf44YZokdpkQntD8SJJX8wk9ZqMlaRv1iYX1yYV4RepkRl0yqz6R1ZjMYATH7Vz71hb1VTvU1fasWul24ofUSw7AQKfZOKXZOCdbAuvsmmTlij+wdEiwtouxcbht6x51ye+mvs13b63foa60Q3X59+veDNTSCz1nGqJtTChU2zjsnEnYWeNQLZOQM6ZAQZIyc7hOGQQC04xrct8TfOsTIDx/Y7LCxs1TxOpAQ9AKmG9wDDoDjibBZ0yCTpsEa5kEnjG6dkrX+bufLn6t8f3b7+1b8/IO1RXbVZZoqCw68s5aTwPtkpx746PDGFw1CIFAnm2ggYZAIM8X6MTYaPQ138Pvv66htnSn2vJDa4CH/iro3AU88Rd4aHvPBDtgoL1ibb1irD1Cdcx+fOu9PWrKu1SXfLf2Jaf9RyPOWoaesgk7ZR122iz8jHHoKUPfY6fNNQ+e+vjLvS+/uk1VbQu+jm35NpVlGipLd69ZdfT99ae/3uz0yx9Jbn7l0en1yfm4kU0prgUeOrGoMoEBTHNlPLMijlkZz6pOYFXjRybw0NXxBbXx+bXxubgSgPDdDR8pX6LJfxL505N69E/JNDaIKcATrFNw1eK5Isy65KJ63EnnGRw49s3KNdtXqm9XU/1l/fsRevpplxxSrYGcUqycU6zdgIFOsnRJNHeIs7CNtXKItvGIsvW9rmv93TsfaKopaaosO/76uqCz+mHnzYCHnlIYOGqbhpw1DdYyxY3vGZPA08Y3TwEbbRR4yujmScObfxjcxHcNBDK4edJAko9hNBlw2lgSDDy0scQ6GwcBG33W5KaW0Y0zhtfO6Dsf/UVvy84f3/tgz0svbVFathVcZLVFmuov/P7NhlC3S621lWKhgHzDIRAI5NkDGmgIBPIcgWIoIuRzW6vLrH/5bueqpXvUl+5fufzbV1af++xTt+PfRxiYJNu5pNh7JNl7xF1yv2PjGnrR9Od33t+tprJHbcXRtWtwA61tHnraMuyMVdgZs/DTppGnzG+dsQg5Zez/yznr/d+d/uyLg6+/ulVtxVbVZdvUlm5VW7ZVfbnGSpXda9f89tmmSyd+jbB0yrocUR59Hy/BkQTcc151Qn5VfEFlfGFVPKMqnikRPgldnVBQHQ9eBcolqSYxT14l5NckFuAGOhXfyaU2mVGfWlSTzKhNKYj3CDj68efb1NU11dV2rVxpsE0jzswyxdouxdohycoxxcY1ycol0dI53twxzsIuxtLhtqVLlLWn31njA2+8paGurKmy4ud33w89bxymYx5ywSzkvGnIeROg4HO4Qs6ZBmubBmnhCjxjchPPuzC+eQZ30jdOGuI6ZXDjlP71k/o3wDMS4TYahJ0xCgTSMpJYZ+Pgc8Y3zur7/Kplc/DYhc2ax995b/fq1RoqStuUl25VXqSh8sLu1S9qffF2lIt5c1HuQEvdcEfzRH83b2xYyOMgIhEsYAeBQJ5NoIGGQCDPLigiFosEIh5XODHKGegebq/vrSvpKM9vzk9LcDHT/vydvWovHli55OCqZQdXqfz01jqDzZudjx6/pnX+tolljOWlaHObq6fPHnvt9T3qqnvUlI+98orXsR/DtY1CtYxDzxqH4IkKxhGnTG6dMYs4axKO20d9719/N9m147u3X9+iuhQYaImWaagu36q8bPOK5TtXr/lpwycGuw65/HI22PjS/cuhxRGJ5bEZVXHZVXEPKuPyquMLquOAmQaWOq8qPrcy/kFlQi4u8EDyuCoxD6g6KR9o8rHkOCXipakna5IK8Lzq5ILalMLa1EJwrE8rqkkprEktKE/IDDAy3/XKKxor1bepKO9/eY3Zjp3B53WSrC4lWtolWtnHWzrGWTrFWjjFWNhFW1yKsnC8Ze7i/OPpnS+/rKGupKGyQv8bzTAds7CLlqGEh75gChQMrgP+wCz4nFmQtlmgtvlNLdObWiaBWibgeOMMkPH100bXTxtcP2Nw/ZT+tVMG108b3sBlgBd7PmuIS9sAyP/Xsw5HvtfX2PHHJ599u+7NnatXbVFetlV5yTblRdtVXtip+sL369Qv7f48SudnZoBT1a0rFZFXKqOv1yaFN2bGteff7SrJ660u6W+uGevt4I0MCjnj4JsgFgrAtwLmeEAgkKcLNNAQCOTZAtgjEZ/HGeof6WjurS/rKM1rL7jbcj+uKSW8LvZK5S2v0jC30hCX4qt2MXq/XPz0zUMrFx1cufig+rJDq5QPr1l54o3XTm3YoPfNZvPdu20P7tfb/MX+l9T2rlQBBvrEa6+6Hv7W9/sfvU784Hn8R/fjP7kd/dH18Peuh447Hfj20p6Dljt2GW7ZcnrjR0deW6uptlxDdZmm6nINlWXb8Tzd5RrKyzVVlTVVVXasVN/7yt+Pvbf+3FYN6+M/XL5oHG3ncdc3iBGSUHUnuyY+tzoxtyohpyohuyoxpzLhgcQK51YkPACqBI+TgPIJgX/i9jox99Hz08y05J/VyYXVSQXVyfl1qYV1acBDF9SlMqtTCmrSCmvu5pXEJtv/9NOev6/dpqaiqaa8/6XVpz/+2PXYiZALurHm1ncsLsVYOERZOEWZSwy0md0tU/vzm3dorFLfvkp51yp17x9PhV+0DNOxDr1gGXrBIvSCeegFM1w65qE64BnLkPOWQYQuWAbrWASeN795zuyGtsmNs8Y3tCU6a3RT2yhQGxwNr5666PerlscPvzt994PF7gMXv9n6+4aNR998c/eaVRpqSrh1VlkKrPPWFf+7W/3Fn99ebam5MejkkfuW2iwHwyInI5azEcPJkOFsxHQzLfayLPG1Lb1sX3rdtSzUpyr6Wm1iWMPdmOac5HZWdk9l0UBj1UhHy8RAj4AzPmmpIRAIZAGBBhoCgTx9UNw1CwWc0ZGetp46disjs+5udEXsDXa4T0mgK/uKfZm/dYWfRYWfaflls9LLZmVXLKuu2VT4W8cb/Gb45btH1yw9tHLJwZXLDq5SOrBS+cAq1UNrVn336ssn1v39yKtq+9es2LdKZd9K1W9ffun0h+tPffjuHx+88/sH7/72/vpf3n/v5/fe/untdT+8+frx11458vJLB1er71ZV2qm6fKfaiu2qy3GpLNulprR3pfIu1eVAO1WBn16qqbZMQ23ZFvDqmlVH3nn3t8+/1N11wPbE795aBtf1rSJs3OJd/e/6B2bfiMwPiWNEJLFupbBupxZHpZVE32XH3GXHZpTGZk6p7A7QvbK4e+AI/gleZccA3S2JTmdHZZTcTiu6nVJ8O4UVmVQYGp8TGJt9IzrzWmRaQHCST4DbH7/vfXWt5kpVTTWlnWoqO5SVvl+37vwXX146dMT3t5Mh+qYRppciTCxvm1reMrb0/V378Otvbl+ppqm+4rePPgw6px96QZKqcdY4SBvISCLDQG3Dm2eNbmjhunLaIOC0fsBpPSD/kxd9fjvn+bOWx0+nXX846XjsV7tvf7Q5eMxs90FDzT0Xvt52+pNNP7//4fG33j7wytrtaipblZZtUwZajPtmpRc1VRbtXrnk53fXWO/adOP3Q+nmWkwXoyJnw2IngyIgR32mgx7TQZ/lAB4bFjsagiPL0aDIARfT0ZDpasLyMGf52pRcc2IHeZRHBtQkhDblJLYWZXVUFPY1VY73dQi5Y9BMQyCQBQAaaAgE8jRBEDF/YmSoo6G97EF9Vkx53PXiEDfWlUsMHwumpwnLy7TY26zU26zcx6zSx6zK17TC37zc36wiwKLyilX1FdvyyzbJFlrOh7acXL/2yEtLD64CWn74JZUjL6t9+/LKwy+rH3xZGWj/SyoHVqvuX6myHzjp1Up7cSnvXa0CtGe10u5VK/asWrF75fJd6st3qy3frb58l9qyHUDAKCu9uFttke7XG5yP7DT46qPf3n3lwKplu1QW7VRdslMd2Gt8ilpTdYWmqvLOlSv3rll78NU3jr393s8bNp7e9NWFrRq623ca7D1gdPCI6ZGjZt8eszz2vdXxH6yO/2h94ifbH34hdOnH3+x//N3uh19tv//Z+sSPVsd+sDz6PZDFt8fNjxwzP4zL7PB3pgePGO8/ZLT3oN6ufXo7917YvuuchubZLZu/X//OrtVqO9WVd6or7VJV2qWitEdVef9KtWOvvfrH++9f+Opr4x27rPfvtz9yxPbQoVMbP92prrZdTUlDednxt944/+XXF7745vymr8999tW5z7489/kXQNqfbdL69PMzn3x+auNnpzd+9vtHn/z20cbfgTZs/P3Dj3/9YMMv73/w4/r3T7z73tG33z7y5roDr726Z+2aXS/hRak11JS3Ki/fqrREYppxaaos3q78t51Kfzuwaukf775iu+uL0DPHMqzO5TvpM50NmM7gqM9w1it01mM46RU66jIc9RngJSd9luQIXDXb3qDETr/YXo9lr8u0v1hod6HQ4UK+/flcxwv5rroFXkYFfubMK7bsINfq6CuNd6P6a0uEE6MwxwMCgTxRoIGGQCBPDbFIONrZ0pqbVB13jXXTvtDXlOFlxPAwZErE8jQq9jJhe5uW+piX+pqV+ZqX+1mU+VuUXbYoC7AsC7AqBwIe+pr9AxejsPPf2+/76vSHfz+6Vum7NUpH16ocXav63Vq1Q2tVDrysfGANrn0vAd+8Yu9LK/Y8Ev7P1cv3vbRi3+rle1cu3aO+ZLfa4r1qS/aqL92/avnRV9VPfvCaze7P401OFbqbp5mfi9D63v2wpuGXH554ddV+4LnVl+1UXbpDDRcw09tVlkmyPoBWaKiu2KqybKvS0m3KS7fhNT3wsh7bVMDzSttUlYDR1FRX0VBX2aaurLFKVRNYz5Uq4MltakpAW1VA2+W4EwWtVJeDJngrSSfAr29XW7FDVQk/qgPTr7x7ldJO9RU7Vy4Hjn8nLuD+l+9RW7FHXQkcd6mt2P+S+revvnz0jVe+fX3t7pWqeFvQp/KybUpLNZTxvBTi8bYVSx5p8dZHAv/csnwx0OQ/l+PPaCgt2bJi8TdKi79RXvy18pKvlRdvVl6yRWXJVpUlW5QXbVVetE35RQ2VFzRVXtwJLuaqJT+sU9f7Yr3roW0hp45mWJ7DkzScDRm4b9ZlOAHHrFsoEcNRj/lIrCk5ABEz07oMIEedQscLhY7nCxzP5Ttq5zmczbfHVWB3ttBOm+FwodBVnx3s9rA4W8Tnkr9tEAgEMn9AAw2BQJ4aQs4YcM/sq7bFPqbALhd5GBa5G7DcDXAD7WnE9DYGKvIxLfY1L/YzL/GzYPtbsi9PqkQi9mWrsgCb0ss2bH+bHEf9Wxd+cD+yzeTrD85/9MbJt9f8+Jra0bXKR15ecfjl5YfXLD+4ZtmB1Uv341qyDxxfWnrwpaWH1yw7+orS8ddUflyn/vs7L2t9+Jrupvdsdn7hfXxP0Knjsfq/37fXKfa2KPWxKvexLvW0KnQyTjPVDj513PWQptHmjac3vn387TX7Xl6xQ22RpuoiSVG2JRqS1YdbVfGJ2J0qi3cqLd6xYtF2pRc1VyzSVFqkseJFjeXgiPvRLSsWbVFevAUYUKXFW5UWb1NZvFUFP2oQR+XF21WWbFcF7nzpDpUlQDtVF+9SW7Jbdeku1SV71JbuXblst/qSnWqLdq1ccvAVldOfvvPDu2v3r1mxS33x7pVLdqkt3qkGXsVn03eqL9+hvmw7viASt/jbVJaCdwQ+GD8qLdqs9CLQlhUv4uez4sWt4MFy/LhtxaKtKxaB4zYlcOaLNVcs3q4EtAQ/edBQefFWZfyENXDT/MI2pb9pKP3vdpUXDr68/Pu3Vp/66A3jbZ+4fKt54/R3d4xO3r+kl+toUOACrLNBoZNeoZNuofNFBpADLuCPWQ66RY56uMCDRwJPFjjq5jtdJFSAS6fA6UKB4/l84KEdtAvstZn254EYdueAgc5zupjrbVqfdUfAGSN/2yAQCGT+gAYaAoE8NUR8bndFYc2d68U3HFn+Viwfc6aHMdPdiOFmyPI0ZnoaM7yMGd4mDB9Tpq8Zy9esCNhof4vpYoOjn1mpv2Wpv1Wpn3Wpr1W+k0Gy0R+3zh6/8dM+v++2exza6nZgs9v+b4Bc9n/tvO8rJ6C9X7mAZw5tAW7b4zsN7xM7/H/cfe23AyFnjkbp/JRkejrLTo/pYcH2sSnxsSz2MWf7WBR7mrA9TUs9zYHKvK1KvK3yXIxTLLRv6/12/dQxz+N7bPd+rf/Nhj82vH7irdUHXlbavXLpTnXcwu5TX7JXddFu5Rd2q7ywW/nFXcov7FD62/YV4PgikKYS8J0vaAD3SRhQ5UkPCrRD9cVdaouAPwZWeA+Q+hLQ1YFVSw+9tOy7tUonXlX75c01f7z7itaG185/+qbpto89j+2MMjh58/Qx5yMa+l+t//51lQMrX9y3ajHw1juBk1ZfskNt8XY1YM0XaeIGHZ8n3qr04lblF7aueGHLir8BbcX1wtblfyO0bfnfNFa8oLH8BU38bBftUl68R3kJob0qS/eqLt2tArRkn9qSQ6uXf/+autaGN4y++chu79dex3YGnvw26uLPaZbaOU6GBR6mBe7GBW7GBS4GhS76uHt2xt0zODJcdBlOFwslAg+YTrpM/PinwJN5uHSA8nHrPKlCR50ChwsF9kDngW9mOoLe9Ao9TFjXHesyogfb6sUiIfnbBoFAIPMHNNAQCOTpgaICzvhoV0t3dVEb815jVlxtclhl9BV2kFvxlUtMH/NCL5NCH1NgoIGNZvqYAg8tmYrGxfadFDDQbD+LEl8Ltq9FKZC3RamnWbG7CdPZoNDBoMBBP99erwAIPHDQIwQeFzoZMl2MmG4mwNsVeoH+zZjeZsDBl/hZsv2sSoB8LUt8LFjepkU+pkXeJkVeJsWPVAKO3ubFvsC7W7F9rIo9LJkuZrn2Bunm52N1/wjX/unG70f9fjjodmSn4/5t1nu+Mt3+mcGWDXrffHjxq/XnN7179rO3z3zylpZEZza+eerjN8HxNK51Zz5Zd/aTNy98/o7Opnd1v3rfaMtHpts2Wu3cZLvna4d9m10Pa/ic2H3l5wOBv38bcupYpNb3t7V/vKPzc6Ler5kW2oVORsWeliw3szxHg2STUyEnD/sd32635wsTjY06X67X/vzts5+9deZTyRt98uYp/H3Xnfx43R8fr/t9wxuE/tjwxskN605JdHrDm2c+ekvr47fPfvy29ifvXvjsfd0vPjT8coPRVx+bbv7Uctsm2x3f2O3e6rRvm/d3u6/+dCj09PFYvd/TzLWzL+nmOegzXY2LPU2LPUzAcKjQ3bDAVb/QFbhnPaYzkC6evOGsiz9w0S100S14JPyx88XpAj5bMussmXgGptnx4pQk09j6hW5GLH+bynDf2sTQ1tzU3poSzlAvIhKRv2nP3FpJAABDJklEQVQQCAQyr0ADDYFAnjoogoiFfC53dHC8r3OorR7YoI6i7Na81KZ7sbilvnO9/JY/O8SdHehUdO1SUYB10WWrYn9LQkWXLYv8LVl+FkVAPubF3mYlQF740sNSL3P86GNW5mNR7isRXsrDstLfqvKydVWAdUWATWmAdekVG1wBNmx/a7a/xDr74o4cuGTQIQt4ay98OSPL01Rio02LvYGBNi32MQMxZT6W5d4WZV5W5d5WZT42ZT6Xyv3sy/zsS3zsGO7WeS7mmU6GafZ6ybY6STYXEqzO3TE/G2N2JsrkVJTxqSgjoJPRhqdiDU/F4DoZY3TyjtHJRJMziaZnksy0Uiy00yzOZdpcvH9JL9tev8DJqMjdnO1pWeZtU+FjU+FtXQHe18uizNOszMscqMTTFIjtBT6+KbgCTHfj+3Y6adbaiWZn4kxOxhmfvGP8B+g/1hh/oxijP4CiDP6I0v/jth5+jNY/GYPrj1j9k0B3DE4BxRqfjjE5c8dU647Z2QQz7UTzc8kW59OsdDJs9e/ZGWbbGxW4mLE8LIs8LYs8zIs8zZnupuB9WR6ShBwPA6a7PsNNDzhjpqse00WvyBkXC8gF/yfDBX9JMiH9pybdM3DMkgcM4kngocHRxQAMeBi+ViU3XCoiLtclhLVkJXaW5A011473dgomxhCxCN9tBwKBQJ4w0EBDIJBnCRSvaCcWCkV8LvBD3JGB8b6u0a7W4bb6gYaK3ipWR3F2a35aU3Z8w92o2pSwyrgb5dEBZZG+7DDP4iCXousORVcvsS5bF/lLHLaveYmPKdvXtNTPvAzI36Kc0GXLClxW5QHWZQE2ZQG2ZZeBbEr9rNm++KQy28eS7W1Z4mVR5IWbQpanWRGQh1mxJ/Cm5iW4QzWbdOreZmw8xwNP8yjxsSzxAf7busQPCNhxO/Zlu+IA25KASyVXLrGv2JUE2JWAZy5fKvK3LfKzZfnZFvnaFPnalvjaFuOyJoT34GMt6Q2cAy42frQoBfK0kKSRWJR7mpfjvhmME0zZ3iZAJbitx1WEJ44bs7xxFYFXfcxKgdH3syz3tyq/bF3mb12Gp4xb4UMFP6ti8GElb8f2BR/fBjwGH7/UxxoMBsCR7W1V5GfD8rNm+FoW+lgwfCyBCr3MGV7mhV4WhZ7mhR5mDHdThpsp080EiOVhygAG192Q4Y5bZ6a7HhDDXbfQTZfhis83M511Jb5ZnwGsMC79QuChXfUKgFxwFbrpF7gbFHgYMXzMmOAmXrMrDXIpC/esuOVfFR9Yn367NT+9q6ygv75i5GHTRF+3YHxExOeBrwwsuwGBQBYSaKAhEMhzATDWCCoWAWPNnxgFxnpisGe0p334YWN/U1VffXlPTXFHWX47sNeFd1vyUppzEpruxTSmhtfHXauN9quO8KwMdS0Pdi4PdCi/YV9+0778hl3Zdduya7ZlV+3KrtiVBVxi+9uw/XDh/tXXCpjXIi8Llhdwz+ZM3ENbABXhwi11MTDWuIc2LfYxx9c4+poV+ZoX+VoU+VkCFftbFeGyLvazKvG3/lOS/iffwgeYV2uWjxXTx5JFyNcCCO/Eh5AZEJ4r4m1RgsucDcy6xLuzcZmW4iVKTMAIARdhoH1w4QknhI3GZVTibcT2MSnFRxFAZmxfMzCcKPE1A8JPWzKPLpEl229y6h0MBtjgn8Q0vA8+Dc/0NmV4mTA8cRV6GAExPIBRNmK4GbFw62zMdJXIzYjpash0NWC46jPdgIE2LPQwyPPQz/M0yHM3yHMDR8N8T+MCL7NCX8sCf+vCAFvWTUd2qHtFlF913PW6pJCG9NtN9+NaHiS3Fdx9WJTVXV7QV1sy0FQ58rBxrLeDM9wv4E4gYhH4NpC/IBAIBLKAQAMNgUCeV1AcRLLdt1AsFIgEPCGXI+CM8cdH+GNDvOF+Tn/XRHfraHvdUHPFYF1Jfw2rt7KguzSns+R+R1FGW0FyS058U2Z0Q9qtuuTQ2oTg6js3q6KvVkUFAFVE+pVH+JSGerJD3IuD3IoCXYtuuhbfdGVdd2Jddyy67sC8col5xQaIEWBVeFmiAGsG0GVrZoA1C3/JmhVgVRRgg8+Ig2cuSyy1v02Rn3WRnxUQ09eK4WtV6Gf5SBZADD8Lpq85Lj8zpp85yxf3r7gkZhdIkgtuMqUiP9wH4/KRpGv7So4SsXAZF/kYFfuZFPubFl82w+UPjuYsPzOWvxkLfwtwNMfljwu8I9OfkAVDcsSXb/qYMbxNC7xNCrxN831M8/HHpgxfc4aPOQOYfvCJAi6VXHUoueZUdtOlLNC1LNCtPNi9PMSjMsK3LOpy2Z1r5QmBNWAwkxHVmBXXkpvSVpjxsDirszSvu5LRW1860FI90tk01tPOGegGd403NgzGSELuhJDHAfcU2GXcMSPQMUMgkGcIaKAhEMhfHRTFcJ8tQoEVEwnEQp5YwBXyxvnjw9yRfs5gz3hfJ3BveKJIR9NwW/1Qa+1gc/VAU2V/fVlvXUlPTXFXFauzgtFRlv+wLK+95EF7SU57cVYLM7OFkd6Un9KYm9T4IElyTGzMiQcesTH7TmN2bGNWbFNWTGNmdGNmVP3dW3XpEXWpEXUpYTVJIdUJQVVxNypjr5dHXy2LDiiLvgzEvuXLvu3HjvQtjfQpi/QujfQCx7II77Iwz/Jwj7IwIPfSMHd2mHtJqAshdphrSZgbO9S9JMSNHeJWEuTKDnbFj0GTR3aQCzvYuRSPBHIrDXcvDfcojfBkg+Mtr7Jb3vhbRHpXRPlVRF+ujA2ojLtWFX+jKimwOjm4Ji2sNj28IT2y8e4t8BEa7kXX34upz4ptwD9gQvODpJbc5Jb8NNwNs7I6S3K7ywt6K5n9NSX9taUD9eWDjZVDLbXD7Y3DXS0jvQ8nBnu4w/3gmgs5YyIeBxHyUbEQQ2HqBQQCeS6BBhoCgfzDQ3g4/IhPaUvcthi4bSAxbrhxiQR8sYAnEnBFfK6QzxHyJgSccQFnTDAxyp8YEUyM4NPe40O80UEg7sgAsOa4hnu5Q73Ao08MdOHq75zo6xjrfTjW0zbS2TLS0Qz85VBbw1Bb/SAQMO5ALTWTaq6W+PjqQVxVwNAPNBKq6G8sJzTQVNEP1FjR11De31DRV18OHuDH6Woo628g4vFIiSr7myoHW6oHmnGBB8NtdUPt9SMdjSOdzaNdLWA4Md73cGKgkzPQzR3qAR+B+Dj4pxsDGgI+WPLBR8EVwKeKuRxwWcRCPiIUICIhIhLh+2njVxK/pOSrDYFAIM8/0EBDIBAIBAKBQCAKAA00BAKBQCAQCASiANBAQyAQCAQCgUAgCgANNAQCgUAgEAgEogDQQEMgEAgE8jyD8DBBIyYewBduQiCQBQEaaAgEAoFAnhVQfhcmGgammPyCdFBOIdqti45FYego+TUIBPJkgAYaAoHMPyiCjA8OTgwOkV+APG8IuLyehsa+llaxUER+DTLfoAhP2GQv7gjEhAPk16SBIthwCNK6Cx20w8Sd5FchEMiTARpoCAQynwDrzE5MCdc1DjxzASjSwKz6fg45CPI8IBII8sNuBZ29SNzKUB3Dyrv3yEGQeQXld/GKD/DLfkDGa8ivSQMVIL2OSNOXaJ82JqyBhbchkIUBGmgIBDKfZF29Sfit6arNySXHQZ55Mv2vUW9leepdchxk/kBGmNy8j7kP1iNDOfImNIuH0c4LSOMGtOc4xmeAf5MDIBDIEwAaaAgEMm901tRSLRdQpKEZisjnBiDPBj0NTdT7CBR6wUDA5ZKjIfOEqCOYm/UKN32RuOsWhgjIL88Eyq9F239CGt5Hu3dhvDQM5ZEjIBDIEwAaaAgEMm+wou9QLReh/tY2cjTkGaY0OY16Ewl1VMmdXQBRCEQoqDPj3F02kfQvwkY7VCBXGjQ6noG2HkTq16OdW7GJIAyBCw8gkIUAGmgIBDJv5IVEUP0WoYYCBjka8gzDjIql3kRCTcwicvRTgjs62lJU0ljIbC+rEPH55JefO4RDgtJjE6n/NZH0T/zS4yinnhwwAyg6eB1p2oLUvYd2bsHGXTFxBzkEAoE8AaCBhkAg8wbjVgzVbxEqjkskR0OeYVgx8dSbSKghv5AcveAgYjHjdkywtu7UWYXrGtc9yCPHPUegiLg/g5v7wUTyvwADzc1aK+pNxFAhOYwMgvbaIPUf4wa64xtsRB8TVcN1hBDIAgANNAQCmTfYCSlUv0Uo+3oQORryDFMSn0S9iYRqc56yT0URJMPvCvXEgMrTMsjRzzQohopQXpu4L0lYb8Er+JyT9j/APQNxUv6dm/+xoNZI1B2LcltQsZT5dWQY6TiH1K3HDfTDr7GhXzAhC64jhEAWAGigIRDIvNFYyKR6GkLJLp7kaMgzTEV6JvUmEgIvkaMXlroHedSzIhR09uJIdw+5wbMKMl4tqLnIK9jEyX6dk7F8IuXfCfc8qeR/5dxdys1+jZv/qaBKCxktw1CKM+ZXoe0/AveMG+j2L7DBQxg/Ha4jhEAWAGigIRDIvNHX3EL1NIRiLGzJ0ZBnmNocqSb1qWfjJDm5Uc9qSkV3EsgNnlUQfpeo1ZPH2MzJUJ5I/rfH3POkh/4/wEMDhy1stEc4zdTcDHQsBWnZN2mg2zZhA3sxTjC+pzcEAnnCQAMNgUDmDT6HQzU0hMJ1jcjRkGeY5qIS6k0kVBARRY5eWEJ1DKlnNaV7l6+RGzyzoGJM0IuMlYq6owW1+tycNyeSH01CJ/8zN+ctQfUFUWc4MsLC9/eeqaodOhCANm2eNNCtn2P9e7FxJ0wMK95AIE8caKAhEMh8EmFgSvU0gZLf1smhkGeYjqoa6k0k9NTT2SP0Z/6OEcq6Fkhu8MyDinkIr0PUEcTNWQesM54DfX+NqP0qym3DEC514nkSVIR0WxIrCHED3fIp1r8HG9XFhFXkSAgEMt9AAw2BQOaTWCt7qqchBPdSeY6gyca5632ZHL2wZPpfpZ7VlKoys8gNnhNQfie/5CAn5T+BgeazjyDj1RgqxToTiHqQDm2k7v1JA928EevbjY38iAmYUj03BAKZJ6CBhkAg80mio9T8VJTeDUCeJQYfdlDvIKEUVy9y9MLS09AUpKVDPTGgCAPT53ijREQgqDWaSF8CDLSg0Q4VDpIDSHCLkbYTRAkO3EA3fYT17sSGj2C8BAyZIAdDIJB5BRpoCAQynyQ7e1BtDRBwPORQyDPMSHcP9SYSAmMkcvSCU5WZFUjx0KE6hj0NjeTQ5wgUFXWGcLNe4dxdJuq+jaEzJD1PA0WGQpBmDcI942r4EO3Zjg0dwjhemLiTHA6BQOYVaKAhEMh8kuDgSrVcQMHauuRQyDPMSE8v9SYSAreYHP006KyuTXJ2n/p23bt87TkqYCcNZKSIl/8pL/8T8VAecMjkl6cj6kW7DKcSoCUG+gO0WxM30KNnMVExrAYNgTxRoIGGQCDzyR3rmXOgQy8YkEMhzzA0M9DAtpKjnx4CLnd8cFAsFJFfeD5B+T189hFB5SmU00B+7TEQbCwFbT04lb8h0Xq0cys2dBAbPorxgjEEFrODQJ4g0EBDIJD5JMrUmmq5AmEZu+cNGgOd4vaUc6D/wqCIQNQZKu5Pw0Sj5NemI2xHu4yQhk+nuWdJGvTDr7DB/djwYWxMBxMyZCWBQCCQ2QMNNAQCmU8i9EyolgvolpE5ORTyDDPc1U29iYTSPH3J0ZD5AxUMYKIxfI5ZGsg4OngVadZ8fPpZYqBbPsMr2QEDPXwUm3DGRA0wkQMCeUJAAw2BQOaTYG1dquUCirG8RA6FPMMMdXZRbyKhuz5PuYzdPzQoBx2ORFsPIXUfkNwzrsYP0R5JGjTw0CM/YVxfTNwMPTQE8iSABhoCgcwbYqGI6rcIJdi7kKMhzzA0Zewy/a+SoyELACpGhQ/RwetIy0GkfgPZOk9NQrdtwvcjxCehJR6a44EJyzGUR+4NAoHMDWigIRDIvMEfn6D6LUIwcfb5YqD9IfUmErp/5QY5GvJEQfmYsB0bS0K7jZEmDaR+prnnKTV8gD78GhsAHpqYh/4BGzPDeDGYqA5Dx+kyQyAQiCJAAw2BQOYN7ugY1W8Rgr/7P1/0t7ZRbyKhp76V9z8KKB8VtKHjGWi/L9Kpg7TsRxo2ku3yjGr4EG3bhHZtwzcmHNiHDR3GRv/Axi0wzhWMn447aWQEOmkIZI5AAw2BQOYN7ugo1W8RgtOWzxc0W3k/CAolRyuOWCRqYhWXJqfVPcjjjY+TX/5HBuFhgmZ0LBXt90K7dNC2I0jTNzQ5GzOrfj3SuAFt/gRt/Rxt/wrt2Ix1a6K9B7HB37FRU2zCH+MlY6IqDBmVUW0aAoFIARpoCAQyb3BGpBroB4Hz4Lr+qnCGRwojo2Ot7KLNbFLcvFtLSskRC05PQyP1JhLKC4kgRyvIUEdntLnNVIdhF42ehY+8oKBiSY05inlFuOhILNJ5EV8m2PAlUv8h2RkrrPVI/ftIwwfATyPNG9GWT9G2L9AOTbTrO6z/AjrijwlbwNmQTwMCgcgCGmgI5B8FFEH6W9uqMrNKk1Jzg8OL7iSUJqc1sYoH2h+KBPNTLxYYQarfIlQQfoscDZEw2tsbaWhOulzV93PIcTMx2tsHIu9fuZHs4gnMN1Cqu09hZFQzq3iO97Srtp56Ex/dytvkaEUA37dwXWNSn0FnL3ZW15JD/8LwSrGxUExYjzvp6YhH0B5rpHETtUTdvKkeP4pr3hZVviWu34OO583g4yEQiCyggYZA/vqM9vUzo2LDdY2oZohQsLZuips3Oyl18GEHubEi0BhoVvQdcrR0BBx8e7mhjk5w5IzQ7ijxJBELReCCdFTVNBYyCbWVloNnEPF81gUD3pd6uULO63FHx8ih02gvr0x196Y2nFLYRSMwQJr1Fn3AzlL7JMS4HUOOlpuhjq4IfVNqn0CxVvbk6GeDiaHh1pJSdkLKg6DQNA+fKWX4BoCBKHgefDEG2x+CASq5pVRQdCgQ7T6BcWIlC/umvyJAOQyk3wftOI00bUPq5j4DLVHtu0jN2+KK14TsNQLWSgHzZQF7k7DhnLg3DOV3whloCGQWQAMNgfyVEfL5wLkGnb1I9SvSFGtlV5acNjvbCqwGtUNCJQnJ5OjH4Y6OVt/Lvnf5GnU6NuS8PnCZwKmAkQC52XwDzDHwjoW3ou/YOFA/BSEw3gD+qe5BnpA31+pgNFcMXA1ytIThrm7w7tT4GZVg7zIxNETuQg4eVlRSeyPEiokjR8vHSHdPpKEZtcMpjQ8MkttIYaD9YW5QWIKDK/higPMBIzdyxJzhj0+Up94FF5B6njMq9ILBXe/LdbkFAi6X3BcZMdpri7RtRUccMaSL/CImxsQDKK8CHU1C+9zQh7/jTlrRHGjCNFe/Ja54VViyWsBQ5uct4+Wq8pkfCap+EbV5iPtTkIl6VMyB7hkCmR3QQEMgf1kG2x9K21hbpoBHzA0OH+sfIHdKC/Bq1K4IlSalkqMf0d/Slul3JUhLh9qKqpwbwU/CLQH4E7hhumVkQX1TaYrQMylPy5jLhDTNWr2sqzfJ0RhWl5sPhhPUYBrFWF7ijdFNZs9IW2k5tStCxXGJ5Gg5AIMfmdcWOGxys5loYhWTxoQR+qZz/PFkOgIOl3ErJuS8HvUM5RG4QQURUWBoRO53CvEI2nEW3zVw8CwmrJK6jA8VoqIejMdGR+PRPmek7QRST967e2bVviMq/7uAocrPXcLL+l9u5n9zc9by2YeFjfbi3gRkvBoVwbWDEMhcgQYaAvlr0lLMDr1gQP3rrpBCzukBg4ii8s5RTQxKNdBlyWnkaEnKx72A69RgekUamgPPTe5rDoAPWJuTG65HTsyVUwkOrqO9veRO5YPGQJO2nkERJC8kghomj/AagnLfRIKWohJqP4TYiSnkaFmMDwxGmVpRu5quSAMzebIguKOjM36x42wdFf2MM9LMKo4wmDnJRCGBk6zMuD/zKfFrcDfc9BHW/x0meAAcOzngMVC8DrSoC53IR/s9kOa9MupA17wlLFIHvpmT9u+c5H/hpL/AL94vengNHStFBYPklGsIBDJboIGGQP6CNBeVKJS2QS/gceWcZB0fHKQ2J1SWkk4KbmIVUxeTySlgdkd6ZulZSXBGRmfMQlZIEXoms/P0NBv+RZlaT4WJhcJM/2vUGPkFDPG0t5VNI4NF7YQQ9VbSMzE0PL3mhjSBMQy55UzUZudS2xIabH9IjlYE8CUvjIyidjsXgf871DR0dCwFbdmLNHyI12nmRkmqMssDgol60JE7aPsPSP1HZN/8aO5ZyFLjZvzXRPI/TyT9EydDSVB9DhkuxETjMFUDAplfoIGGQP5qtJdVzKN7JlQQEUV+m5kYH5BqoMtT706FoShaFJtAjVFISU5u8k+NS6OvuUVmXoGcCtMxnEUWwWhvL7UrQreMzIkYYOwy/K5QAxQSvkRPkcvVkF9I7YRQRXomOVo63NHRWMtL1E5Ikr/KISv6DrU5oVZ2GTlaboDNTff2p/Y5d2X6X33si4qK0X53pPELfMvAHk1swnOmNGjpIOPoWJoknWOG9YWisle49/970j3fXSKo0UPGazCU7OAhEMjcgQYaAvlLMdTZNeMP3HNUkJaOPAv4xvoHqG0JladlEDEogmRdvUkNmIVaitmPv79i9DY1h+oYUrudtaJMrXljiu0JQlM5O1zPGJMMNrJvBFNfnYU6axSoE1f3II/aA6GqzPvkaCmAq0GzFnNK6V7+cv7EAQBjOWoPhBSdZZ8CuOe7PpepHc6Xpg85UH4dvi6w7gOkfj3atRUbuYAJyxXzuMgEOhyBtOwml7qrfUdQsIKT+q/APU+k/Ae/7AdkrBzmbEAgTwhooCGQvw4CDjfGwpb693teVJebT34/CnQGWjIDDdxz9vUg6quzU5qHD/kM5GagrT3sotS6frPWvYDr5HeiRcjnUzshBAZCIKAkPon60uyk0AYoNVkPqD0Qqs6Sq0Y1f2Ii3s6J2pykBHsXhYqZ5IfdonZCaNa7seQGh1N7m0eBcdrkbovICDrggzRtJiwv2vENNvQdxg3DkAHFUixE3Xi56IbPpxtocdU6XvYLxPQzN/d9cV8SKlbgwkIgEIWABhoC+euQI2uqMtbKvrGQCZzNVJPxwcHu+sbq+zmZfleCtXWpTaYkj20a6+unNiRELCKc9TK4GRV09iJ//M/PIj+glcw1bbOWQokEKIoGSik/Aj4d6Eraq1MK1zMG/q82Jxfc2bKUdJpq37eNLchvL52qzPvUHgjV5uSRoykIuNxEB1dqW5KizW0ULZhIY3bbyyrI0XJAk1Q9XVFm1jk3Q0qT08ClBoNJ8IAVfQeMl8Dz1GCqKjMyMVEvOhSKtBxA6t6fNNCtn2H9e7DRcxg/BUOGFfHQKDaRjbR+N9XVZP5G5v+TTD//p7DeDOV3kxtBIJD5AxpoCOQvAm62KH+2p6soNp6+ygFvbJwZFSstf7qvuYXcgMKodANdmpRafS+b+vwcpZBbJQCe9a63Ar/XA4dKbPInbQcQkmIsbOmvMwmasnT0GSaRBmbAy4pFj/3639vYTFMQcEyOPByCivRManNC9XmF5OjHAe45ydmd2pAkYOgVrZMIoPkFYxZ7GY5094Scoy1Xp6UDxqX9re3kltMYHxisysy6Y21PbjtNKc42aJ8j0rL3sb1RGj7AJ6EH9mOjOhg3BBOWSmy0fF8e8RDSbYY0fPKngS5Zzb37n/j0c/Yb4v5UxdJCIBCIgkADDYH8FRBwuPRbVNRkPyC3kUJXbR21OEaquzc5biZGe/uob00oxc1bmjWfUrC2btbVm03Moql6wJzhEZqc10DJqODxU5CNnDOO4IQbChikXUgmBoeq7mXLnL0GDae3ood6teVRht8VafnW96/coMYTkj9rvDz1LrU5ocZCJjl6GrzxcXk2HwHuX86qzyTuXZZajaSnoYkcTQsYStEXYAFjIXnGjZOgaDOrWNqa1NDz58UNm5D6PyeMJ9X4Idq2Ce3cgvYeRgd10TF/jJeOiRoxlCdrQhrBM6Gbt091JSxS59z9D2CgBeU/IRP15HAIBDKvQAMNgfwVYNyKof7NnlLpTDWYaRjp6Y21+nM6Ld7OiTsq1+/soCH13eVRkJZOfliktF/z80IjqU0IZfgGkKNpAY5cZuozsE3ddQ3kltMQCQQ0iQSB+BVzJreRToSeCbUHehXeiqaZ5G4tKaU2IUSznQ0J8J2hNicEbCI5+hHgeyLPqkEwZphFxRKCNE9faoeEFC1jB8Y51E6mlOLqNT3ZSU7AUFZaNQ9eubTdBNcjDR8gTR+hLZ+ibZvRjm/RHl10+AYm6iT3/jgotxgvx/FoKaGQpcZJ//eJ5H8RtniiIoW3zoFAIAoBDTQE8twz1NlFM7l77/I1heqXESBicXtZRUV65sOKSvkrJIx091BPQKZum1jSzx3yxsal5WfHWF4iR9NCb3wDJTO7Qj6f3GwmCsKlrmYDkr8sNE3W8owqjIwmd/E44HJRWxF6cDOEHC0FdkIKtTmhZinFLsb6+uVZwwrcc3+rvBeHSpKTG7VPQvIUiplCLBTR7NOZ6OAq59eAhFgolPYdGy/+mGKdcYmr3xSVrRUWrxIWqQMTLGCtEpa+K27Txvh15N5JiAeQjvNT+6oImCqctH/j3F0i7o2DGw1CIE8aaKAhkOcemi02Ig3NJpf/LwizMNAJ9i7yTG9n+AZQ2wZK9kqUf3gATo9mpBEocc/yjxZAZLydM7UTQqzoO+QGUqDJgabqXsB1eapfRxrMnM+T6i5v3ZLiuERqc0IzGuiBtnb6JCJC4XrGIJLcWBFoUo0V2rG8NkdqJg+4erPbLn7wYUecrSO1w0D8N5YLwupPkPrHC88B91zxKr9gBff+/3Az/i83S4nP/FRQ9auozR0deYCJZf2/QMVIj+1UGrSgUImT+q/c3A+QYdmrPCEQyByBBhoCeb7pb2mjKdQw68q4s2O4q5t6DjSKt3MScLjkXmaiLDWd2pyQnD1gsqaf79g4KFRPDdBd30Dth1C0mQ05Wgo0a/5IirWyl3NaNEFKBQx8OxX5KLojdacbqoHurK6lX+9IKELPZEDBLAsqkYbm1J4JkdZT0oGiNKkms1iZKhYKS+KTpP1OAhRvY4b22CDNO6bXzRBXrePnLeWk/ttE+os8pqagwVbcm4hM1GHiCVkJ0JOgQzeQpi2S3t7l5y/npPwfPvsIMl5NjoNAIPMNNNAQyPNNpvQ96uSfbpwvFDLQt00suaPyThm2FLOpPRCSs7IEb3w85LzUegtBZy/OLq8g0VFqRoE8JSbEQhG14YwC5kz+HF9pE/aRBmbkUCmwYuKpzQmRcqBrc/Lo5/UJRRiYzjrveTrSimaEnNcnh0qnu07qyEfRrHpAW2m5zL3Ky1PTMWEbOngdad495aGFxas4d/+Tk7FcUHVWPPgAFQ4rmnqBjmcgrQfx3mrf4ectAwZaWGcMC9hBIAsANNAQyHPMaG+ftPlL8Py8+BWFGOrsop7JjAKWS4H6BpJdA6mdEJLzY1bfz6G2nVJhpFx7lVOpzpLaLX21CgL++AS14YxiJ6SQG0tH2l6PwIWTQ6VAs2P2lIFGEYRxm2716pRuG1vMruYGCZFAQO186i3I0dKRuhuLls5QhwIba/e3tqd5+JA7oQgMHgRc/McNVNSL9rmgjV9PzhkXrOCk/Qe/9Ht8y0BM3tyhxxDUIe0/4b3VvMV/sJiT9v+E7VdQMYccBoFA5htooCGQ5xia4hvZ14PI0U8eYD6oZzKj2IkK2EEM77mT2gkh+gWIU6S4elHbEgo5rydPHvaM0Gy+yLwdS46mMD4wSG1IVYyFrQL5CRiWczOE2gkhmvId02FGxVLbEmqSGGgBhyvn9tfg5MHHJL/BrKDZ+fyOjQM5WgrgCgBHS+0BKNP/KjlaCmA8IG2UQtW0nBAU41Ui7T/jk9C1b/NzF3Puq4u7IjFE3jQkMsgY2nkBqVsvrn6Tl/Mi9/4qUU88CitAQyBPHmigIZDnFUQslloBTUtnuOsp/IxLY3OnK87WUf61egQ0BfI6qmrI0RR44+PSpuoDFdzjmsptE0tqn4H4TuO+5FAKgw87qA2pUjQr90FQKLUTQiKBgBw9E8D9U9sSAgYa3Gh5Cm4ESu71rAcnVGhyhMAAiRwthb7mFmpzQl21sgpfSKxzzo1gebJWCBF7cP4JKkT7nJCGTeKat3g5L/CY25DREjkznmcCQXsdkYbPxFVv8LL/xivchAwXzKE3CAQiL9BAQyDPK+1lFdS/1oQy/a+RoxcEueyglk5vUzO5pSxonJM85pJ+m0aFkkmoSEtDl2cdYXd9I7UhSYkOruRmsqDZrk9OA02Tm3H/yo3QCwbU52dUe3klues5QON9wV0gR0tB2iaL0eY29BVdwNc76+pNmpEYWVo65WkZ5F6AvR1NRJp343PG2X8T1FxEeXLlIEkBxYbD0GZNceXr3Pv/wy/7AW6hAoEsDNBAQyDPKw8Cpc4ydtU+nT+i8hjo2U33DrQ/pHZFqIlRRI6mwJSe0RtlZk2OVhBpnQedvSiz5BzNKGhKIIbcTBY02/XJa6ClZwcppChTKz5n3lJyO6pqqG9BKPtGMDlaCtIGPMVxieTQR/Q2NklblylN4brGbaXl5I4koLxqtO2EuGodN0dZ2B4w101PJnKQ1sOiite49/9XUG+BCvrIARAI5AkADTQE8lwCnJm0sruxVnb0E2lPjkHpNpdQ2EUjhYr1TtHTIHWmtu6B7Kq36V4zbw4HVBAxy+WDU1Tfy6Z2S0hmiT36zfACicJzit/NdC8/aleE5DTQhZHR1LazE76VzzxBs8liftgtcrQUpO2fMmOB6o7K6hQ3qdnz0pR9PYiukjQygnacFVe+wWesF/enY3NLWUYFzUj7b6KyV3g5yqKH1zC4ghACWRCggYZAnkto5nrJOZcLCM08MaHKu/fIbeQD+Bhqb4SqMrPI0RSkpSkHPloSNxeamEXUbgnJXDxXmXGf2mq6arNzyW3kIMnZndoVITkNtNQ6FbNSTdYD8hvMCprxhpw71wh5vBnrpoPh6PSBChigthSzE+xdqJH0SnH1kiNDSYz22oor3hZUHEbGFP55gQwyinYZiMpe5Re8Le5NmqMdh0AgcgINNATyXCDCxMMYKpxaHlSXW0D9401opKf38bYLx0BbO/V8phRtZqNQKYnp0Ew9lqWkk6MfB0WQGT0TobmXV3tYUUntVs7OaTb8C5TUNhZwZcxhzwjNLiFioVy3gGYZ4iwUck5PzmqD9NTm5FE7J1QSn0SOnglpI8+cR5ucI2IxsOmxVnbUGHolOrqBYd7j7yYNFB0OF1VvFrW7oPw5/29FBWifu7D0LX6JBjLCnMXvFRAIZBZAAw2BLDSoeBy3wgr9nRM0ocOhmKB+anpJ2gQhvhDq6dHfSmegSRtwKEQTQ+osL03qKgF3dIzailDQ2YuK1gOh0lVTR+2ZkMxaKPlhkdRWU5pydYoSZTZzlgKQnJ9X/hptcgpYUpF82yjSUJWZRe2ZkMxxFIG0nzKANRcLhdX3c2h+rJCmZBdPua3zI/j1SH8oOlEhGRXPDRRBR6KFpR8Jak6jHLlKOkIgkLkDDTQEsrCgIlHPHXS8WpE/nCg6FIS0amLj4RgyTjwlbfuG3ODwx9suKPi+4pRTIhRlaq3YmOFxaH67Z9yOIUc/zkh3D7UVoVtG5uRoxaHZ1k7mDPT9Kzeorab0sGKWJSyk5ccDyVzXSKDomrl7Adfpd0oHyg0KI7+NgkgroAEEXiJHz0RDfiG1LdCDwNBIA6kXTZru+lzurm8kv4dcoJLBsFw1uWXDrxK1GIl7IzGR9MRrCAQyr0ADDYEsKKhwgMfUEDY5osIh8mvSQIVojwXS/AU2bI8hk9tWR5vNvHXwfCWbzo6+llbqKRGKs3UkRytCI4NF7ZPQg6BQcvTj0GzvMsezIqCZgZ4YknGXU929qa0IhV00knO2mEq4rjG1Q1xaOuRQKdDsO0NSsLYukYYuFgrB9aQGTJc8JVNoKE/LoPZJqDLjPjl6JmjmsOVXkJZO1tWb8u+s/sRB+SivERX0oegsvzAQCERRoIGGQBYUZLSUm/MGv3g/ypthyf/MIGNI+69I40ZsQBsTtWEoPmsVcl6f+nc9UL5dRZ4cNGV64+2cyNGK0FJUQu2TULqXPzn6caSlvQbOqsQylYdSsgIC5ajCQeM4s64FkqPlJlxPqoGWcwY6/pITue1MirG8NL14xXBXt7RvJqFQHcPR3tnXWStLTaf2Sagq8z45eiZoLLg8AqOFvJCI0d45Jy5DIJDnHGigIZAFRdwVwclQ4mb9HRkrk/cHXEEL0rwXafgA6zuGCSsxVAw8kLRVcQNPdVaM1kA7k6MVgWahnsxZZJoUjgR7F3K04kirwgGsJDmUAk3GbW3ObOpvENCkcIiFcuUOSav1Nl15oZHUtGaa5a2EwDWf9VpSGvsr5ww0OymV2lYehV4wYEbFTgwNk3uEQCD/kEADDYEsICgirDXkpL8wkfKf4r5kDJGroBg6fg9p0kDq38d6dmH8bAzliYUi6h94QjJXrT1RehubqKdEaI5WtadBas8RBqbk6MehWUSI18yeM9ISc2MtL5FDKdBs6ddaUkqOlpsoUytqh4R4Y5Np9PSEXTSitp1SpIEZzfYuWdcCqU2mi3k7ltxGPqRd6kC5c6DLUqTOYUtTuJ5xSUIyb1yu6waBQP5BgAYaAllAROP8or3APU8k/ZOwyR4VyjWbhQ5eQRq/ROrXY92aGCcUQ0YxFJW2n/CMm0EsGDTL6ZKc3MjRikCTxxyopUOfKwxelXa5wnQMydGKI23xnMzNpfH6epRWU+ppmN3qNByaMnYy1zVisgr/3Qu4Tr8bjoDLizafOUd/Ulo6s9viuypTatnsslS5qnBUSd/1hqpbRuaVd+8JeTxyLxAI5B8eaKAhkIUCRZGxct6DtyaS/gUYaH7RboTTjC/GlwGCdhsi9R8jde9h3RrYmDOxjjBUx5D69x5odr5kvuisrqWeEqFkF09ytCLQzCIH4mv1ZAxFaGZkuaOj5GgFkVYzWGZlYj6HQ201pbnkCic5Sd1IRZ6qEfzxCWpDQhF6JuTomehvaQvW1qU2/7MffVO6vfqkUJP1gNoVIXZSKjl6JmjKuUwXGADU5uTOOtUEAoH85YEGGgJ5wqAIKhpDuG3ISJGgRo+Tvgi4Z1zpi4StvsgoG+F1YAiXWBo4AygPbTuB1L2PG+iurdjIBUzUCoLvWNtT/+oDladlkHtYQGgylVPdfcjRioAiiLRZZKD+1jZyg8dJ8/CltiI0xyHHWF8/tU9CbaXl5OjHmRgaoraakpxbBs4ITRE6eepgjEr/UNFm8hYap0m3IJTi5g1uK7kZLXW5+dR+CMksB05Asyc8oThbxyZWsaInBoFA/tGABhoCeZIIB8VDD0TtAYKq07zcDyZS/u9E8j9PGmigtP/lFnwhqNYRdYYgw0xUPDFDpWRBI9K8B7hnILRzMzb8AyaqxjBxpt8V6t9+oHRvGSUpnijAMlJPafLEZNXKkEmkoTm1W0IyTTAr+g61FaHCyChytCKwE1OofQZKtmiRWYJjpKeX2pBQuK4ROVoRaPYRLE+9S46mAAYk1IaE4i/JXU0FRe96X6b2MF2KbjtPM38s51benJFRaltCSc7uNIndEAgEMh1ooCGQJ4h4hMFjaXIylk+k/MdE0jTr/Kf+eSLlPzmZKvyy7xFOE3UeGh1Lw1cQEgb64VfY4AGMn4WhvJL4JKoDCJT4Nu4oXX7qE6WlmE09JUKZ/tfI0QqS6OhG7ZZQXW4BOfpxWtll1FaEIgxM5dzdmoqIzwfNqX0CJTt7kKMp0NTXi7WyJ0crAismntonobyQCHI0hc4aqak4Ka5e5Gjp8MbGbhlJHfYESr6ufc0t5GbSaWYVUzshVHgrmhwthRm3aQRnMpekc3rAFwz8h42zdUywd6nKzILT2xDIXwBooCGQJwgqnhD33xXUmfKLdnGzX+Ok/fd0G81JX8zJeYtfvE/YaIcM56MiDrk96GHAF238ctJAt0sMNCcYQ0Y7qmqoJoBQ0Z0Eci8LBc2G29nXg8jRCkKzaV+prPxX3vg4cEjUhoRmXTAOXGpqb4Sq7mWToynQ7Dsjj/+mgWapXIqbbAdMMxDK8A0gR9PSVVNHk3sDFGNhS62FJw2agVB+WCQ5Wgq5QWHU5oGSJYNzT4inAuxyupf/9DcC15B+2SsEAnn2gQYaAlkAUJTfLe6N5xfvl3hoIn/jb4Lqc+KBe4hggDrx/AgE6dRF6j+aNNBtm7DB/di4PYb0iQQCaRXQQs7ryVNp4UlQnzfzPsmB87HHODMqltqt/J1L2/wcKNLQbBZFynoamqSZcvA8Z0S2FettbKa2JQTOlhytCK0lpdQ+CYEPS46mQHMfZzEQkvZryZQKwm+R20jhYUUVtTkhmRtSTtFeVkFtTijO1pE/PkFuMDeK4xKpb1SZcY8cB4FAniuggYZAFg5ktIib/dpEMl6Fg8fajnJbZFThEI8ibSeQ+g8mDXTLZ9jAPmxECxPjtepyboZQ/zBP+YC5197qqKzO8A2ItbLPC42cGJSxJTVBTbbUIgmzLv07RXVWDrVbQvKsUKRZfwaU4XdFoR/WwRBFWvJGoNwus7dJqoGeY8p4f4vUJGYgAVdGcjbNBLb8E71TgAub4ka7MbiWTldNHbnZTNDklsh5zTFJWcNIA6kbzcRfcpLz2y4PDfmFM07Az7GqIwQCeepAAw2BLByoaITH2slJJepAO2IiWWW8eJVoy36kbv2kgW7eKDHQRzFRFbAB9PUEkp09ZC5ikwYwdiTHAwyHPLPaNIUX2Akp5GgFodkx+7aJJTmagkggkLrBtUS5weFyeuiBtnaaFY1AwL+S28wETQ70HKv+8cbGqX1OSWbRkrLkNGorQrMbCE0MDdNf/GhzG3mqjnTXS/3O3wu4To6WDs0HDJSU2AOjR3IbBeFPTICRJ7VzQjK3z4RAIM840EBDIAsIiggmdyL8L3F/OipjJ0IUHb6NNG4m3DNuoJs+wvr3YMOHMV48huIJ0ylu3tS/zVOKsbCVaZVIDHd1Z/pfo3YFlOjgOkORkMcpSUimNiRUlZlFjlYQmh25A7V05MmjlZlLkO7lR1+cGDjsqnvZIef1qG2nJL+Toyljd8fGgRytINIyfALlqGRHk9vNiokjR8sHTfoyIXnq0NHsFZ8ha9ua6Qh5POCSqZ1M1/0rN0b78JrrijLa2wuuEv1WjvJ/SSAQyLMJNNAQyIIi7o7iZKhwH7yDjFdJT32WgHLRLgOkYeOUgUYaPsT6dmHDh7AJewzpARF9La0z/kA8paCzF/PDIsf6B8idUwBeITc4XFpSL6Ghjk5ys8cpjIyitiLUxJRh2mSCiMU0e3MMtD8kN6Ag4PJofrsnFKZjCJzcGMU5cUfHarIfxFpeojaZLnCGIz29pLbSEItE0jb8A+dJjlYQms0Iy1JkbNrHuB1DbUVIHpsrDWmr9wiBSyfTsPa3tlMbElK0gGMjg0XthCwtnUy/Ky3FbJkJUWKhqLu+gZ2QkmDvQu5kJs39vwMEAnm6QAMNgSwoyHg1N+ctftn3KI/ejKIoh4G07EPq8S1UJlX/PtazExs6hI3+hImKMFQI4hi3pHqdP6Wlk+bpW3Uve6CtnfRD+Uh3T11uAalKgDQ9rJBRbvne5Zlnr4HkTHKlR9r2MUCNhUxy9Ew05EtdHkfSbRPLNA8fcGXAMdqMdmPqaSpVsLCxtHlQMC6SM59EGtIqhQPlhcrIYy4Iv0VtRWguqTgCLhdcVWqfU5KZx0yT9JLm4UuOlsW9gOvUfmYUGFgmObmBEWZ5Wgb4pk0JDEXAk8A00wztqIq/5DTHmwuBQJ460EBDIAsKKhoRlJ0QPbyGiuiqNKDIGNpjgzZ89qd7JrI4ujWwoYN4FgfHG5+ERhGxUJTo4Er9I02jcF1j4AiB6OebqZK5uTTNjtky28oDTSU7+VML5LdNigp4LEXLkwEvRe2HEH0yiUwKb0VT+yQksxRdXkgEtRUhRUcIJGjKaODS0qFPtR/q6CI3eSR5FpKSEPH5ck4Yz6PCdY3k/40CAoE8s0ADDYEsMCgyzED5XRgq3WmhQnz/lJZdj00/Ewaa2EsFGOiRnzH+XQydANETQ8P0E3vzImBeyef5OGP9A9RWhIBTV9RZzkhZajq1c0Ly133jczixVnbUHuaoSEMzcCPIbyaLdC8/aleEZCbM0FOVeZ/aJyE8nZ2W/DCpq9/mvld89vUgardTYtyKITeYBk0evPxfgOlwRkZpcl3mXeBLIk+uEQQCefaBBhoCecZARRivHGn/CanfQHLPuIFu+QQb2IsbaKCxi5iQhWE80Gasr/+JeugEB1eZtc+66xuoDQnF2zmTo2cFzfYxYTqGqKw1jlMAr09fRkNRheoYKrSj3hRZV29SeyM0x43xaBbtRZvZkKMfhxUTR21FaO4FjIFnBTeL2vPkuZnTnRsY/EjLGs+5EUyOlg/+xESyiye1w3lXqrvPHH9VgEAgzw7QQEMgzw4ohnIl7vmPqc1TyKpf/2cWx/ARbNwA99CT89BDwKdS/2zPXdk3guWpcTExKLWmRFFsPDl6VgCvQ7NoUqEskZGe3vkacoReMOhtbCK/gXw8CAqldkiou66BHK0IA+0PqX0SkrmXSt2DPGorQvV5MnZNlweacofAW5OjH0da5ZlmVjE5VG4QsRjf/Fz6V2uOAhe8oYAhs4gNBAJ5joAGGgJ5FkBw6yzqREcTkdZvkfoPyb55+iR080a8FsfQoUfz0Ocwfgom7gA9iATc3OBw6t/vWSvGwrattJx8stLJmGnhWsg5PXnKgMgJTdJwfyu+v4z8TAwNJzm5UftRSNHmNnPJtZhxmzpCo71zypTFJ2spfRIK1zMmRz/OaF8/tRWhoc4ucrTiiIUiaenyMncaH3zYEUqZwE739pf/9wdp9DW3KLqcQKZuG1tUZWbJU+IaAoE8X0ADDYE8RQjf3I/xa9HRBLRLF238HKmf3DaFRmjrZ2jPDnxb76GDEid9DBu/hPHTMHEDhgw8LC+JkVVtTaaAda57kKdo4jJ/fIK8KktLB/RDjpsDRbEzlygO1taVmWRCRSwSFcXGK7qYckoPboYAn0ruVBGkFTaeex1owC0jC2rPeOfW9uRQCjOu15SZBy8/M242HqSl01ldSw6lMNzVDYZqROGLSENzMAgBjpwcNDtQFIwYk5zdqeemkMA36t7la+3llbDaBgTyVwUaaAhk4UEwhPPIN8ejPeZIywGk4WN5rPOfavwQbduEdW3FgJPu343vUDh4GBs+jY27YvwUhF9dm50Wa6W4jdbSSff2Bx5i1n/4geeuyX6Q4RsAnHTW1ZtdtfXkiLkx1j8Qcm6GfUwKI6PIoXIz1NEpbfsYaUpx8+qun1OKxRTUmnEh5/V7G5vJcYojbS1g0Z0EcigFMBpJ8/Sd3gq4Z3kyeeQHz5qY1j8wxHiegyLMfdZZGsCjl8Qn0fzcMaPCLhqB73x9XiF3lK7GDgQC+QsADTQE8oRAJaKAilF+AzoSg2+S0rwHz3VWyDeTtR6v1NG4AW3eiLZ9jnZ8g3VroH17sMFfsNFLKOdOV+X9gohIaT+X/yktnWQXz4r0zImhIfIJP3s0FjJJc8bAtYhFc52DHOnuAc4y1kpqqelAycQ8Myp2oE2xXBEZoCgYchAlrkPO62X6XRl82EGOmRXjg4PUDbTBG8k/VQ8+KVHwGBhK8mvzQVdNXUH47axrgSUJyfOY5zOP8MbGH1ZUgv8aucHhYERxx8aBKAFJKNXdG4wVWTFxwPoPtD+c9bATAoE8d0ADDYE8GcRDmLAFQ/9/e3ceY1dVB3BcCwgKiqIGJZIIkbIUShtbdpBNBAT+UVQkQTFo2DRGY4wkkhA1JsR/0ARcojFGQwSKKy0tbelCN6C0023aTl9hptuULjPtvP3dc67zptCUR7fTzkwhfj65f/Wd3EzSf745+d1zmkdktPx7WP/90HHp4XXzvp/+13aMCx3jQ+Hi8OqVcdO9eX1t/99Q6untXLxk2dTpC554uj8F+otz+u/+uOtiiK62pQdfVO8Q/T238F//7f/7Fzz59GDtBO9W3rFzw4qVq2bPWTxxcv/TNmlKf0H2/0tl587Wpe94zWmHR3+/a8++P6bn/31CrfQu+78GeAcS0DA0tv8lbr47ry1tHku3p6w3bHoorL0lrPncwMeCg5fRK8eG9jFZ++hsxXnZsvMaS0bXFo2rt38zlgutEc//n6GbdgD4PySgYSiE2P3TuO6GvDQhj2/7yCyUY2lh3PpY6LorFG4MHZcfeknviuYVo7Nl5zTaRtZfPq264LTqvLMq8y+pLv9eY8vk2OhVzwAwuAQ0DIFYCZ13xM6r8t6f52Hfk52hL5bm5lsfieu+HQo3DMx1tF49uI+nv5vPz5aNaiw+o/7SqdUXPlqZcVJp+inlOeOry+5rdP8zVrvjfm46BAAOg4CGIVDvDGtvbt4a2HNvXl/TPHZjf2KebYvFWaH7Z6Fw014vIHzLs3Jstuyc2vxPlqcdX3r2qOLEo0vTTqksvLWx4fFYfq11YgQAGGwCGgZf3DklFq4Lay7Kt30tr83PY711xV6Faiy+ENfdHTou2/dEx9hsycjK8ycUJ763+Mx7ihPfV5kzPtv4eKxvM6oBAMNDQMOgi3HLb0LHFaHjguYJzeUJeSi2LtmPelfc9OOBwei9NHS2/NzK8x98o54nHVNdcG3oOehABwAGg4CGwRZ2hM47w6rxoWNcvvnmvO9XediStj1cXxfW3988IvptAV1bcErp2aMH9p5HlOdcmPUsMLMBAMNMQMPgymLPU7Hw+Wbvrv5svumGvOeuvN6W52mZG0vzmtcTrh7/loBuH11+c/u5NPUT2aYJeXCmLwAMNwENgyfW8+qy2Hn77vBtXg247ct53yN5tulAnxK+VWzELb+Oa67aM6AbbWeWnjuuuf38zIjqsvtidUguhwMA9k9Aw2DoT+ewIxZnh6479zxGI669pDkG3XN7XvpDnnXlsXrwGR2r7fG12/Y82K6+8NOlyccMbD+fnG2bEYPRZwA4AgQ0HI6Yx1qe9cTi83HTA6FwbVjVepBzfO3y5iT09lvz3h/mpafyeiGPfQOf/R1wKjqL3Q82D4feHdAvvjEAXX3lq7HS1bocABgWAhoOVcxiozv2TmjuOjczdy+HZrzxrB4XChfHzivjhuvz12/Pd/wyr0zPs9cPvBu949+h8IXd79n9BWG987exsbN1MQAwLAQ0HKpGd1h3z8FdHzg2rBwT2s8P7aMHnrHZ6gvDhu/kjfWt72xRXdX8lPDNNK/NO7l5c8qkY8P2eXk8UHwDAENDQMOhitXY91zY8KNQ+OJARo/f+yb0yjGNtjOq806uzDyx+cw4qTL71OqLl2YbHs2zntZ3tgiV2PWt3WMh1TkfK00aUZ41KhTbW1cCAMNFQMNhCnnt1bz3ibj+u6FwTesM9MoxtRc/NfDl34jS5A9V5oyvrfxJtnVarPccxAx0U9j4QOi4ZNfbKrNOKk4aUV10WygbgAaAI0ZAwyCJ5dg3NXZ+Pay6YHdA1xd/pjTl2OLEo8qzxzTW/TnWug889/xWcdufwpqrd7V4ZeZHihNH1FY9GOtbW9cBAMNFQMMginl5UXjtK3sMXXy8OOmoytxLw45XDu3KwFicGQo3Nt/Wfn5lxon9Ld7Y+GQeKq3rAIDhIqBhcIXY83hYc83AnvH5lZkfLk05Idv0VMwO9crAxrr46pf635atOLc8/YTS1JNDz7w8Zq3LAIDhIqBhsIW+0HlHWDUuWzG6P3krcy+LxdUHOfG8FzEMXM4yLls+qjztA5U5F4W+5Yf+NgDgsAloGAJbHolrrmjuGU97f739B7G2pXVBghA3/yJ2XN5YenZp6nHVJXfG6obWJQDAMBLQMPjizqmhcF22fFRp6vGNDX+NWal1RZLtf4uFaxtLzipNObZeeDjWt7cuAACGkYCGIVDvCmtvaSw9uzLrjNAz/9A+H9wtlheEtTc12kaWnjuh0f20LwgB4MgS0DAEYi12faPRdmZ14fWx3Nn6a6rG5vDqrfVXTq/MHhm2zz3MHAcADpOAhqEQYvdDjUVn1QsP5Yc/cRFLYf39tYWnV166OhRX59EXhABwJAloGBKxd0Jjxc2xd04e662/pYpZ3Pxw7eWRteX3xOrG1l8BgOEloGGIhIFh5bR7B/cl9v6j9vJ52brH8saO1t8AgOEloOHdIGzPtv4nVrpcoQIAR5yAhncLo88A8I4goAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEjwP/CmlV0myb88AAAAAElFTkSuQmCC)\n",
+    "\n",
+    "This notebook is meant to show how you can quickly parse, chunk, and RAG on arxiv papers yourself!\n",
+    "\n",
+    "We use some awesome open-source repositories in this notebook. The stack that this notebook uses is the following:\n",
+    "\n",
+    "- Chonkie (of course)\n",
+    "- Docling (for PDF conversion)\n",
+    "- Model2Vec (for embeddings)\n",
+    "- Vicinity (for indexing)\n",
+    "- Together Client (for LLM calls)"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# 🦛 Chonkie: An example of RecursiveChunker for PDF/Markdown Chunking\n",
-        "\n",
-        "![chonkie_logo_white_bg.png](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA8AAAAIcCAIAAAC2P1AsAACAAElEQVR4Xuzd91dUZ7v4/88/cM46JxGmVzoW7FETY2IF6b3asMTeGzCVoUqZBihYqdKmUe0mpmnUqLGAFHtDep2y9x6+ew+aGMyT55kn33OCZ12vda1ZEyIziPzw5l73vvf/GwYAAAAAAAD8y/7f6A8AAAAAAAAA/jEIaAAAAAAAAKwAAQ0AAAAAAIAVIKABAAAAAACwAgQ0AAAAAAAAVoCABgAAAAAAwAoQ0AAAAAAAAFgBAhoAAAAAAAArQEADAAAAAABgBQhoAAAAAAAArAABDQAAAAAAgBUgoAEAAAAAALACBDQAAAAAAABWgIAGAAAAAADAChDQAAAAAAAAWAECGgAAAAAAACtAQAMAAAAAAGAFCGgAAAAAAACsAAENAAAAAACAFSCgAQAAAAAAsAIENAAAAAAAAFaAgAYAAAAAAMAKENAAAAAAAABYAQIaAAAAAAAAK0BAAwAAAAAAYAUIaAAAAAAAAKwAAQ0AAAAAAIAVIKABAAAAAACwAgQ0AAAAAAAAVoCABgAAAAAAwAoQ0AAAAAAAAFgBAhoAAAAAAAArQEADAAAAAABgBQhoAAAAAAAArAABDQAAAAAAgBUgoAEAAAAAALACBDQAAAAAAABWgIAGAAAAAADAChDQAAAAAAAAWAECGgAAAAAAACtAQAMAAAAAAGAFCGgAAAAAAACsAAENAAAAAACAFSCgAQAAAAAAsAIENAAAAAAAAFaAgAYAAAAAAMAKENAAAAAAAABYAQIaAAAAAAAAK0BAAwAAAAAAYAUIaAAAAAAAAKwAAQ0AAAAAAIAVIKABAAAAAACwAgQ0AAAAAAAAVoCABgAAAAAAwAoQ0AAAAAAAAFgBAhoAAAAAAAArQEADAAAAAABgBQhoAAAAAAAArAABDQAAAAAAgBUgoAEAAAAAALACBDQAAAAAAABWgIAGAAAAAADAChDQAAAAAAAAWAECGgAAAAAAACtAQAMAAAAAAGAFCGgAAAAAAACsAAENAAAAAACAFSCgAQAAAAAAsAIENAAAAAAAAFaAgAYAAAAAAMAKENAAAAAAAABYAQIaAAAAAAAAK0BAAwAAAAAAYAUIaAAAAAAAAKwAAQ0AAAAAAIAVIKABAAAAAACwAgQ0AAAAAAAAVoCABgAAAAAAwAoQ0AAAAAAAAFgBAhoAAAAAAAArQEADAAAAAABgBQhoAAAAAAAArAABDQAAAAAAgBUgoAEAAAAAALACBDQAAAAAAABWgIAGAAAAAADAChDQAAAAAAAAWAECGgAAAAAAACtAQAMAAAAAAGAFCGgAAAAAAACsAAENAAAAAACAFSCgAQAAAAAAsAIENAAAAAAAAFaAgAYAAAAAAMAKENAAAAAAAABYAQIaAAAAAAAAK0BAAwAAAAAAYAUIaAAAAAAAAKwAAQ0A+D/CjKGIUW8YGtAP9pkMQxhqGjabR/8hAAAA4C+DgAYAfLjMJqOh8+WLO5e/qzuRJ92+LiZw6S7P+bu8Fu72cxdHRxSkJV4+W/vi8QOjQY//4dGfDQAAAPxbIKABAB8kDDU9bb5XpkwTrwhdOXNCmAsnkE0JYVOCmZRgBiWQRg6i00K4rCg3h51+C4vSE1pu30AR0+hXAQAAAKwHAQ0A+MDgHfystemkNGnDgk/CXTlBbEogk+RPs8GjOZBKCsLTmUIKIONj60+y8SP/dyDLJtCJsWrudKVg78P798ZMRpsJGA7FH83vPpqxD2vzCYaYejpeP2q4fefHb66eq7tyqurKmZpfvrvQfOPqqycP9IP9w/jfCAAA/g+BgAYAfDjMZqN+6Nb3F8XRIVGT2IEcmyAuOYBDCmDbBDFtA+k2+PhRP/amfORB+e8ltI/caR950T7ypn60lPqxB9PGx4W1NdD9rLoMNRlHv/L/BDyEEZNxqH+gp7P9xZMXj1qabt+49t3FC9XqmtLC0rycwizpCVnq8fSko6nxh5NF+Bw9IDmekVwgTS3NUejyj16q1v7y47ePm+61PX042NuNGvXD2JgqUbNhoO/eT98XpEuSvoravGD2qumuKyc5rprouHKCQ7Sb88Y5U/mhXtlxO86rStqfP0ER5MP6xQAAAP4RCGgAwIfBjGE9Ha+r8nO/mj891Jka6UCNsqdEutI3zJuUsjagJHnX+YL0azVHb58r+uVc0ZXqw7UnUnL4G/YELQqd4riIOW4Rw2YJw8aLS1vx6bTyQ8re7s7Rb/AXYBg6NNDf8erFk5ame1evXKrWVBxSpO3atD8yYJvvkk0eX6xb+NnaL2ev+nTGsk8mh08dHzzRKWi8Y4CLvZ8jBx9/B7afPcvXjuXnwPZ3tA9wcghycQyb4LpsqtuKmVPxz1q74LONHvN3BHqlbt9QLE/7rq7q3vWfnra2drS9MgwNYv/rVY2h6KsnD79WF/OW+66c6+Y3nu7nQPFl2frRbQNotsF0cjCVFEQlBdNIYSxqKJe2fKLjtsVf5KdImm/fxH8FMkNGAwA+cBDQAIAPgdnc3fH6ZE76itmuIU6kKBfaCmf65hkuR7ctu1d9uL/hQk/D+d6mi/0PLhlfXkY7bqBdN03dt/Svb3Y+uPK9Nj9p07LF9pTFDBtPBsmXQ10+e8oJaSryF9ehzWYUQTrbXv108Zz6yMFccaxk3fItngtXzZ4WPsEx1Jkb7MgOtGcEcukBLFoghx7ApgUwqQFMmj+T6ksn+1LxoXjTKF40smUolsGf0LzpdC8aFX/0ZTJ8GXRfFt2PRffnMPy5+DBDnO3CJrosnzFlh5d7fPSKPAlfe+Jww83rg/19/zthahgc+L5emxAdEj3DMcSB7M8l+3JIvmyyN4PkTSf5MMi+TIoPzdaPQQpgUgKpNiEU2zAaOZhBDnNk7/JaXJt/tL+763/nSwUAgP8hENAAgLEOj62B/t6qgtxVn00IdiJFOlPWTuEKPT+9cCDmbqnicmHK10fjLx6Lv3hccu5Ewun8hHMnU3+ozm78sbzj4bdD7XdMXU2dD66dLcpe/eUnS+g2XgyyN5saOXtK5dFcg35o9Jv9KbMZ0w8NPn/04Mr5UyU50uRta7d7LYyeOXnZZJcwF/sge1Ygl+HHouF9HMCiBnHoeET6MWz9mCRfpq0Pw9afRQ7gUsOc2MsmOqxwc1rp5rJ8ikvUdJeoGeOXzZy4/JNJK2a5RU4fHz7FNXC8nZ8z24ND8WDYejFtvZkkHyYRpn4sCv7K/nikMsiBbHoQlxHkzAme4LDq0+k7g7zyEgUXtBUPG+/1dnViKDr6q//LzBj2/GHzQdGedZ+7RbnSQ+1twxxI/lxSgCN9xcyJW9znJq4OPRy3Vbl3fcbWlfwVftu8567+xDWYTQ6i2+AlHUixCWZR8e+VfO/2J00NxI4OAAD4MEFAAwDGOqNB/9PXpze4zwpysI1woqx2Y6WGLDyduvtrBf+sPKZesa82a39VTozuEE+TJ1AdFqjyBFWHxTVHJKeOp/ygO/Lo59OmzvuDbQ0/1Zau+WLWUgbJh0X14tLWLJx758qPo9/sH0BNpuePWr+p1eRK4naGeEbNmhjsZu/nQAvg0vyZFF8GxY9J82XTvNm0pSyKO9N2EWOctyN1+SzXnT7z4lf4Zu1clS/YWp7O0+Uknj6Rean84BXdsZ/rCm6eLr5xrvjm+ZKbF07eulh662LZ1TNFP1QfO1eWVZOfXibnHxZuTvwqaF/oougvJnu6UL6k/cd86n+4Mz/yZNt4Mcd5s2w96bbeLIoPi+zDJgc4MiOmuKxb9NmBbes1x/NuX/1RP9A/+m/y7zPfvvp9/LqIZVMdwpyoIQ7kECdygAvlK/cZRWkxty5UdD26OtjZoO+9P9TTMNR1Z6DrTvuD734+U1Qk3r5jyawwJ3oQkxREsw1kkIMcWeLoyNY7t6ChAQAfKAhoAMCYhqHo4+YG0bqwYFdKqL1N9AR6sv8X1fFbTqXvqsvcVSvbUyPfV6OMqcnhVR8U1OTG1+RJanMT6g4l1h9KrM1OqDmYoMtNPF+Z8/jOxb6nt78tO7Zy9lQvJs2TSg6w4whXL+/pah/9lm+ZzdjgQP/T1uZzmvIDezZv9lkQ+cmEAFe2nyPDl0PxZ1P92Xi5krw5ZH+8XKe6rJs/KybKL4e3teZY5rXTJa0/n3rSePHVg+86n/7Y9/LqUMcNfe8dw8BdIz6D90xDDYgBn7uI4TZiuIMY7xCPhtumoduI/o5Rf9swdFs/8MtAz8/dr75//eybZ63nW2/V3Pq6qK4gWclfuydq8Yr5E4Onc/0dGUvpNl7UcX40Wz8aCX8MYNN8ObTg8fYr587YHxVUelDedPtmd2e7+S9slUYQ5NZP3+4IXBzizAi3p4ZwySEu9G0es2uPpjy9d2Gw8w6qbzEjD4ymZr2+YaDvdl/ntd62n/peXel9fa3nxU8v7l2oVop3LZkTbk8LpuMNbRvsyNgX6nv3yg9/dSMNAAD8HSCgAQBjmn5woLb4SOgUjr/dx2FO5N0LJlfw1tWn7ahN31Yn3VEj3VWr2Hs6O+ZcDv+bXPGl3IRv8pIv5CWfykmoy02qyU2qyklQKcQVClFVXsqtM2XdDVfLUwTe9kxfNt2PQQuf7HKqvABDR6+DmjG0u73t29M1WYL9e4K8I2eMD3Dh+NjRfO2ovvY0Tw7Jy57szhkXNIWzPXBeVtxaTV7CtbPFr5ou9b++OdRzxzDYgOgbENN9FL2PIA0mtAHBGlGsEcEaEHOjZe6jw034I2JuwIbvYea7+KDme5ZpwMyN+BMEu2vC/zxG/C/MfA9D76LIHcR02zh4fbD3an/XT22Pztz5sbg+/8CJhO07/T/3crRdQP0Pd/p/edI+9qLZ+DDI3nhPs6nBzuyNiz5P3BBdlX/kUVPDv7e1o/HW1Z1hHsEu1CD2uEB7W/+J9CzexpZrpw1d982DrcOGB+jg/ZePv7t9Q/3j18e/qc05V5Fx4eSBSyXp36vkV+sON3xb1nbnXMu3mqQon1C8v5mkYCY52I4piAh5fL8Bw/6dLwkAAP5GENAAgLHLbCY23e4N8/TBo41rs3IyJ29LWF3GTm3qppoDm+rSN5/K2FafukXFj85b5ysNXZDgNSclaP6hjeHqlH2ncpOqcxOqDiZWKRN0MrEmg1+tiL9cltdQVyaM8PMhru2jB9gx9oZ7P3/YMvJ2eFz2dnXeuvxtoTRpX7jfsjnT/Fy4/vYMHzbVh0P1ZJF8Hejh0502eM5J373yVFF688/Vrx5f6uu6qu+/adLfQVGilU1m/PEeillqGLtLdDDxpAHFP4g0mLEmYpBmM9o8TEwThjaYUbxr8Y68j5mb8EfUMvhzs7kFG24yDzeYzfjcMw/fxYi5g5lvE4PdQkw3jYM3h7qutj3+5u6P5cfSduwMXxg5x8XHmeZB/9id8pEP1caPauPPIAXZMSKnOG9YPFfB233l/Onu9tf/era2v3jGWxvm50IJYH/szx234jPXqoIDHa9umgYfDOufmPpant09/211Xn3JgZp8Se0xcd0RcX2uqC5bWKcU1mcJ63OEtbni80VpP+nyLh49sHvJ7HAuNZROCaFTQ7nsrJg9nW0v4ZpCAMCHBQIaADBmmYcG+2uLj4ZM5vqyx4U6UPa5z9IlbqtJ265N3VhzYGNt0vr6+K/y1/qkeEwXfObK+8R571S7rW6cjVPsd3w+JW/rilNycU12olYRjwe0OkNQkcYrSd5//pjs9MH0FTMmBbAYfnRK0HhOTf5hM4q0v3h6Xlsm3b9l5Vy3kEkcXweKjz3NnWPrYU9axP44ZJqDZHVQmUx47XRRW9Olwc5bxv67iKERMzZgpoZhDA/fRgS9h5kbMQyP3ft4E5vxJ9h9M9JoNjWajffNpuZhpGXY1DpsbBk24OmJT+uwvsmsbzTrG4hHw32zsXkYH1PLMNI6jD40o4/MxJNm/PWJQe8PY43D5kazZZWaSGrsrhm9S7wXchc1Ngz13uxtv976c93pk3LpzhWrvpz8Je0/PRgfezFt/dgUPyYpgEsLdGKFTXERr1+hLTra9brtn5ar0WgszM4InGLva2frZ0cKncI9VSQdaP/FNNSKDT3qfX7j54uldUXpNUeTag+JzuSJz+WKzx4Unj4orDsoqj0oPpUTfypLXJctqskR1x2Mr1UIi+I27fhiRiiHGkQnBTGoUdMm1ZcUDA0OjH5jAAAYwyCgAQBjFIZhr548TN600seOFMAhL5/AztsQWZe2p/rANm3y+qrEdTrhquMrPdLmT47/xEk03Yk/2X7/RLttLqx1DtTVTvRN05xz1kbUySXVCokmU1iZzi9JjS1I3FeYFKNOjxcE+/nQaQF0mj+TvOnLT6U7N210/zxihqOfC9nH3saHMw5/U0+ubeA07q6IhbUnUlqu13Y++Wmo6xfTQANmbMbQZgRtRLBGPJGJejY1osZ7eCsPY8Si8jDSNGy8b+r/ZajzZm/b9a6nlztav3t+59zd7yqvnyn6XnfkfGlWXYG09kRG3bG0uqMpdUeTa48k1x5NrjuaSszxtLNF0m9Vh66fKm78sep5w8WOJ5d72n4e7Lxt6m/A9E1EguORbbK8F17SluVtPNyHzU0o0oiamowDd/varz9uOHOmVC5Y4xcyw3Ep19aXZeNHHxfIIAeyKAEOrLDpE75aOr8kJ/NRc6PJaBj93X/r3s3rG3wW+jnRfbnksOnO2tyUgbbb6GCrsa/p6e3zX5dl1R5NrT4kOXU48cyh+POHxBfzJBdzJRfyJGcPSuqz48/kJHx95MC5g4lnDibWZ4nxgK6W8gpiN234dHIQmxzEpPhzaVu9Fzbfufnv7S0BAIC/BQQ0AGCMQkym21e+X/WpWwCXigf0pjmT1aIdVSk7NalbNEnrteLogs3+qYumJH3iIpnuJJriIJzqtGc8Z5MDfbUdZZUDLcqOsnHG+Py9m6ozRFWZ4vIDvJKUuPzEmOPxewuE+6RrV/kyGf40WgCNHMikhDmz/O0pXuyPPbkfeXD/awnnv6LmOMt2rLxYmfXywUVD323TUAOGtJiQZhPaZDI3GxBiWzOx3ozcHzZZihltMRvuD7T//Kz5wu0rldcuFn5fe/hChbI+P02bK1FliTTZ8eossUopVilEarlYo5CoZPFqqUgrFWqkAnWmQI0/SoWVmUKVVKSWivHHSqmoTCosV4rVhxJrTmScK836TnfkyqkTty5VNN2o63pyxdRzl2hoYoiON+Mpb76PYk2o2dL36D3D4N3+1z/fvlReJuft9J7rw7XxY47zZ9j6s6m+HKonm+I33m6j3+JjGUmvXzwjbiH+e2azWSmJ9Ztk78OleTvQU7evef34BqJ/gg09vP+j7syJtLqD8acOJpzNTTqXm3AhL+Fibnx5wpbsrWGSyCX7/eft8fs8LmRRxsYwbWrMhYNJp5Xx1XKBTinUyQVZW5dHTeAEMGwDmGR/B/rhJP5Ab/eodwcAgDELAhoAMEYZhobOqUp87Sn+LHKoA0vsv6T2QIwmdUdl8sbKhLVl+yKUIfMS5rgmz3RN/3SyYuHsbI95aQs/3TKeu5xlG8EmhbJJYXaULXOnayUx1Wmi8uS4kqS4fPG+E6I9B3du3O2+yINK9qFRfKk2xFHNbFsfOxtP+48DpzJ3hHyhOih8dLO+9/lVY99txHgPQxpRtAnFWlBzqwltRtEWDG0eNt3HhhoHu252P7v85O6py2eO15/M0BxNUOeJVQdFlVn8CgW/Qs6vlL4ZtZSvwVtZJtLiIxXpZGKdTEJszpaK3oxMpJGL1fJ4fFTEo4R4IouvlBElrVKIKxWicrmwXCGqyBJX5Ig0eQlVJ1K+0R28+2Nl+6Nv+zt+xvR4RreiSCOGl/Rwi+UiRfzLbjLp7xl6b79s/ubn+vz4aN9QN6478yNvNsmbhQ95KZsaMMlxW5C3Jv9wx+tX797X8PWr52vdP/d1YHhyKMvmTm+8ehY1Pkf0Tx/ePHfmWGr9wfjThyRnDyWcP5Rw8VBChXBzQvCXGz91jJ7KWjaZETqRFuBK9Z1A953EDJ/hkLzKX5cWW5stVmcJVEq+OiM2xueLEC41kEHyYY5bu2BWw42f4FQ7AMCHAgIaADBG9fd2F6Qn+HGp/hxqmAsnZ+NyTeq+8pRtZUkbyoSrCrYEprpPT5o1/siSz+tWR17Zv+1WAu96Qpx269pd08cHUv4LD+ggpm2UEycjMqj+gFiVxCtPiMvn70ldu2z13JmeXPoSuq0Hw9aD+dFS9keeduP83ejidb6nStJfPvx6sOeGydBgMuHdTFzthyL4tJjRB8QgD9D+xvYH3zZeUV+tO3ahXFF1LLEym1+Jd2GWoFLOU8l4apkAz2V1Jl7MfI2MNzJaKU8n41tGoJMJq+RC/FErJ0ZjGTX+qBRrFPjE46NWxqvx53K8s/HaxrMbfy5SyQSVMn6lTICneZmUVyaNq5QLyvGPKAW1x1Mvnzpx96puoP2GZXdHKx7TGNqEDDcgw40oHtPIfWSosfPplQvlyr3hizydSB6sj5fSx3nRyR508lJ7uvckh/it6y5fPGsyEkfLYRh6SnUyZLKjD4fqbk+T87b3d7aYkZeP7126WKw8nS05fVBSnxt/KjfhVJbwyI6o7Z+6rJ/EWDeeutqFssyZEuZMDXSh+brSvJyofi70oIlMftiSirT96iyhKluolvFO7F+/arJDIMPGh/aRvxOt/KB8sO9/6WaKAADwF0FAAwDGqK7XbYlb1gTY0wPs6CunuhbGba1M3VuavLVYvLY0ZuXRlV4Z86eXB3re2rX1aWL8i7SU10rp8yzpQ2Xm6Z1bNjhyg0kfhdJsQhmUTdPdqiW8mmRR3s6NuzwXBE2wX8ImLWaT5jPHfcn++EuH/46c56qIXX3zXNHrJz8O9fxiQu7rkXsGc6MBu28y3TcjrRjywDDQ2Pni+oNbZ77VHa46kqLNFldliXQKAZ7LFfI4lYKvGQlifKQCnVRQlSnQZfC1mURAa+W/G52cr1PgIxiZKnzkAp1coMWH+IhQpxBpLYO/Jv6CeHAT/4sY/ptRCNT4Wyv4KhlfkyHUZgrVmQJVhkAlFaizxNVHky5UKh7dqu9pu4HqiX0d6HAjMnwfIQ7Oa0IRYod024Pvfqo/LlrjHzHNaQndxp1JXsiwXci0dXdihsyZejQj5eWTR90d7ck7N/g7MJayyIEzXS/VFZv0z148uHa6QH5KmXguK+FUtvh0XsL5Q5LcrZHrP7H/ahJjgyttgzPlKwfyWgfaKjtqlB0twoER6sgIcaAHOFCCJzHl25dpsoSaLAH+bVGl7I3xJhah/WjjfFmk/eH+zx62QkADAD4IENAAgLEID6m2Z092hnoH2NGC7OibP59xUrizLGlXsWTTSdG60l3L8iO8tFGBD/hx3Skp/RnSfqmsVybvVirbFIrm9AOH/X0jbD4OI48LoZEi7Jgntq1PWx62csYkHweGO5vsziUv4Iz70tE2cK5LTvLmO1dUg69vIP0NJv19E9KkR5sM+CCNKNZqRh4OdvzScEX3jfaw9khKSSavQiaslPK0eNRm8rSZcRoZXyXlaaS8KrmoWibCu7laKtQRI9DJ+FrZSCuPniqlYGS0+GQJtUqhGq9hfJR8dZZQrRTho1IKKxX4xwUavM5/P3h2ay2jwVs8U1iVKayW4u8uHtlOjX95FTJeZZaw5ljq9TP5LTd1g90/m5EmYl+HuXV4+CGG/71MTchgY8+Lq1dPFaZsjvScQF/AtfmC8dECps0CFsnPzTF+fXTFIUXorMmeTNISlu0qjzlPmn8c6Gi4pD2iU8afyUo4rRCfypGcPZhQm7Br7/wpq1wp0c6ktU6kDQ7kjVwKb/L4nCWL8zyWHpg3b+t4pzWO7GVOjCBnyoaFU8sP7NUQvwYIVOmxGevDwlyYAWyyN8MmbLLzvWtXYBcHAOCDAAENABibzC+fPNziuziISw3h0vcs+qyYt/WkZHuRaENJ7OqKbVG166KeSET9aRnGTDkiyzLKsvTSrAFFdndWzkuF8oeYmE323FDSx4EUm0AGZflE52BnrjeX5smmeHApHo6Ur7zmFMrj7t2o6e64ZhxqMJuaMaQFQVpMaCuCPTAaW3te/fz41pnLNcfrCzLUOfEqhajScpGfOoNPLDPLeHgFauQ8y85mwcjCc5VUWCMXV8tFOgU+Qo1SgM+7ufzrVGcJ8alSCrXEcqxIQ0SzQKUUqLME6myxKgsfUaWloVUKIRHWCr76ncHr801DWxak8YjXENtCiJ0h+JdhWbrGs1tUKefjL6s9JK4vTPtanXP3x8pXLd8Mdt9GjS3EVmm0BUOa8b97+7Mfr10oStu7MmrepAWscQvoHy1m2Hg7sUKnuLhzyIvp475kj+NvDO9+duNqfUHtoYQamaBWLqxVimqz4jWJe+KXfrbWhbLOhbLGYdwmJ1LGglmn10c3CPmPJUlPxSktcfE/7dh9aKnHjsmuy5wZy6faHVjtrzqwT5URV5Yec1S8ddUnLv5ski/D1odDu6hRGQ360T8IAAAw9kBAAwDGJvOrp4+24QHNIodwaDvnzy7hbS0Wbi3ibyjZt1q9dcVd/v6+dLyeFSZZFiLPNslyTPIcvTynV5nTnn3wfkZGToBfCHlcINXWj07y49B88Hq2o3o5UEOnOx3kbW65VjvYccuov29Em00Ykc4o0mpGHiDG1rZnV376+mTNsTStXKyWCfEMVVkqWWdZXa7C+5jIU75m5GI4YmeFWEfsVCa2cFQpxFVKsS5LqM0WjYzOEsr4VGeJ8Hn3uWXE1cp4fPBP1BGfiz+J1xEjxl9WKxOpFcJKJTGWkhaqLFulid3SI3s8FIJKBU+l5KmVxMr0SE9XKUcKXqTGk1pJvAje9xp8FEJ1juh8ZVbTzzXG/nso/qsC+sCINZnQBqOhYaD9RtNlnXxXtN8E5hLmOE82yYtNWsqwWciw+Yz5UX5G3C8XK07lJtbK+PVyQbWcX60U1ykkByK9101grnUkrXew3epAKgn0aJUIXqYkv0pKfp2U1pGY0SFJfyVJbRSIjgb6bJ7suHwic/vC6cWCzWUpe4oO7M1P2bN96aeBdlQ/BtmbTso/kDTY3z/6BwEAAMYeCGgAwBjV/uLZ/sjAQCY1gElZ/+nUwphtZaJdRYLtBXs26LZt6EjPHMpQGDOViOIgns5GRY5BlmOUHRpS5HYqD7XKFKUb1oWwaP4U2wA62Y9D9XKk+k/lxq72/rHuWM+Lq8hgA2K4j6GteEdilksDkcGm9offX64/rjuaVJllubBPKtDIBWo5T00sNo/sZia2T2iILchvF4Pf7Fp+U8m/TZaI2JthGV2WSJf9x1OV/aakq962NXHKmxKPY7x3iXdXyXmWId7r7XMesa/DsryttnxcbdnXgX8lxKdbHt+81MjXZil7jeWKRpXMcjBItqi+MKPhR01/+21E34RhLRjWbMa/FUP3u59fu3quaGvwl0udyV5sW2+GrTvTZi7tP2vyUs+dkNYrJTWZghoZsWO7Wi6qiN+1bc74dY626x3GbeTa5C347AmP1yNJ6RAnvkxIak/PGDp4CMk/bso/Zig8/jpPWb9tbezcSbsXTj0Ws6YkeWdR6u7ClN3CSC9/e5o/g+xDIx3YuqGvq2v0zwEAAIw9ENAAgLHJ3NPZLt+/w59J86OTIyY6Ht+7uVy8r1Cw+/i+LVW7tvUrDxnlOYj8oFGWY1IcwseoyNMrDg9kHXmlPHRq+/bNkyf40m3xMvNnkf0cadHzp55U8p82XTQO3DPpGxDjfeJsDVMzZmo1mx70vrx240Jx1dEklZJfKYvDW3kkQIlutqTqu/O73RSWdd83lwO+XV1+N2SJgH6vm9+f32rb8vwP3+vXgNZYdk6P/N9fryx8N53f1rNlp4flSkRi8F8JZIJKKb8CL2m5UKUUniuW3fq2svf1DTPxTWgdxh4i+vumocYnd84pYtZ6O1J8WSQP5sdf0P/zdO6B2uykaqm4OpNYg8dfqloqVH4Vvn4ie4O9zSZ7m10O1OvbNnWJEnoFiV3i5MGcHKSkwFxWZK4sNlcUmtXFaFmBvuxY/a61KYFfnohdW5K6Kz9pR1Hy7tSvwvwd6Pg/sR+dIlgZ0fW6Df+nH/2zAAAAYwwENABgjBoa6Ncey/VhUf2oJH8ONXNNRIUkpki850Tstur9u3py8ozyQyZ5rinrMJp1xKQ4olce68059iwrV7tx4ya38WEcqi/9Y2+2TdBEtjja/84lVe+La6ah+wZ9I3EmHdKKGZoxY2t/+617lzXV+SmVWfxKeZxKGqeV8UeOnKuyHHyh+f3+41FjuR7udw1dbTmd49ei/YsB/e68XX4mmv7PA/rXerb8DmA5LM+y5UONd7NMMLIJpELGJ65WPCSpLki//W1F36ufMX2zGXlgxr8t+gddT67FRXn6OlI8WeMW0v+rMH4XcXZ1BnG1IrGejb9Iyn6e1xdrXRgb7cdt5Y5TfD7jET+uW5TUK0kxHszFykpQPJ3LLelcUTCMT3kBWpH/Ml9ZsTu6kL++JGVXUcru4qTdGRsjA52YeED70kgxEUGdr16O/jkAAICxBwIaADBGmYzGy+dOB7ra+VNIAQzKjsWfVSbxiuL3nojbruXtfqbINigOY9nH0JzjJuUxU05Bb07+E+Xh/Og1q8Y7+7HJvqxxvpyPg6fZHU3c9fLe16bee6ih2YS0mEzNiJEoRVNfQ+svp8+elJYreeWyWLWMRxyagU9mXJWUVz3y/O1miX80v17J927F/hqv/0pA/5rO7877b6R5uxo96iP/JKCVxG7pd2ckoDVvY1olE1ZIBRUy3umijDvfVw51/DJseDCsf2Dub7lQJA1wY3iyP17C+O/0jZHEtZKZ/Gq5SCPl6+Sik+KdO+ZOXetE2+JE3sElqQO9XseLu8VJpqyD5tISVHXSpCo2q/B6LsRURcPl+cPlRXhPD1XmX0qJKRNtOZmyq+TA3uLkPRkbIoKcmP50sg+dFBsV3NX2avTPAQAAjD0Q0ACAMQpD0Uf3G3YHevuRbf3JpGVuLidid5YmxuULdlfE7bmTJh3KLjDnFJkOFhoPFQ0cPvn6SEn55h3hLk5LubRF7I+X2o9b+6Xb2cLM7qfX0IH7qInY7mwwNWHoQ8zY2tN288e64+pD8RUyYtVZI+dpMmO1GbF4PetG7ngiJ84q1iqEWqX4j+ZNjxK9q3yzGPzbsvTIIvHIEXVWBvSoVh614P3+jAroXzeQvEl5Jf764pFz8UYG/89KYjM0/uWJNcS1hvHaDKGOuNkhT5UjPlUsbb5Wo++8OzzY+uBa3calMwOdKMHjGTk7o7V4eWfydJZ9IHhMn9i/Yf1Ul7X21PX2tvucGd+tW9UhSdBL5ebCInNlqUldYqgswsoL0YoCpBKv53xzKdHQQ+X5P2WI1fE7y5L34PVckrI3YYV/oCPNj07yZtiK16/s6ewYhqOgAQBjHgQ0AGDs6unoyJMIAtkMHxuSH5uVsCysPElQINhXHLPvoii552ApcrDcmFeqP1HZU6Q+L0pePW3GIhb1C7btYifyV54zr+jy9G230MEmzNiCGlsw4qiNFryeOx79cEmTq1KKVMQdtuM0mcRoLUPUs+WSQTWe1ETC/qOAfjuWiwXfL92RDn43oKtyxO/X8/sl/W5AE6/z64xcyPjevL3HCnG9YJWSONbDcgqH0PIREVHJynhNVrxGKVYr8BGpLMvPGoVYJROqZSKdXFItk2gziTsdVkoFZXJ+ebbwh6rDz34523Xngk4al/VV2JEdqzUZcSP3VlRl4N8fkSqTd2jryujxnLUO9LUONjw3+7v7d/VlpJuPnxguO4mUF5tUxUhlsbmsACvPx1SF5rITw6WF5pOFQ2UF12VJWsnu8uS9Jcn7SpP37fNb6GdH8WWSPBk20thd/b09o38IAABg7IGABgCMXYjJePO7SytmTvciUT0ptIgpbkf37iyXCAtj4jSxCTclh/oPqfTH1Z2FqnOipLWfzF7CZc3n0ha5MLaGLLz5damx+w6G17OBuELObMSnRd9zp+ladV1BmjpLpBk5NVlK3GR7ZDRS4p7b6pF7miiIQ5T/aUATf+AfB/TIvN/K78/7OzfeLDC/uRDwt5Xm9+bN/cDxXCZO0LM84lOdFY+PTiHWZSVolZKR24PrlBK1HA9lvKHj8Q+qZCKVTKzFA5oYMd7TlTJhuZyvUgrq8hK+Lcj85nDy2UxhfaagSsYnTrzO5KnS41SWx8zVIdGunNUO1Ggn29TPpz9OEpuO5A6fLDaXFyMVRUh5kbmscLgkHys7Ya4sGC7NHy4tHi4rHigrvCpL0iXur0iOKU3eXxK/Z/3n0305ZDygvdi2ZbmKocGB0T8EAAAw9kBAAwDGtO7218q4/Z50hrst1Z1G3zBvbnFcXOF+fvG+hNq9mY0Z+a+PV1wUpayd8ckiDvMLDnWRC3P/yoCmK7XG7nuIpZ4xw4Nh0wOzobXv5fWf6o7pciWVxC21hdpMflUmEdB4NI+MWs4bSWfLTQEFqqx/KaB/7d2RK/zeb+g/38jxfjq/OyOnfLw/I2fqvR/QIw39znN84quVCVUKiU4ePzIauRjPaLyeiUcFMRrizGliNERe8ysy4/BXrpbzT8kFZ6WieuJOMTxio0tmrDYzrjI9RiMVJER4LXdmRjtQV9iNy/Vb2HlQhhXnm8tK8IDG8HouLRw+mU9MWb55ZP9GaRFWXtJ9suC7dEl1Kh8PaFVq3OHdXy2f5uLHpvgwSd4O1B/O1pmMxtE/AQAAMPZAQAMAxjS8qG7++MPGJYs8afQlFMpSBm37/Pkl+4VlosyTMZmnxIoz4tTNs+cuZTO/ZJEXu7L2LPO5f7kO6WnChh5gxoeY8bEZeWLqa+p4+OM35UqNEk/PODUeglK+TobXM7HReSSdf7eEjAexZTRKYhfEn8y/EtB/ntGjAnpUTP9JQI/MH65AW9aeicPmqhTianl8Fd7NxI2+RUQ9S4ndGiMNrVHEq5SWWx4SlwaKtFKxRop/HA9rwUguV0t59XJhDbGhxXI+SUasLp1oaPz7Jgx1XzGevYJLXsH6+NTm1UMn8ohNGhVFaEWhubRguCR/uPgEdvIEsQJddmK4jNi/gZaXvCg8fD5FoE3hqVJ5FYmx8WE+wU4sXyaxAXrFZ9Mab/2MoujonwAAABh7IKABAGOa2Wzu6+nWHj8SOXmSO9nGnWobwGbvWuBRIEzTKYqytvPWzpnnTme4s+hL7KgbvOfd/aEG7W9B9Q9Q4yPM8NhseoIMtLxo/u5ciUyLJ2lGTLXlkA1NZpwa72biJtgjGWrZUkzsNn5brkoBcUPBrH8hoInbcQt/7ebf1rDfy+g/DOiRhn43sn+dUQE9cmngnwf0u0Ps4pCLa2TxtfKEWkVCjUJSrZCMLEXjuYzXs1oRX6kQVSqEKpnwbUDHq6Ui/D9VcuIED62Mh9ezjjg+D/92xeky4qoz4lRp+zWZ/Ix1oVHjWXhAb3ZktKQnIsXHzeVFKHFWXcHwSECX5COlJ5Cy4+bSY/hHzKWFxvLi+7mK03hAHxCoDggK4ravneXmx6b4MYljCqW7txJn2MEVhACADwEENABgrDNjWPuLF8dTEkPGO3kySD50SpCdw/JZn+8OXhEx5wt3LteDxVxMI/k6Mw/GbHr8y9fdT6+b+prN+idmw1N9d3PT9fpTJXJNVnyVQlQtE1Rl8oiAlvErpHGVxF0G3wS05ao7y9EZRLYS51cQ98H+Z6PJIu7XTQT020XrUQ2teedIjT8P6FH1TAyesG8DWvc2oC13KLTsSCbq33KfFDlxs+4qmahGgbeyWJPGK0/al8/blr0tOnllUHyENy/IPTZgsSDEUxLll/lV5OF9G0vi95SlxGoyiYxWEWfbiTQysU4m0crjiY3RclGlTKBSEIf0VSneBPSvK9CaDPwT+aXxO5PCvfgLZtVtXdt3PBfFA/pkvrmsYLiiaLiscPgkkdF4T2PlxC4OjHhe3FVy4of0hJpkniZNqE0XxQV6BDowfFhkb6ZtxFTXr3Uqo35o9L89AACMSRDQAIAPAIoizx89zI3nBzqxfZkkfxbVj033t+f4cFleLJoXk+rJIC9lkAJc2GsXzOKvCio4EPdTfemrez80fVdTfyyzKju5WpFQTRzZJtBkEPWpVggr5EQjEjfBttTzr+u4WsshFVqlxDLx70fz7+btLbvfXWn+kxn5wyPd/O65HKMWnomFbeIMDfzjeNDzdJaKxRsaT2qVQqhWiCqIzSfEvgudEv/FQELc3+QA/8TeTfI14TzvBdu/mBk92WX5RIcIV26EMzvUgRVmz4xwZIc7sMIdWeHO7OjpE7bMnx0f7qPYEl2aGlelSNRI43UKiZq4rBD/AsSVeJ3jX8mb98V/wbBcZJkZZ6lny7kl+JO0mLNpvKaDaf1Fh9GiY0Q041NWNFxeRCxCl755jpQXmSqLe8oLrslTTiXxqlIE2lRR3s4N4W5O3myqJ5viZU/dG+H/8skjMyw/AwA+EBDQAICxzoxhg/29965dlu/eGuzI9KXbWO7RTQpgkQMY5CAaCR9/qk0AzTaYSQ5m08IcWSsmOW36fOZez/lx/u5JUQG529aViffUZIiqMkWaTKFKyq+UC0bmzdqwgkjnt3cb+bWe/3lAj+yBfi9/f38s9D8IaMuIdVnx+Ix+WcsJdFpiFVw4sgaskxGhr1bg0S8kNl2MnEYnFejSeaXindK1IXs95q6fPTF6ssMyF9YKV06EHT2cQ43g0qM4jCg2LYJOjqSTl9EpyxgU4gmXEWXHWO7IXuXmtOHTqfg3SvZVVIlwpzpDoCUaWqCS8VX4N8dyL0ZiLHdnfJPOxB5ooqerFcJzSvF1RcLjI9LewjyktICYskKksgipLDZVFOFjqCjuKT3xPD/vJ2lSvSRGJ4nVJgkO7diw5tNpXmwKHtDubFLkp5O/rasyGvSj/+EBAGCsgoAGAIxdZrPZZDDcv3mtMF2y229RlJtTAJfqzyLj48si++HDIPnTSX40kh+FCOgQFjWcS4/kMpfbs5bbM1c6sqOdudGu9isn2H81c2J8sGchbzve0JUZvErLjawtK9BCy1EbozZsEKe8/ZWA/kcN/ft6Hgloyci8/174l1StEFUrBFUj+57fbAsZWTgX6mTCiqS9mav8d3w5dc00hxWT2CvGs5a7MKKc6JEO9AgHRoQjI9yeHs5lhOG/VLAo4XhGs6lRHDre05EsShSbuoxDW86hL2PTVziyo1zYq2eMl0T4lEh24w2tU8Zr5MRi/Mjea0tD8zTSOMu8OfWvSi6oVwi+kQmuKiWNh9JflxzRV5Xqq8sHa8r6q0p7NEWvTh5tOiy/nCE5HR9TI96nk8SoE3iy9Ssjp7guZVM8GCR8/CZwC+UpxP1TAADgwwEBDQAYi/B0RhDT8wfN2kNSQZjn6pku4S70YHuaP5fqwyH72NMDx9uFTnWJnO226otPvlo0d4P7Fxs95q1f+OnqT6eumDYhwtUuxIEe7sDAM5pYf+VQIx0Y4U7MNbMmJkb5VyTHqKV4y8ZrlMQdrdWK3+53/U6//ksB/esWjt8NUdV/vKnjjwI64e1I3q5Gv3nTkYCuUQirFELtyNWNWUK1nF+lFGkzeXm71+z1/nzDTKc1k1grxtOXj2dEuTIixzOWTbZbPWv81kWz9/jMT4oOk21dc2jfliOx27N2fJW0Onyn94INX8xcPs0l2JkV6ECPsmes5DJWcOjhbGoolxYxgbNmziTF5hWadH6VDH93sY5YmydubaiVE3uv31y5aAlonYw46q5Ozjsj5V3IFFzOSvrlSOa9fOWNw9LL2SmXZPGnk2OrJfs04j2a+H3q+P2qhLj0NVHhU1zcmSQPJmkJ3cadRUrcuubZgxYMg8M3AAAfEghoAMCYg9fzQG/Pt3Wa1A3LN37iEuVEDXekBDtR/R1pQW72u4Lcc0W7aguyb17QPb57ue3xL+3PGl6/aGh/fu/141uPbl366XSF6lBa5s51axbM8ndgBNvTwxxZYXhA40ntyIyaYLfbfW6RYCceiDqFRENcCDh6Rvr1zVHKlqj983k3qUfvx/h9W/++nkWWT/81oH+bkYa2BLSlYomXJT63SimsU4qq02IV60K/mjNh1RSHNW7caDf2ikmssAmMNZ+7Ja4OUikkl6uLXt39vuvxrZ6XDb1tLX0dD/Dp7Wjpbrvf/uxO681L5yqOFmSK9kb6hrjZhzrQI+wZoRxqGD5carAdFc9oUchS7QF+rUJSbTnNA/8+WLaGE1vG321oYn1aSewwqZHx66T8uvS42rS46pRYXXKMJmm/OnF/ZcJ+dVKcOolXxNsliQgMGe+A1/Mihs0C+rglbNKuYK/7N64hJjj7GQDwgYGABgCMLRiGvn7+tFRxYLv73JVu3GWOtAg8oCew1s2flrkz+ofqwscNP/S0NQz2P9EPPUfQDtTcg5i7TZbB/xMxtRv1rwZ6HuM9fe/ahZoTiv3L/CJmTQpy5QTjDe3IinBkRY7n7vWYp06KrVMkVGVJNAq8ZeN1ORK1UoQ/Es8tWWwJ6D8O3HfmDxr63fnT5WeRZdU5UZeVZHkkXrAqO/HX7RxEQCvxhLU8x+s5i6jnU5n89EjvLXMmrp5sHz3FYflku6ip9puWfHIoZuO9S7qXTVeGOpqNA08Q4ysEaSO+Pxj+/ekxYd3IcDf+jUKxLtTUYRh43t/16Mn9az+fVyv2b1z95cyQCXaBXBqx34NFC+XSw53Z+70WqBJjqmWiWvyLtJyRZ1mtf7MO/ebejW9v3PjmIxk87YE4TWqcOiWuMjm2Iim2TBJTzN+TFh0RPWtygCPbg0FawiQtZIxbZEfaEep984dvjQY9XDsIAPjgQEADAMYQFEWetNzP5u1cN2fSMidGlCMjzIWxavb4nP3rb54r7315e6i31Wh6bkRe6bF2g7nTZO7CAxoz96LmXhPWgz8nehqPRXyQLoOxfaD/yYvHN7/WFSRuXBE21TXIkRnhzI1wYi+faB/nPb8yfl8tXqiWvRNVeDqPTLblP//VgP5138XodH4zf7L8/EcB/c6mEZEGD3pFPD5V2RK8v2uzRbWZvOz1YVtmjV8/1Wn1FIeV05zXzp+ZFbPpxjlV7/O7poGnBsNzlPi2dA6ZO/XDPQYinftMWD+KDSBYH2rGn/ShaC+G9prRXsTQZRh61dPZ3Hjt7LEU3vqFnwbZs8K4zDAuI9SeGe7CFQR46A7w65UJNcTtDMVaPKAtVxb+FtByXqVlKqSxWjm/Siaok8bXpIu0ybwi3s7M9cti/N1XzpjkZ8/0ZJKX0MYtIdaeP1rqTBNsWH7vxlWjHuoZAPBBgoAGAIwVCGJqvXcrfsPyZTOcw51Zkc6s8Al2axfNrjkm7Xx8yzDw2GB4akJfDCHP9VibAWtHsE4U6TL2v+rveNrT/qin7eFg93M8CjG0D7OUohHFC7LbgLQP9D5+9eDWxfLje4M9wyc7hblwIp3Zq92chH6LtAf4dYqEamLp15LOb1egibuQEBktea+YrQvoUcVclSN+9/S6dwKaeCm8nomt2MTpdW+a+81dUbLFVVnC+pz4o7tW7XeftW6649qZLqs+ceUv8/vloq7zyW1T7xPU8NKEthvQ1wasw4B14WNEu/FWRvTdQ/3tg33t+r52dKjbjAyYUXwGEVMfgvQZsJ4B7LXB2Nb9srnl6tfpm9eET3YJdmAH2zFD7FhhTmxBoLsqKaZOLqklzssTa2QCzbsBLeVVZsaqFfxKIqAFpZJdCRG+e5fM2zhnavS08aET7HztaD5sijtt3FIGaRH1oyUc0sr5MwuVBx633EdMJqhnAMAHCgIaADAmoIip5c7NxA3LQyZyAhypAU6MkMkO/FXB39eV9rc3I8aXRtMLI/LCgLw0YW0I8nqg6/HN789qThzKTeAlbl0vWLdC9NWqtJ1bjqVI6oqPN9+4jPS346WIEuuvPUak02TEC/Jp888X5fs2hk5zipzAXenKWTfVOWV5YE2muE6ZWEOEbLw2mxiiibNF1Vmiqn+wR/nfC+iRev5dQ799/d8uWPztqkSBLktQRVxEKK5WimqyRZWpu4XB87fOc/tqzvivvpxaKRc9vfe9aeAJMvQCNb02Ie0o2oH/Nc1ot6H3RcP1705VFhdnZR5OjZfG7k3fu1Met/9ISkJ5Xs7lc6cMve2oqR/DBk1on364x2TuMSGdyNDr1w9vV2anhU4f72vPCOIyQvCMdmLGeM+vThPWySRVMuLe4G+vKeQTh0PL4jTSWLU0TiPn6aS85BX+y9zswu2ZIWxaMIviy6J4s8ieTNul+HAoYTMnHti96eo353q7OjG4ZTcA4EMGAQ0A+PuZMezFowfS3ZvCx3MC2KQgJ1bkHLcswfYHd77XD74wmdpMaPsQ+moIeTkw8Lj53g8FWSk7IwOXz/s00G28n7OdrwPHz47jb8cOsLMLdHAKcXNbt2iBZN3qcyWFbQ8aEX0PgvYa8azEOo2GFy9arxanC9bMcVsz0WHdJIct86YXxG6pkyfU5SRV/Q8H9B819K8B/fYV3tazRsnXKvk6Kb9aJqhRinQy3uF90Xu95mxfNJ0f7v5N2aHeF7eNhqcI8spoeoWg7SjSMdD79EHDTydkybuiglbOnxs81c3P1dnb2XGpA9fTjutpb+ft5OQ7aWLwrFnrg/zzMlIeNtzUD3SgSB/x/cF6hkwdJqSjv/PhqYKctQvmBNgxwrisYHt6iDMrKdK3Kk1QqyDu5khcWGlpaOLmiHJelYynzozBvzxdJi8x0jvChRXGoREbqRmUQAbVl00JcOUsnzM5bdfmK+dPtz1/ajIaYOEZAPChg4AGAPztzF3tbQXS5KipLgEsUrAdLWKa6/FUYduTBr2hc8jUaUC6TMYOo6Ht0f2rRzLFy5d+7jHJfokd051B86bTAhg0fxrFl2zrTyEFUsgBFIo/herPoAfZ24W5TdwdElhXcLS/7bEJfx2sa8jcYUDaOp7dKUyKXTnFZd0U502fjM9aE1ovFdXgIZst0RDzJoursyT//27heLeeq/B0fnO14u8Oy9NlETdPIQ67wMdy/HMNnqqZcSfF26TrQ/b5zxMu97p3SafvbDIMPTagL41IG/4LBqZ/9aTxulywO2rhp0sn2Hk4spay6UsZtKVUqjuN4k6nLKHZLqbYLiLbLqZS3JnMxSzWEntu1Odz8uKFj2//jBl6UKSHaGhzD/5dGuh69GNdxbov5wRxWaEsWjiXvmKSg2L98mopsYujJltSpSR+u9Ap+FpZnI7YyEGcD40/KeBtWjd7YgiXGsykBNPJgTRKoAMnPzXp1g/fdrS9NBognQEA/0dAQAMA/mYG/dA3tZro+bP8uLQge9qK6a5Zeze/enjPZBocQoeG0D6TsWew/em3VRXbw/x9prjMZ1MWMEmL6CQPBsWbTvFj0XxZ1CBHdqirXbirXTCHHsCghDBpgURb0wMc7aJmzziwY9Ozplt4Qw8RDd1pNLx63ng1e8/GtZ9M2jpzfEa4V32GgLjRd06iKidRnZ2ozUqsykqoViZUjc7l9+dfCWhhVc7v65kIaMnIjPrc6ixifffN/f/wwTNaGlstjTuxb13a2iDFzlW3zlca+x4hQ0+Nxud64wsUfY3qX107W7Uj1N/ThbuYRfFgk5eyKV4cOv4LhgeD4clh+bs6BE92jpw1KcjN0ZPLcKdTfRhMLyrVi071dXDY6utTczS37/UTFO0ZxLr6zV0GtMvQ+/xiZfHKT6ZFspkRdEoIixo9fXyxYFetIsGyiwOvZ0GVUlCtJPZyEGdxjNxjJT1GvjEiarI9cb8bBsWfSvbnsi6oKvSDg6P/1a2EYShqGkRN/ahpAEPxEIcdIACAvxMENADg72TGsKetTXui/Lwdab529LBJTsnrVz67e82k7zagej2mNxp7u14+KjukCPt89gI75gIWZQGDvIBBWsiiLOYyPBzZ0V/Ozordps3NvFhx9GLZ4ZI0YUyoj68Dy4/D8Gcz/blsHzuu30TX2NXLm3+5gmDdQ0g7inWa+p89vf29bMuqjbNc0yO8atJ4NXhAZxHLz1rL4HFMHMTx11agdVlvVqDfXXh+N53f/9yRDRIjVWqZOLU0tiJtb96+Nco90S2Xaw1dzYj+mUH/zGh4iRrbBrsfVBcfCvls+iIu05PD8GCQvdhUDxZ5CZu6iEVf8dmcg7y936iKGr8/9fjm1zfOaY5K4lZ8OnMpk+7FpHuSbT2oVE87uwC3SUr+/hetd4xIF/47hhHrRo2dvS9aFft3hDlyQxiUUDYtkEPd5zlfnRJXrbQsz2eLq5VCPKCrlG++WqKhM2LVqTEHVgUFOzH8WFQ/OtmbQRWvWfn6+bO/svaMFzNq6sSQ18NYhxltx9B21NRjxpC/8poAAPBXQEADAP5G5r7uTtXhrMDJXC87ctBEh71hfg0/XEQGu03IoBEzmNDBgc4X5blK72mT5rPpC+iUxQy8C2kLOPQv8Xqe6ByzOvLqeV37s7t93Y/6+h4NDjzp7WhtvfXd0QRe+LTJ3hy2P5vlz+F423G9J7ruWRn5qPFnk6HDaHqNIq+Ng08bf6iThHsmRXrr0ni1ckmVMgGfkTJ+uxn6nwT0+7cq/DWL3wxxpeBv683vpPNv/f1+QI9cpfcmoGUx5en7DvLXX6kvNPa2IIanBuNzxITX8+uh7seHU+MCZk1cyKUvYVKXMqieTIo7g4TX80I7xsovP7954Uz305aB7mfGoeeo6aVx4FnPi6brp7Tr3Rd6cBheDKo3g+7FwLOb4TfRJW511PPWX1Ck24DXKtpj1Hc8unt1i8f8AC49lMsIYdMjnNg5m1ZpM0VaPKBz4muUwlqlEA/oka+WCOjMOG0mX5Ucs993QZAj04dJ9mZSw6dOqD9ZZBgaGv2P/y8xj9SzGetA8XQ2d2NYF4ZnNNKBIb1mMzL6jwMAwP8KCGgAwN8GMZnuXb+6xWehjwPZx4m6dvFnZ0sLDP09JtQ0ZNKbUINxsOf6+frILz/7gkVdSKe4M2lL6JSFTOoXHMaSKRPiNq9puvXjYN+LIUPbENoxgLUPYu0mtNM01Nb+uDGPH+fOYnkzmX4spg+L5cFmeU1w4a+PftHyC2JsN6JtBvTVYO+Db4qzMzZGqg7EEQdxyPEoJHZuEPuSLQGtfXNj7T+Z91edRwU08ZF36jmh6s0e638Y0FXE8c8CfEYCuiJjX0n63qr8tP6uBoPxsd70VG98gRjaBruelOQc8HJzWMylurOonkQNU72YxP6NRVxa+LxZ3+kqB14/Mxq69aYuPdYxiL4y4t8fpNPY//L6maroBXPxhvZh0r1pNB8GYymT7ulsJ1y/8lnTTdTYiSBdQ2j3oKH9YmX+sllugRx6GJMWzqJtmDVZm8Yn7vCCB7RCWKsQVr8N6DdL5lJ+lVRYLNq1Yd4Mbw7Fm0nx5TK2+S19eP8ehmGjfwL+GQxDEFMPhnWjWDdmJs6xRrB+s7nfjPVgaBdq6h+GRWgAwN8BAhoA8Lfp6+k5eVDp6cTy4JKWzZlYKk/ubXuKoCaDGTUgxqG+7sunarYEeM/n0OczyIvoZLye8VnApH3hwFkZ6HX98kX9UMeQocOAdA7hYx7ZftCFId3oYEfD95dWzZvnzqD7sPBMZPiw2Us5bJ+J4w/s3tL9vNFkatOb2/Wm552PflZnJ5alxtbKE+otU6OUjBzHocnBA3p0H//5jK7nt/P7gP71nikSrWU7xLuvMBLQvy3rZsaqpLHlWYL2x1f1hkdD2HM99sJkfGXoe14oS/n/2Hvvt6jOtW//P3i/z04EpleKNaaYHRO7dIZi7y0mxoIFELBQhyagtKGq2Oh9YArN3jWxd7GLdBiYvvp873tGDDE72XnedyfuHMc6j+tYezHMjKyV+eGca3/u617w9efuAoYXkGYeU8Jh+XKZEj7DU8iYKWSoiw8aetsRowZBdQipNVADRgsscItIYggZ7KzOy5A4CyU8YM9sfw7bl830Af49WpQQuK73xQMM1ZgpnZEa1PY9O5K4e/FYpyU8znIue7GQvfe7RQpZnCJH2pQbBwRaNfzXDmdOIhuyYurTow/t2LT6q/F+ApaEzZjjIizKTDXotP/b0AWBGwnwX5PU4VCdjThlJigzThpsDk0RepKkh0nT0NB8AGiBpqGh+TCQBPHk3p1NcyVuIrbvOEHUd4t7XtwjUD1CoAiOm42GH4+3rnGf7e4kmM1nufIY7lx7D46DB5fpKuC4jh+dEBnWP9BpxIZM2CCCDWL4IEYM4uQQTgwB5aJQbe/LJzvXrJjNY3nz2b58jj+P58fnewv587/8tDx3r0kPTLTPTHbjxvZXN8+U741SyZKAPTdnJzRmxyvhpiqx9aByYn9tyb9TNlf+DXW2hTfeC4HEv/8OcE4czEXYrLQhK6omK+ru+VoCeY3gb0wUHINNmnrO1JfN+Wy8t5gP7NmL6+DFZXhzWT48Bkw/i1nTRExN51MMGURQPYYacFyHUoNmiwYKtHXqM4UOvrp11W+8s7eALeEx/bhMf2sBEQcOnRuz09Dfbia0RkqHEv39L24H+bovFvCW87hL+Kx1X39SnhiuyolvykloyolX5Vjn/Y3oQ9dnwfHVisy4vRtWLBgr9uUwfQXsdR4zb1+5iGPY+5+D3wZ8QihSRxFDJLBnykBQJmDPJGXCCT1FGS2kDhSFm+kmNA0NzV8PLdA0NDQfBr1OW3Ew12ei83QBI2DSuNLsZNTYh+N6FDfhmLnz6ZOEjRvcRQJXHnsWjzGLa+/KtXPj2rtxGTP5bNdPxmSlxOmNGgOpMxJDCJBmoFmgSC0ON/TWkqSup+NZ+LrVMwQsTwHbR8CBDs23OrRY8J3E9fmDHxG8F7H0EUSPvvfxydJ8Zc6eJlliS06CGpjuzxud/DuBHt73RJ5t26xbai1o3j8PsMv5l53pfx2htnWgbUoK1+fJYpuPZQx13cWQdoyEk7BJvO/F3aub50m8RDwfHtsbCDSP6cFjefJYQKY9eQ6ejux/cuz0wICRITNmIFADhelIYhAjBxAo0BrCorPg2t62u37jXTwFLC8+04fP9OMx/LkMPy5DIuQs+PLT86pak6EXofQINUCgfYqCjOVjXZbwOCuE3MXO3MwNK5RZ0sachMbcBFWudKRA244KuL4wrjJ5d7D3TH8hR8JjzRktztgVpunt+V80jAnUgg9AS6YMOKm35jcMBKknSYOF0lssBgofspAILdA0NDR/PbRA09DQfAAokux6/TIhaMNsZ/ZMJ84qn9lXTzfh6BCG6zFMj2gHztVVLfh0ohef585lz+IyZnDtZvHs3Hj2cP6GkOs61lkaFqQZ7DFReqNFi1JagtSS4GjRgXOUGsLxoVdP7343TzJTwAYC7cVnS6BAcwP4fIlQ4P/pWFXJQQIfQMh+GAs2vLl/XqXKS27KTmrOTVTlxSvy4xRvvfCPC3Q0KKtD/7wR93DFwiiItd4J9G+lqBVwkh0UaOs2LtK6nLhbZ+oI8xsM70SJXhTro8x9R1PjfMY6+vDZvlyWN4/tAYoPCjg0wweUmP0N1+7Bj+dQVGfGjCRmsGBaCz5EkRqcGkAt8AsGhQ1dO9noM9rJS8j14rO8+TD7ARw6gM/05TO9HHmhqxYPdr/ACDgZGsX6X969GixxX+4kXCrgLBazt3tMaUiLbsxNUuXGjxToBhlQZ5jetqZQpMrs+CO7ty7+xFkiAKLPXj75i1sXzv3xJjRFmCkg0BY9CdvPetICjwT0ab2Fgu1nC6GnCFqgaWhoPgC0QNPQ0HwAgEXd++nqeslsd0eW53hx6HcrBrpewbQupiUQTf+rR/Hr17rzuJ5sjgeHPZvLmMmzn8W3d+PbuwOBhosI+cu9PZ7ev4MReqDLsOVMDZEWLWYZQuBRiyL9V0+ovSeOdRdwvflsb6tAW4McXImA7zPWKWVHEIFpUAKursPRnu7HPzUdTG/K29OYl6jMTwACrcyVqrNjlf9eoN9a8juB/rVP/6KGHfr99xmudx1om0DX5CcMdd+niB6E7DXjfSQ5hGo6lkz7p7eTQMJl+nKZXnyOB5/jbhVoLx7Dl8fw5jFm8RwOpMRhJi1KGOGqO1JrIQctpIakNAQFu/W4sT8/IdrHxcmTzwHfLryAQAugOvvDzbeZnkKOxzina2ebMRRGPlByEB18UxAZunyc8wpH/hIha/k4YXXCjsb8Pcp8+H0DOLS1Xw4nQytkUQ2wouGFyOJVWQk75nj6i3i+PE6AWJAeFqwd6PuDTWg4qA4fslB6ymIC9mwrKNBAnYFDwxMDQaDvv4yGhobmz4cWaBoamg8AYjKeklcv+ny872j+3H9+UpiejBi1ZkSPoIOIruOSqmL+pHHA7bw5XE8Ox43Lms1nzBY4uPPtPWEYmjWLx3UfP65w317cNEQRQxZiCDiiTaAx2GEdGux6nhoU6M7jeXM5PjAcDAUaOrSA5ysUeLuIf5gnMQx2YOSgkRpAsV5T37PTpQWN+SlN+XtU+cCh45R5sY3ZsSprMOOP1EiBtp0PP/Ku4K9sGv070WpbBtom0A250hO1+wmsCyd7EXIAIQYoTHNRXevuLPQR8WB2GUgzVGeOmwA2ob3h2DgmcGgPAWudn2d7232CNKJAOi06i0VrsWgoyyBJacG9uv/j+dVebl5ioTeP48Nj+fBZNoEG9uwnYHmJODNEnPTYcLOxB+5NSA2S4AtJY+2Kz8ctdxYuF3MXChm5gavB9w0lvFe/EGgVuMasKOtoDnAJcars+KORwUs+Ge3H5/rxOKu/+fLqyRYM/YPWSxGYicR1FGUkKT1J6SiLEWo0ZVtEqCcwI0X9ryd70NDQ0Py/Qws0DQ3NB0A7qDm0N9FvnNhvjGCJ69c/nj+OmPUIZjAj/X2vbmeFb/Jy4njw2F5wRDHbg8dy5zGtxXDjMtx4zFl89kwxb6X7rEtNDYRpgMK1JKGDS81IHUFotf2v6w/nL5j0mZeA5w0snM8ErukjYHkLOD5CLlBPH0fB0umTH10/RxADKNWPEj2Yof368WpVfnJzfnJjfpIyL0GRG6fOlv5bgW6wZhXg8Obs2JHn1gwDrIbs6AbrbiM/Lw18+1prThqGH37OdShy4pSyWBXcjDBakRtblxf74KcmiuzDiX4TCf7UQWSoY1/IVh8nIbgQibVhDK7LC8ZU4CQ7mGaGu6gw3QUM99GCfOkuo6aDJIFlAuO05oYpuCav79WjnWuWeTkLfQVcoOASa/t5uFg+Ira3kO0uYn8f4N7d/tBMasC/S2AD+jeP17tOWeosWu0kWCpgR/q7NeYkqvYnqvLjbAJtG7038krhHZDFKTLjwwPc5znx/XgsPzEvLXSbpqf7DzehSWDJJD5IUaC04CqgScO8+yCJDpKw/fyH3oeGhobmPwst0DQ0NB+Avu7OXd+v8B7N8xsvClwW8Ob1YxQ1mFGdydTz+KfjGz2negtZnny2J9yMmu1pXSHnYXVoNz7TTcCaBUxazJkt5q7xcasvKuxrf0oiOgozIPr+B9cv5SXFLvzmnx4ivo+Q520VSptAewk5XiIO3EBEzJ/3xQRF6QEC78OIXpTswZE3L+6cUeTtaclLbspLBALdkBevyo5TyYANQ+X9rXonyu8V8GBb/VIorSvtRiQ9bAKteGfPOXHqHOnbwXC5scrCpK4XPxFEH473IZZBhNS8uH/tB083P7FQIuRJBGw/OPWZZbtGHz4TCLSXgOkBSsSaLWR4jxEWxEfcu3qONA1ZcIMFN1ow3ZNbV+K2rPMd7+Ir5vrzWAHW3rOt/QzsGdx2LzEbvBuoJVM/v3vtBEIMYDD1oaGM3Yk/rFo6zmmlo3CZgBM47YuGtBh1QaJ6hEDbFhGOvN56+H0gsXDHpqWfOPmDf0XAWvLlxNuXzhP4H94DBUg0bqYwLQlj3FqSHCLwIRLXkQRC2zMNDc2HghZoGhqaD0DHy+ffes/0cObO/cwlPnyjRtOOwvyG1mToutJS5TdWAETQE2ZzuV5We37r0HyWO5/lIWABjXblM2fzmTPFvPnf/HPz4vl7woOzYiNit2xcF+Dj//kn3k4ioJhwsptNoPnwxCrQXHD0AQ49wTk3aTdi6sSIPoTswdCO/lc3gUA35SQ15iYo8+KhQAOdldnCCf+mlLL3S5EVDev9juz7Am1bbPdrgYb5jZzY1pL0ga47QPEJst9MaVBi4GJj3ZwJ4/1FQjhXRMT2E1gvcIRAWxvSTC8Ry03AcBezfD9x+dbDNXb9unxpdE5MRNyWDYFzfed8Ns7bkScRsv0FLD8+01fIkght+Q2rQItsPWn2vEljz7ZUmTFwfzQ4PmAx91WkJywa77REzF8m4q75zKU6aYc6L0Gd975Aj3ToBhhKiVOkxwZ5Tpkjhn+wxJGbFxup1w79wSa0FfBcgiRRkjSTJGI9If43L6ehoaH5D0MLNA0NzV8NRZLPH91fNvOfHo7ceV+Oy90bpdN3YZgex3QmbYe6KHc2dxRwQdiBFnCtS9zeNqFtDu3GZXgK2O4CKNNufJargOPuKPQZ6+I/cZzv+NHezmJvMd9HyPHnc/z4bB8hGzilL+yzQoH2FHK8YXG9xojitv+gG3qBkv0I2YthHbqu+02H0tS5iarcuIY8KShVjjUG/Ws5HmHD/yq38POv6mXRclkUTEKPkOaf7TknRvkLgYbjLKA9y2JUcP/C2NPlMm3fA4zsIYg+8HdiWH+ZbJ+PWDxHKJDAOApbIrTa87BAgwLnnjwGvHtAo2EXn+UnEs51cV4wftyCT8bPGz/G30UsEfP8xDx/EccfOLSQDQTaR8SyCbT1awbcDxz27McJFeX7zUgPSmoIctCCay7Vly78dPQCMXepI2/5eFFpdJA6N/49gX7PoeGehdnxykxp3ta1i8YJYcCaz1jrNu3RresE8Yeb0MNYpdlWNDQ0NB8SWqBpaGj+anAcu3f96uIpn7uLuQFfji86kGZC+3FcT6BaXf+ro6kxrhw7b6vveghsMyLeFnRoPstLwIEmzWV6g0c4DE9wYn2aRMQF5Svk+gpgp9NfwPa1dmTfCrSQDYVSCBPDPiKOhwt/d+AqTX8bSvSZqV4U69D3PDxRkt2YBwQ6HthzfR4UXNUvu8sKON7Ymq/Ijqm3rhEc6dDvch312THAm+usVZsVaTsBT64DL/m592wrq0Bnw+nRCuswOBVcuWgdwZErPVuVo9c8NhNdGNGLkf0EPpAWtk0iFM7h8/1FPC8B01sIjfkXAm29ZBhltqqqn4ATwIc1R8ANgMWZI+KCOzPH0SrQYlaAiO0rYo8UaPBuvlxwznZ34pTvTzMZu1BCgxMaCut/cOXEymlfzHfmL3biLRnDPxS6viknvnF4Csc7gR7p0PVZcCC0Miu2OjF8s+vkAEcO+NskLvyirFSDboieQEdDQ/M3hRZoGhqavxocQ69fOD3/nxPcgMN9OaGmpMCMD+DEEIkNDXU/y9wd7AHbz0xPIdtTyPGyTnH+2aG5TC+4YwjLi8vyhlOQ4eZ53jwGbJryWUAB/a1HPyEb5nqFIzrQVoH2ErE9bW1aF37kljUD/U8Qos9EdKNoh6730anSHDXcGQR2oOW5tqFs0Q3vZmLAJYPAqq0nVgm2CnSMrazrBa3jNXJi5dkxdTJQ0XVZ0fKsKFg2mR42abltWaHMVvCFDW8XFEKBVudAH1Xmx5+ryTNqn5jILoLsQ7FeAumXbljrK+DP4fP8wJ0RsiRieHW2mIrNoWGOmceAJ9bgClxoKIBrDf15zDk85lwBe66ANVfEAd7sL2b7Chn+QJ2tAg3nb1jvErhjfjAbzXYVMvNTogy6DpwcBAJNYn0vH1zd4Dt7/mjhIkfuImduXuAauHHjvxLoEQ4d2wAuMCtakRGdvn7ZgrFCCYyaMAL9PV4/ayNJeoYGDQ3N3xJaoGloaP5qMBT58czxeV+McxNw5kz6pK7sAFyphg+SmGaw60lS0HoPPpyY4SXmeIrY4MTWYLaVN8/qzcPlxQM+Dfev9uEzrMbMshUwQm+xtYRvO9C2cAIQaHD0FrK9xwqSd23SaZ+b8W4z0Y1hHfrehyeLZaqceCjQubHyHNtQtlhFbiwMYMhgBkORK62HUzWsnWOr7yqzpUqZVJElbciE3dZ6KNPSellsXVaMrRoyo0DBPa5tTejhzjRUTGtO2pb0sC4ohD1pINCNuXFwGWJewrnqAsNQm5HsxIlenOgn0P7o71dJBPx5QoGfiAuvTgS/JEBptgWgR9TbGAYQa6GDj9ABurKQMUfIDBAw5ohY/mKWn4jpI2L4Dd8uP5iHtgZdoHNz/IFAi1gZ0jCD9g1ODaHEAEkMdD2/vX2J3/wxQKB5Cxw5sh+WN2f/ogNt3cf7Z4e2XmOMPNO6N2FWbEVC2NrJnwQI2HDDcBf+GaX8D8+zo6GhofnvghZoGhqavxog0FdPH184aYI7nzvns4m1xfsRfADFBzC0T9PdlrD1Bw8B10fIhXEL0duML5wvMVzv4gq2ZXOeAmveV8DwFgIjhFIItBLIJXitTZdHCrQntGf4bpLxwrzknai53YR1oGQXirZre+43HUxtzIlXw71OgEDDtIYS9pVtm5tIoStbdVkli7OWVC2TNsoSmmQJjVnx6sw4VYZUmRkHSpEprc+QNsCKVWZEKTOjoChnwjgHTHRkRdZnRtrE2ubWMCqdHS23tmxhANr2L+bGn6vK12seI2Q3TsIIB4n1R/2wykfAm8Pn+QKBFjElYtZIgX7v/gCBBuceQoYnuCEihgTqMix/EdMPmjcDJjfgCsIRAi2Ed8lPwPYXctwc2XnJkQZ9J05pUUJD4gN9L+/tXrlg/mjRIif+fDE7bc2iJlncO4G2BjZ+Yc82ga63teEzIhXpMeGSWfPFXAmX4cVnJAdv0g4MvP/hoKGhofk7QAs0DQ3NXw2OoTcunF3y1WcePO6cTyZUHcoxIz0Y0Y9gPZrep1nRoW582Hj2ErC9YQf6fYH+ZbE8BSzo0FZNBOUlgovnbAXf5P0ONMtHDBMLcz53rizci2MdCPYGwd+gyCtN+w1FTnxTdrxaZms5xyqzYoEoK2Xxyqw4FTDjDKkiLaYhNbo+OaI2cWd1fFi1NKwmNrwmJhweY3fUSHfUxO+UJ0bU74lUpMSo9kkb0+Ka0mMa06OARisyYaoBNptt0yoy4SMKW3M6yxrtsLalFVmxoBpkwOClJ8uyh/ruY1Q3RnYjRA+O9e3dsdVLxA8Q8mA0Bdgz8GABFGhr4vndd4m3N8cWiX77oJDpLWTYutF+bwXaOr1OAKVZAqUZpsatb8uR8FngbT3H8MsKM0zmHowcQnAg0Jq+5/ciV8xf4Cxc7ChYIGLvW7OoURavzou3beX9LwW6HrafYSK8NiNCnha577sli0cLA3gsHy7je7dpT+7dJgni/c8HDQ0NzX89tEDT0ND81RAE/vDGtZVTvvTi8vzHjN2fGqfXd6B4rxnvHhp8Ubk/YxZcFwiX+sF1cv9OoGEw2uqInkKrPYuYttiGhM/24XPg+/xSoL1FLF9H7qoZk26ckWNIO4q1m9FXqOn5y9sn6rOljcCYYRgjWp4Z3ZAeo0yPbUiLrU2OqIwLL4kIOhoeeHT7xqMhG48Grz8atL4oeENJ0MaSbRtLgjaVBAeWhLyt4tDNpWFby3ZsK9+1rSYmuD4pXJUeqbIlnodndMAhdzaBzoysy4Sd6VpwkhHRkBkDCvzrdbKYpqNp/Z03UaoLwTvNZDe4RRV5+zwEXD/bCA5HcGkOtgEjIwUa6rL15sBWNI/lzWPDgslvhrfAATi0RMSw2fPw+GcYfQECDSPjIraPE1ciZPuKuHMnjT2uLEPQPoTQmLEBEtN0td0Om+e30Em4RMxf7MjL/H4ZuF3q3Li3G4//K4GWZ0TWZ0bVZUVVZ+6uTt15KGzjqolj5ls3cAkYJ5IfO2g2Gd//fNDQ0ND810MLNA0NzV8NRVEvHz9cM+MbLx5P4uycEBI4NPjKjMIsss7w+oy60mO0yFMA98ODcQvbpLYRUyb+lUDbmtBv7VkC0whsPx7Hj8eV8DlQpm0WLoT2LBGz/Vz42+Z56DruYchrE/bKjL0y6Z/cOFmpyIFJDEVGbF16jDwtuj4lsjYxsjx2x7GdwUfCthwO2XQ4aOORLRuObt1wbOuGoi0bigLXlwZufFtbNtmqZOum4q2bSraB2lgcvPHY9vXHwjaURGypTghVpEfaRnnUZ0fVy6IaYJYjQp4ZUQcqI6IuPaIubbc8Pao+I7ouA0hntOJAUk/7dYzsNuOdCNWLYD3n1VUBE0b7wJEjbBjhEDHgUAvb1Q3b80iH9uGyJRyOhMuRwP26wd1jeAkYPsCefynQPrAJDd6TA8uRC49OvGVuX9+5ccaM9pnxAZTQUOjAi1uXN7rPWOQoXCriL3URZG9cpZbFqX5XoBtsGg0EOmN3Tequ0qjgENep84VcXy78Pwrit/zQ19VJ0UsJaWho/m7QAk1DQ/MB6Hz1YqPEzYvP8XQUbVk6r7+zDUF7zHiPHu28c/PUaslMVyCFcGwz2xNOaoMzJXx5TGBdvlYRhMVj+8DGqlWdoT3bVBt2nX35HH8eJ4ALiu0L3we4GsOWbfDhs/wduf5jhVk7NhG6l4jphQ57bkKf63runikvUGUlKtLi5PukNSlRNUm7q2N3lEVsL96x/Vho0JGQrYXbAg9v3Xx0a+CxzZuObd5YFLixOHBjCahNQKA3lW/ZXLFlc9mWzeVbN5dt21xmPZYEbzmyfcvh7YHFYZuLwzfXxIcp0mCQQ54dKc+JkMt212bsqs3YXZe+S562qx7Y8z5wAkw6Up4Be7fAod88uogRPSa8CyH6MKz35d0r37pOkQg5tugFDHzbxtjZEt4iFrhdNnt+F4P24bJgH9rq02/dWvDzyA4/uPiSAYeTiLlejnxfMc9fzPF1ZHuM5oduWNnb9wLFNRisARLtv3VavfTLCQuFvOUiwcpxTodCN8IsuFWgbSM4fr2IsD7LGuHIjK5Li6xJ2VUVH568auF8FwGcxcF1WDnly4c3r/8vdiWkoaGh+e+AFmgaGpoPQH93Z8z3K7z4bFcee+G0r9rbbuFYvwnrMRG9b9rvJoRudHcSePK5ngI2kMJ3Oea3YyXe5hOgQNvUcHhNIQuGd/kwEwxTDbapxjD7+zYV7SMAPs32FbLnjhGlbf3uze2zuq67iP4xrnvce/fMmSOZ6vS4hr0x1cmR5Ym7SuPCi6NDju7eeiAscP/2jQdDAwvDAgtDAw+GbDy8feOR0MCjYYFFoYEl4ZtLYW0pCd1SAkQ5BGY5ioMDS4O3lIZsLQnZWhyytWz7toqQLVXbt9ZFb1elRCgyIhsyIxRZkeqsyPqM3TXAofftqk3dId+7U566Ezr0vgig0UCp6/btfnxZjaFdZrzbRPSgWA+ieZ2wea23mAuu1w+OcH6b37AJNHTo4fbz8D2BM/7e3bR3v30n0L6CdwLN93Hk+4m5/uA9nbgenziqaov15gGMGEKwAYIcpNB+9ZHcBRNcFon4K0T8tZ+PrZSGqXLgLiq/K9DQoeEgjrTI2mQg0DsOhQWu+HysxPqHScS85upyFDG///mgoaGh+e+GFmgaGpoPgE4zcDAxxkPAms1h+n86/scWBW7qNaG9JrzPqO84KS/1meDiKeR5C7mecJIG2xplZg8vGYS7eXvCXAe0ZJs0w9nPtoIr4d5uSQ3K921KAVqmn4AVwGfNE3DmiTgrvxi7PcA1N/T7G3X7h262vGwtP3sgRZkWVZO8szxpx7GE7ftjthTGB5Wm7azNi20uSjtdlXNJcfB6y7F7Zyoenq9+fFnedkXedqn20fnK+6dLb7cc+7HhwMWqnDNF6a0HkxVZ0pqUiFLp9mO7txZt31wavLkqdGv1jm3y6NDqqJDSqG1Hdm44Er6+ZOfGkugtxxKCypK2lydur0gKrUwOq0wNr9q7s2af1ar37m4pzSaRTozsMZE9CNFLoD0XlBWuYrhrDBw2Zw0u2yIccLj1ewHodw49nHh57wm22wILbmoI1Jk7R8zxd2R7unA3LpR0vHpswvRmYhAjBwlCY0H6s3cFLRjrtNRJsEzE2zr9S8W+aFXu2xWENnv+lwINR3CMEOjy6PBgj5ngz/bmMT25jJTQIN3Q4PufDxoaGpr/bmiBpqGh+QCYjYbGsiKJs2A2i+Hj7HR4Txxm6jOhfWaiH0P63rTdDFu9xJXPgRkP4M3Do6DBuZuA5SZku4tgtMPaZwUCzZEIOEDI/IQcP3C0bq1nK3A+h8+aw2MG8Bn+PMYcPmMuj7lIyF7EZy5z4q4cI9z69YTcFT5n03bdKc06kR+nsG4cqChIOFeTd+9c1dPbTe1tJ/vaL+g1N4xDt0y624jhNmq6i5rvIqAQcLyDmG4ihhuI/oZZd9M0eE3f++Ngx+XeZ+c6H556eavl2Y+qx61VV0rzmtJj8zavSVrmHznHbYfvzDDvaTt9Zkjneaasnpe+deX+nesPRwQejdlaFBdUtCekJGV7aWp4RerOytRdJWmRpoEnJNVrILpMll4z1q3re77KfYqHECZVAvgcP2tPHTah30+H/+zQ7x4ZKdDw7sEOPSxfAXsO+F4h5MwVc3ydOe5jBYXpCUZtH4obTcQQSg6S2ACp6wpd4LtwtHiZk2CJmBO3SKLMkirz4uHOMsPt539RtgEjUKCjapMjquN3V8bs2LNiob+Y68lx8OIxNvh6vHpK76hCQ0PzN4MWaBoamg8AhqI3L51bNWPyLKaDO58ftnRhf/tjI9pnQPtQpN8w2H6irmTupIme0KGH9yDks90FLFcBa7YQODQM+1oFEc6q8xFxJWKuryPXzxE2UOeIWfOEzPkC5gIBc56AMVdgHyCw9+Pb+Qvs5vLtFgjslgodlgsdVjuyNn3Cj5k9oeAHv6ulqXdaDj6/Xt/37Iyu65pRcwfTP8CRNhx7TOGPLYS1qDYL9dhajyjqIWUBR1APLOR9az2w4Pcp7B6F3CNNd0nDHUJ3B9fdQTV3jN03rqsPB8+dsX7mZxunfbppysTAKZ9tm/FlmMeUqLkeCSvnyAJX5wWvPRD+Q+HujQdjNh2Sbi5KCC5NCqtM3lGavOvRlWYL3m0iO/WWHj3RhSA9tYUy34mjJUKeP58L7NnWhB4pyiMdWvLLAR3vyibQsLsvhP37eXzWAiF7jiPHazTX95tPL55SIyYtihrNpBajBilM037nyvfTv1rsLFwq5i0Sswu3r1fK4hqgQL/dQuVfl3U8nzwzaligd1XF7MwPXLdknLM3l+HFcZj/+diTijo6xUFDQ/P3ghZoGhqaDwBFkm9ePI9at2omy34mw2HplK8utTYYTD0mrB+OfUB6O1/dS925zcOJ785je/KAQHO9+BwPawcaOLSbNa5gyx54CtgSoM5izlxn3jwnznxH9kJH9gIxExwXOnMWTRAs/kK0YrLL6qnjvp05fvXUMUu/ECwcy5gn+scSJ7v1k/gZazyu1aRpXp4yaX5CzfcJ9JEFe2rBn1nI56TlBUE9o2xFPrXAekIRTyi8jcQfU5i1gF6TbeBxC/GIIkE9JPEHJH6fxO8S2B0CA8f7pPn+y5uKXcvdfpg6PvDr8YGTx2+Z8snmGZ+H+U7fvcAjftWcjE3Ls7eszN22qmD7twVha/NDv80PWpO3edXRkHWl0dubj2SZ+5+geIeB6tbCiRy93c/vRK5b6SXm+9oGQtuG/f1Snd9asnW94G8JNHyVmOslYAUIOfMEzPlClp8Td5YLJyLoh672pxhqxDATQulwcogy9zcfyV/x2fgl1vbz2s9dahJ3KLLj6nOkDcObeI/05p9/lEXBjWOyohrSomv3RFTF7aqI3nEkZMt3//wMzhbkMb0cOUcyUg06HUVR739KaGhoaP5boQWahobmw6DXDlUUZHs68Wcw7LxdxLLYnbrBdjPab0B7DViv3tT54NqZrQv9Z/FYbjy2B5ftwWO5g+Kz3AUsDz7LE27fDQQRKCB7jhN/gSNvkZizzImzYjRvyVjeqq/GRC73LUoMPVmZffd89YvbTa8fnmh/2PrqQcuzG/VnqtP3hSxKDZzbekjafU+FaH4i0PsY9Rih2nDqGUk+p4jnFvIFRb2g8Oeo7lF/x7U3z86/enjq+Z3mtmuKR1fkjy7XPb4sf3K14dl19fNbzS/vneh8elrTcdk8dJNE7pPYAwq7h6N3gEZT+F2L6Y6h49L+iLXBnl+Ge06One+auWFxYfTGqpxI5ZGU1nJZS2lm46E9dbLIQ7GBWcEr0zYuli703PTV+K1fTtjhMT31hxUnSvIJUweK9+iIbiPeg5t7nt68sHzGZHegv2KuJ3BoIccbfJfgs7xgvxmWLSzu+asfRz7uLYD5ch8RO0DMmSeGR8k4cfj3yx7euWo0aFDUgGEGhNCSuGbo9eOU9WuWjXNa5sRb6syJnDNbmQED0PXZMAD9nkC/jT7/LNARVoGOqdkTUSndWR4ZVhwWFDR72hwR15cHVT5u8zo4zI4WaBoamr8PtEDT0NB8GAgcf3zn5iY/z5nMj2fxGGs8Zz6/e9Wo7wYCrcN7DFj3kObZGUX5Krfps4TcGWwHNy7Llc1w5zFt5cljwAiHiC1x5Mxx5C4Us1eN5n07Xhg043PZllXnaw48v3ViqOeOSfcYNbVR+AuKeAaLfIIRD42GG92vT3c9P2EcuEYg9wjiEQ7U2fIMI58jSJvZ+Fg3cOd12+nbV+qutJacbzh8oiK/uVimPpKmPJCi2r9HXbCnCVYyOKry9zTuT20u3Nt6dN+J0oxTVVnnlflPrsn1XZcx/R3KfN+C3LOY7uH91x9fqDxflnGttuDRifL2u8f72y8PDlzTDt3RDt0d0twe6rve++r88/vNVxsPHUsOiVjssXHqp+smjl736ZiNUyYFek7/sbkK1bcbsS4z0YeivZihW1W8f/6Uz2ZbJ9BZ5/1xPMBXCx4cjG3Li9tq5I8e4GkiGCu3Jsvhdo/e8Mj0d+T6OXN8xwg3L/K/fem0Ud9vQnQopsdxHUZoKXTwUl3591P+udxFuNyJu3wcryBojUoW824H75ECDV3Zuie57aQeCLQsEm4ckx5buyeiInZn6a7Q0vCQ2Dm+8x35vjyGl4D5vdfMF48e0lsS0tDQ/I2gBZqGhubDQFGUVqMpSkudzRo1g/GR7xjHo6nxZk273tytw7sNeJfB3D7Q29ZSU7xg2ldT+MyZPNYsNsOV4+DKdXDjMTyAe/HhDiB+YpjcXTiGs3byGNnmFXebSgaeXUU0jwnzK5LosJAdFNFuwV9S5CuCeIaTz1BLG0q1YeRjDHtE4E9I8ilJPMdMbb1vfnx8s+nKydLm6jz50b31h5IbCpPrC5Lr8/aAkucm1ecmNeQk1csSGrLjFdnxSlAyeFIvi5dnSeuyYmqzoqtlUVXZUdW50crDSVfVh17cVGGDNyymB4ThPqq7bxy8jww9wPVtJAJs/gVBPSWoZ7Dg39CG448w5IFBe0fTcfWSsnDftpWrJ0/47tOx344bveKT0Zsks5vKDuBoD0r0mfFenOjT9T9rKM6VTHR2E3M8xFx3odWPh715pEC/Pbc9QWSdrg17z3BpJhwpDb6EOHE8R3O/lcy8ca7VrBtAED1KGDFSjxNDJDak7XgWvWrpkjFOK5wFS8SszTMm1qWEN+bB6XW2ERwjBdpmzz8LdHa0XBYJnqPMkNbuiayI2VGyI6QsPCRz9fIlLiJ/HtObzwqY4PzT2VM4hr3/EaGhoaH5b4UWaBoamg8AsGfEZHp6/27Kto2urI9dmR97cVlbfL3uXzqp1b0xYN1GtNOIdeiMr3vfPCoryJB8OeEbjsM0lv0stv0sjv1sroM7n+ElZAH5m+vMnTeO/4PHl+WZu9vvn8B1j0nkhWnwUdfTy9fO1F1qrbh6ourG6epHP6qGOq8jpjYMB9r6HBb+DMeeGbX3Xz869WNj0bnKgsaDe+V5yXV5ybW5SbWyBODKCmupshOVOYmK7AQlOMkF5/EN2XGgFDnxypw4RXZsgyxGnhVdlxldmxFVkx5VtS+iYm9EVXp0bXbsicqMjraTBPqMJF/j5GuSaCex16j2kan3tub5uTd3mt7cUrffUnfdb9J1XjQPXkfNjwikDRm49/LmicPS7Ru++uw7F+dVo53mjXNa6zn9dGM5gvYY0W4T3o3hPbr+J1V5+xZ8NXGWiO0qsIZbYDxjhD1b28zAlW0F7RkK9NsffQQcP+jQLC9nzqYFnmdVFbqBTgw1mc1GFDeg5BBOaAhj78nKkpVfTVrqLF4m5CwRM9PWzmvMjlEDgZZFw/3JfynQ734cFugoeXakIidGmQkFujwqHAh0SVhw4eYNqz8ZE8BjSWBfnFVzqIDe05uGhuZvBC3QNDQ0fylAnQkca3/yqDhr70ZfD7/RAjfGP7yZo/wY9ovGOOfsDBpov4+YOxGsS492gDIY3nR33FPXHNqyfN4sZ9FUtsMMtsMsLtONz/QUMXwcWXM/dYz6bv6lxiPa3puo8XH3y0tAl+sL9xbvjSzeE3ksOQpUcUpU2b7oSlnc8er8Z3dP4MYnFPZC23fr7uW6liqZ8nCKqmCPKjtBnZ2kyk5qgJWokCWqZIlqGXjQesxJVOcmgVLlJChzYTXkxNdDh34r0A2y2Pqs2IasWHlmrDw9Rr4vpjo1sjIl4lhyaFNpGoW+suDtBPKq98XV+2drzpRmHd+fdDw/4Xhe/Mm8+OO58S150ub8uONHUq4oC9uuKjHNI0LzpPvBheKokLXjRq8c47jYWTRvjGid94wTNUcxtBsleox4twnr0vY9Pt9Y/l2A61Qhw1XEcYcxaK4Xj+PNh+XDt4Y0oC6zPUWwA+1hdWhvERcINBz/J2D5OXO3LvS8faVJo3lmxjRmVAvDG6QOwftxsr/zwbW4b1csHe+y3JG/UszdMGl0TXxIc16cKjdWlROryo5VwGsfEeHIhl3nelm0XBYF28/Wgr3qrNja5IjyyLDS8JCS7cFFwVs3TJ7kD3eOZHkImQlBG7VDGjoGTUND83eBFmgaGpq/DpIgNL3dLdVFu1ctXDhhjDuTMZs5yp35kR/Dbq693QIue903XygL0sy9TzFzpxE4NNJlNHfq0dc9Q49vXT9Tf2R/zLer3EWCmWymh4Dl5Wi3fPrEQ6kRT2+dMA8+1PfeutxaVJUTV5S0uyh2R4l0d1lcREliVFFCZGlSdHFCRMmeyKqMOPWhtFut5S+uN11UHlQfSa7PkzYAEcyNs26qlwD82Lo5yLtKUABjhtJs7T3nJiqGqyEnYbjigEnbqkEWB006M0aeEV2XFlWzL7I0dUe1LPr5j+q2y4qL8gMthSmK9ChF6u6GpB1NqZFN+6JUe6Oa0mIbU2OUSZGKPVE1iRH16dKL1YVvbp1G+x703jh5bNfW9ZMnLhHzloh4C11E38/+5lJTtVnfbsJ6DGSPkezQGV5cu6hKjw5eNHWS1xixq4DjIeB6wvHYXF8hzwvO4rDusQL3+uZ4wCnaHHch28uRN2ec00aPqcXJu+9cUmt0z7R45yDWbcT6UXQAwwZQtH9o4HlR3M71X3220lmwypG7drxQtnZBY0a0OkcKvjaAO6aUwSHQ71rOUKOBPefEgCMc/wztOaYuO6YhN1Ypi6lN2V0eGVoSGlwaElIUvC3Mw9UPeLyA6c633xjg0dfVQQs0DQ3N3wVaoGloaP4iCBx7cu+mLDJo1ZTxvsJR3qyPPRmjZrJGzWSOkrAZc9nMpTze6tHOEQE+1+Ql2MALBO0yod1mpFuPdevwHpOhs/3O1ehVy9y4LHe+g6eTw/Ip4+oL92na72C6Z71tF0+WppclhxfHbi+KDMsPDkz5flX8mmVJ61bJQgJLE6Lq0pLkGUm1GQn1OUnqgyktx9KUhYnyvBhlnlSVK1XnxVkL2vPIsnaaE95J83v17lfvTLohG5il1NqNjpFnRtdlRNVmRFRnRMpz40BVws0Fd9Um7FAlRzTE7TgasiHjuyXJq+Ynr1yQvX5NVWS4ck9sXXxkZdyuiuTdVZkxt4+Xm59e1Vw7Dgx7zUTnpWLuUmfhXBfBavcpV07IUaTbhPegRBeOdZt1r/s77j+6frq+JH/n+mWrfab7fCJ2FTPchQx3EctTzPF2hKrqDTvQLHdHzrKZk3Z/t6iprODZnXN9HXf0hhc6vGsA6xok+/TEAIJpSGQQ6euoy8/aNuPrH8Y5r3Xir3LmpiyVqPZGqLJjFECIoT1LVZlvd1H5LYGugwIdaxPouuTd5RGhJduDioODQcUvnBfgyPcSMDwEDitnTn7R9pDeToWGhubvAi3QNDQ0fwUYgjy+dS1hw+oF4wUS3v9IOP/Hm/V/AsSsLf6eZWlJJfFRm91nfPvFJ6lLF5zL2vdMWaO7/xPS+5Qwd+FIjxkZMKED2oGXjUX5iz8f7wXs2fHjuV8KCqRBA69uUoaXpo5bN+WFDck7qqODC7f+EOI5e/HEcb4uYg8x18OJN2fi6O9nT5UFbZSnJ6hkKcrcZGVeoupAUkO+VFEgtQn0sEMngGrMT3xn0kCgf+3Nv13x1kQHdGirQEfVZUTWpO2uzYqqSo+o3Le7am9ETfJueVLEsbDN22Z/vWKi8zxnrp+Y5QeT3IJVn0+ULp5bKd1dnRBZmrCjODGsIm3X/aZi/d3TfZfU+7etXTFetGy0cKET39eFv3WRr67nCYp0oVgPjvbiaA9u6kKNHYP9bc/bLl+72NBYXXA4PSJ609JtSyXfek1bNXvyD57TQhdJ0kN+qDuw73JrxbMHZwcH2/TIaz3yRo90GpDuQXOXjhrUUoN6VEOatbeaG3f4B2yYMH7TOJe1zvydbt/IE0Ibc4ANS+vz4DUCe1bD1Mr7Am2rOjh/A/wIZHqEQO+2CnRQcNG24LTVK+aPFnvxHDwFDgsnjb924SyO/9+sI6SsgP99/xc0NDQ0fxq0QNPQ0PzpoIj52pkTEUvnL3QR+vPsfXkf+4kc1s+cVJ4a9eLWBV3306E3D5/9dPp6XXF7s9xwtlV/tkV/+aT25jnzsxvEwEvSqDHr+x9eO7tlrpuvmOkrtls8WZgXH9j19CfC9Mbce/d+S0lrepQqOqRo07frPp/gxWHMZNpNc/h4isM/vmF8NIX58UweI2C8c/TyBaqs5KbclOaCFHVBkqIgTpEfCwU6L264EtT5iY0FSeCohPb8xwU6wVrxChj/eJuKrgdmmRlVnxFZmxFRAyotQp4eW783pjBow+ovxnlzHTzZ9h4sOzcYYgFHO1e2g0TM2+w+/WhESHVyZOWenWWJITX7dl6vze+4IL9bf3jvt/OXjuavcBEucBQEjHUsy0xCta/NeA9C9JqsJo2h3SbkjRFpH9Q/HRx63NNzq/3Fj6+fXHn+8OKzexde3jv/5vGl3hc/abvvGAYfoMhzE/Jci70cwl4bkTeouRtBeo0Y7ECb0YH2uzfil60I/PTLwPHjNoxzjvKcVhW5rSUH3iV5vrQuN0aRI22USRXpw948PP55OLkxLNCyGLnMJtCxbwU6NLg4KOTYtuDsdeuWThzrAweq2EtGC5qryv+3+xGSJE4SZpIwELiOwPUEbqZIehYeDQ3NXwEt0DQ0NH8uqNl0+/K5iBXzFrjw/XlMPwFr3gTHkPneF+Ul2o5HBNJJol2E7oX5zZ2hG6fNl1rw883oabX5nFp/sVF3tVV396K5/Ynm1RNZVJhkDNffyW7RZ5y00OUdTy6QaB+qf33rdEVjjrQpMVyxc2uU23RPh4+n23881WHUFLuPptr/Ywpj1FSWPTjOYNkHjHOUbVnXmp/akp/clJ/UtD9BlR+nKoj/ufIT35UyL8Fav3blX9dbdYb2DPvWce+Gu8F4QwZcWleXEVGXEVW/L7oiNvzbLyd6Am9mjHJjOoDyYMHjLIb9bDZjFsfBQ8TZ5D6tNiWqJnl3bcrO6uTQ+oydp4+l3mwovFiUuWnKp6tdhCudxYtcxN+7TbneWmcyvUGJHjPaaUa7zXiXiegawtr1RIcWeWXC2g3IawP62ggUGX2FIC8wUOanpKmNNDwGRegeI8anZtNz3PyaNL4hzd2EuQtDuswDL8+VFKYvXhI1eWrIPz+PD3CTS0NP5yW1FoA7E9+QJ63PjW3IjlFmxSgyfzEB+jcFOgc8+a1Al4aGFAdtLwraXrBp07dffubDY3qw7bzFnLLcTKNe//6n5zcgSQLHTAQ+RBIDFNlHEb3gSOL9FKYlCdRC0VEQGhqaPxdaoGloaP5EUAS5ffl89Nolc0dzfPl2fk6cjV4z5PkZL+9eM2u6LeYBSvcS7bitu3tae1ltOFuPnKpFTlabTlSaTlSZwMnpOv0FVfeFJlV++uLJn3qLHBZMYEatdn92oxE3d5H4UP+rW6qDifWp4er40CMbVi0ScWbY/w/Q5W8YdlPtP54GBdpuCosxlWk/nWE3m2P/w8zJivS44wWpzUCg8+PVI+35lwL9TqPfybGtGnJg/WzMVs8e/hUcymELhLybkaywTXPLjGrIjKlNjgyXuPlwGe4MOw8Ww5XJdGMzPVhMNxZrNos5i82ayWHO4DA8ReyMTasV+2IV+yIa9u2oSw+XZ0c0HUo6V5JRvGPT+s/GfOskWj3acdFYx+3zvG6drHvz4JK+9yFqajcSHTqyc4js1FJdOqzThHQa0Dda4pWefGnGoToThkdY7y3s1VXkwRnk9gnzjePGG8dNt09h98/jbVeIlzfxjrtY1z301e3BK8dfVRddTJYqpGEtmbHnClNPHUwGAt2Un6iGXfbh4Ru/3IMQflWQRdVmRYIajnDAoRzgmUC1a/dYBXr7diDQxUGhhVu2Bk6fIuGxPNl2XkJWTvQu7UC/5d+vI6QIAiEwLUVoKHKQIAdIspei+oBAW0ARfRSuIXET7dA0NDR/KrRA09DQ/FkQBP7y8QPp+jUBY3ge/H94Odp/7zXleMUhXc9LEtFSiJ4a6sbuXTSfazC1VmLNFXhLOdZaamotMrQWmZqL0MYipKlU31LxqDJv19zZ3iKWvzN7o9fnZ+pkmP45iQ4O9b2+qCqpz4hoSNlRFxMU4T3DzeEfUxkffc20+4ZpN9UBCPRHU5j2U9iMqSyHGUz7mUy7ABdBZfyuEwWprfv3NBckNP52B/q3BPqdNI+s4V/FKaz2/E6gYWVHw21EsmOVmbFHdm4B1uvuMMqTae/GZMxiMFzZLODQbiz2bBYLCDR0aLbDbJ79Vu8ZDXtjmmVxKnB1WbtrsyPkuTFN+5NaZQlxczzWOItWu4iWjxHPdxYUhm36qaLwfmvV61undQOPzGi7gejQk51GvNOMdpmxN2b8JY48JbUPgTej90+ZLyvNp2qM6jKzqgxVl5sby8wtFcipGvP5etMVlemnJuR6K/ZTK3GpCT/VYGyteVp/5Gpp1rmj+04dSm0tSGrNS2rOSWjMliqy4C6DcFbdvxXoHKjayoyYuj0RFVaBLt0WWrwt9Oi2kGC32X58tjfb3oPnELfpu97ODup31xHCGYiYkcAGSKLfQg5aLDqCGiQoDSiSGoSPkANAoym0Dzg0PdODhobmz4MWaBoamj8FkiA6XjzL2hUSMFbozh8lGcPZNM+ttfqwYfANhQ2SZg2heWO4ewVprSJVxZTiGCU/TNUfIhQHzcoDBvVBo7rQrDxkVh7VyI+cSQlbNpbpK7SbM5azZ+tiXfcNCuvS97262lJfn5OkTItUpu4q2cmmSqgAAIAASURBVB24etKYGQ7/M5UxagrDHgj0FHjy0dcs+284zKksxnQWYxbT3kfEKYkKPQkEOj+pZX/i7wv0r0X5dwoKdF7cuyWJwxWrzI1VQJOWqmVxaeuW+fIZ3gw7L4a9q4P9LCbDjQP3J3dlsVxZTHhkM105zNlc+1WTP6lO3NWUHQd3KsmJrs8FGgreKu54blJ1zPbvJo5ePcZxhbNwhYtwy5TPz2bt+emo7Gbl/nvNpa+uN2varyG6JzgCvPkVaXxO9N/Fnl0232w1n65B1SWk/BhZc4SsPEJWH6VA1RwlG4rIxlKipRI/UY2fqsFO1RAnasiTtdSJGuJUre5M3YvG4qvFmacPppzYn3w8L6klO6FJFgcEWp4VVZcFkxu/L9AN1u2+wfcHeXJkVUR4eWhoeVB48dbQ4uCwnT4+AQKuD8fBnWO3bYGk/flT6nc7xwRuJrF+iugniQGCGKQoHUEOWh16iKC0JKmjSC3QaArvIVHwHJR2aBoamj8JWqBpaGj+FHSDmqr92YsnjfEU2Pm4cEKX+d84q9YNvEbMGhLVUNoO9NFlw6lqTH2EVBQSdfsp+QGq7gBZk4fV5iH1BUbFfr3igFZxqLM8f/+agPmC/89P8D/LJ7s0l2WSaLtZ//LepWZl3l5FOsw5KPdGHgnfNNeFP9P+oxn29tPtHYBDf838eDLro69Y9l+zmVPYzOls5iwWXKVXHrvjRH7q8fw9LQWJjb8d4bBpMThRFySNrN/T63y4xm54Ih4oKdyuLx9YdZwqN06dJY1e6OPNHuXDHOXFsHNnAm9mzLZtTs6GWY7hcnDnMRZ95lIWH96clwQHVOdKlbDi1TnxjdkJzVnxUQHuK0aL1riIVjsJljtzK0I33irMuH8s+25p9oPa/U+Pl3TdUBteXDC9voS0nUOvNZtPy82NZXjtYbLygKWswFKabyndbyk7YKkotFQestQcsciLLA2lFlU5pa4gQTVWEOpyqqWSPF5FnK43n1G8aDh2+Uj6iYJkWwcaCLQqK1qRGQVXSf6uQNdnRyusUZZhgd5RHhZeHrwDCnRIeJT/nLkigS/HwZNrv3Lal0/u3fmdSXYUhWOIhsD7SHKQJIdIUguLGiKhQGsJSk9SBlAUpbdQGorowTEt+B73/rvQ0NDQ/CegBZqGhuY/D2o2XznZ8r3bNz5iOx8n+1WzJl1UVSC6HgzTY5iOMnQTT39CTpdjqgKTMk+vyNerC0zNB5GWQ4j6oFmeb6jO1lXlGuQH9IqjjwrTw6ZOXCT8aMFou/Clbh1PruBY16snl9XH9jamS5v2xSjTo5VpUYfDA+c5C9zs7dxGOcwaxZjqYD+Z9fGXnI/+ybb/msOaArPFLFcuc9nn4+XJMSf3px4vsEY4rN6s/LkSbaXIT7CVMj/h1wL9vjcP2zMU6PxfCLQKCHRBvAI+mKDOiote4O3DsfNl2/uw7D1ZDu5spiubMZtrDxzaZs8eoDgMd57DysmfVCTuai5IhvNA8uBAPWDP6hy4IWJTbtKxXVu+nzRujbPwWyfBEhEr3n92W2n+0/K8p5XZL+ryuloO669UE7fV+LV69GQFqSgl646RNYeoigKyLIcszQFHoiyPKM8nKg+QVYfJmqNk7TFLTZGlpsRSV2ppKKeUlZSiglJCn7Y01lDHG0wn6182FF08kgEFOjehMRt8H4gBDq3Mim7I/IVA29rS1nor0LYsuCoztv6tQO8AAl0aFF4UHBY3f+ECsciXzfDmMeZ+6vLgxjWC+M0xGrD9jEN1JkgtTupISg9cmSKHKOjTwKSBQJsIi9nq0FqK6CUwDUX95rvR0NDQ/L9ACzQNDc1/GOBAr5+27dm6UeLI8YPbnYwpy4439L8kMC2OawljL/H0Bnqu3qw4YGrMN10oNt+sRR8o8cdq8nEj+aiRvN2AX6lGjpeYVceG6g63xAR9N5a7TGi3+nNRSdouRP9Cr3lyXl0kz5M2pUW3pMeoM6Ibs6TFUcFLPxs7Y9RHs+zsZ9oxptnZf+0w6muW3WSWw1QueyrbYTbHwUvECvGdrc6MO7k/uQUGoOMb4SCOdzWi/fyzJccrrRo9ouJ/XSN62PGqvJ8LvrwgoSEvrrFgT1N2Utq65b5Clg+X4cVmuDPt3Tksdy7bjcOCQQ4Ww43DdOMyPHgO7jy7rV7TGmXxLflJjdCe49Q51sqNU1oH7anSpTsls1aPEQGHXubIXz2W/7S6oFN9sP/4QcPZo9jFEvJyleV8JXG8CG04TNQcIisPWioPUOV5ZFkuUZaLV+SiFblYVT5aXYBUH8TrjuC1R8jKw1TlEarqGFlbRNWXkQpYFlW5RVlpaaolT9YbT9U9lx++dDD1ZF5Cc45UJYtRZ0sVmdY+tG3SSFZEXWaEPDOi/m2960DHKHOAbcfUp0RWRoTbOtClQTuKgsMTFy9d5OToy2V6cx18XPh3f7qC4/j7n6dhCDixbggnh3BKR1BGymKEzWZSa6GAQ2spykgCe7Yg8AQGOfqBQNMdaBoamj8JWqBpaGj+wxi0QzWF+Qs/H+8j5i781FG2e2PP69vAZghcS5l6iTf30XMKRHHEpD5A3JWTXScpzXlKc4HqP0/COkt1n6ZenSRvq9GTlW/KcmXLvFc5OaxyZIV4fHP7XD1qev3k1knVoX2K3PjmrNjmzBh1JhDo2LqUyNAAj5ksu2n2o6ba2U13YExnMKYwHL5hOExlMWawHVx59gsmig/t3HA8L6F1f2JzQfzb/MYvc8+/SmjE21rLv18jBPr9zrS1jZ3YmL+nMWdPuXTnyknjPTj2HmwHDw7Dg8tyYwOH5rpzONCkuQw3rr07385L5LA/9IfmnIQT+/c058U35sbByotT50NBBwLdmp+yP2jdyrGOq13EK5xEC4X2pzN36S4UI5ePEVeOWS6VWM6Vks1HsYZCrPYAUXOArN4PCqvIRaryTTX5qOoQ0ngYbTqKqg+jyiNAss3yQqT+sKnhiL7+sF55zKguNiqKCHW5RV0BimqspFqriZO1ppM1HfVHLhYkHc+OVctiVECgZTFKGOSA9lxrLaDODZkRiszIBlu6wzqFQ5EdrcyMlqdEvBPokm07ikN27lm6YpEzFGgvjr2XmHPr8gXi9wQaIXCNtQOtw0k9SQKBNlKkzkIAe9bB9jNlhgUf11kFepAWaBoamj8JWqBpaGj+k1Ak+bLtYdAiPw8RM2CcOHiB98Orxwmkj8KHKEMf3v5Qf6XZrCpGFAewq2VU32nccA43XyIMl3DdRXzoPDF4Djp052nqYbPpTOXd/XuCJ49Z4eSweiw/fsVcXdfDwb5Hp+sONeQlKXLim7KlTTBIEKWWxSozYvO3b/AfI5rO+Hiag910hv00B/tp4Miyn85hzODYS5w50hX+LTlxJwqgPTfvT4Dt538r0LDB/L4u/7pGBKl/0ckGZRNoVV5iY25SY2ZiytqlEjHbjWPnDjSaCx3aA6gz1GiWB5/pwWd4CEZt9vxGnRXXmpfUkp8A1LkpLx5UIxy6l6DeD9+zpSBFtTf2uy/GrxrjtNxRtEjokLvO33C5DLtcTFw6ajl7jGw9gjccRGsPErWFVPUBqu4gLj9oVhw0Hy/Cr9eTj1qotuPUo1bqtoq6XEeeLCfOVpF3mvC2E9izU9iz08ijk8hPKvR4JdlYaWmqsjRVUs2VRHMldrzKeLzytfzQlYMpLdmxjeDmWwUauHIdzD1bBTorEtizMjNSkWUdgw2b0FENsijwNHny7sqIsLLQsLLgcJtAp6xYtcjFScJleHLsPUXsmxfP/Y5Aw9nP6CBJDJAE1GgSOrQ1xQGjz0aCNOEksGczCa16iCIGCNxAb09IQ0PzJ0ELNA0NzX8MiqJ0Q4M1R/L8PhN4jWGv9fhGXVxg1nZZ7bkfefFQe/G4ubkarz9sVhcQT+pxw2nEfA4zX8ANFwntRWroAuxG9521dJwi7qo1rUXN0ZtXOzksdWZ8+4XLYel2VPf6/o8tDQf3KXKSFLJ4lUyqkkWrc2JU2bHgXL43Onb5XB8nzjSHf8xgfjzd4eMZTLvpbLvpnFHzJzpJVwbIU3cDe27NT2gpiG8qiFfb0he/UudfCrRVsgv+jUb/vkCDoxqOT05olCXWpURFLvKdM5rvybN359p78YA7Mrx5QKMdPHj288eLdi3wrIgPa8lNbMmNhyntkasSwZvvT2zcv6epIOV4bmp0gPfKsc4rnB2XOHJ2ek3qaS3Er5QS54uI1sO48iBRX0jKD1N1hy21hRbFYazpKHKxknjUZOm7aBm6Qg1dsQxcotpPW+6ryUvV1C21pfcqYbiGIzdJ8y1Kd53qv04+OIUfr6SaKiygmivJlkq8uQJrrTS2VnY0HAEOfUIW25QZDb7AKOA8u8jabFhAoBuAQwNjlsHGM1BnWykyouR7dlfuDivbHlYWtKN4a3hRUHjqytWLXZwlXKYX18FLzLpx4SyO/d5u3gSBEpiGxHspcgAO3KCgQ8PeM2nGoTojJGWGsziIIZIw0gFoGhqaPw9aoGloaP5jEAT+7OG93f8/e+/9FUW6rv3/Bd/1rvfMCE1HsnF0Zpwc98wYUJCgKJgd08yYRYLk2AQVRaAbdFRiJzKdu0HMOedEjmYJHSrX93mqwYB79p59jvu8e9aqa12rVnVR3TTV/cOnbq7nvtcumj7RJehL753b1z7tvoMjLyikH+9rH7xwwmquIzRyquYAbjpAtenIoaPE0Aly8BT19ATV3US1mvG7WvRGHXqpGjmpelx/YN8S32XuY0K9XVZ/M/lsbdFAzy2zal+dJFOTK9bkparzktWSJE0ejNhq8pM1e5MrMmL2rF++2fcHpnee8ww3l6ApnhHBM/ZF/arek9AA6TnVXJgG8xswrJyilqa8jc7vFqAdIWldIZw/os9PM+Slq9KictcvX/fT5wCXfUROviLObBEneKJ77NyZBVtW1e6INeSlMLXnZL0UGC5MHPY+MbBuf4Zh346Ggux9G39ZMXkCAOiFnsLfPve6q9xNnVXiR0ow/QGi/gClLqLVpXRdCV1fTOtK8UYZfqWe7jlBD16gbBcpywV68Dz18AR512g7ocCvaunBSyh22U5dI8kbJHKVsl2nH563Nikxg5wyKkiDnDYqKb2cNCqIw5W2BlWfpvj8/ozDuQmGEYCuAQydG1/H4LImLwE6n3FeAuRpANDpMaroCFlYhHzz9rJNUcWbI3YuXREy1gtGOABAe/5zgIb/4SBQDHmO2x9STCtoCuAyZQW4DDCapmwkMUBgLwhsiCL/sJLNihUrVv9zsQDNihWrdya7zdakrQ3+ctK0CS5LfKYe1xejSB+BPidf9FiunrUc0RPGaloto2oO4roD5PV6srOB6mgk75vwy3X2Eyprk8zWUIo2lGINZXiD8pGyMP7rKas8uQvH8tZO+6TtStODC+a6/TvVeen6vHRtXpo6P6VeklQPEE0CJ5XANXa5KZo9ydVZsfLkyLL4sPLEcGX69trd8bq8FHOh2FSY2rAPbNMMBUwiYrgC/fo6wleG6WcYgH5Jxn/I0K/R89/JQIODakmyDtaS07R5Kfq8NG1Osjo7QZUWKUsMO7Dtl4L1K37fukaVtK1+R6w+J8mUn2ouSNPlJ0F6hn3xkpl3wvwWAND7MzT7MnUFWaaCXaqk6DWffbx0nPdib9flE3nnClPIs9WYuZjQHqLVxXR9KV1fRqvLaW0ZZZBhjXLiYh3ddpR+eo4euET3X6SfnaM7jqIX615ofkePKukn53DsKkJco9BrNHqdtl+je09bGuV2XSlplJF6GW1U0ACjTQrKpMDNSuRwxSNN0WlpSgOM0ECGBgANuz7nAlyG0KyFn0s8AGgt2M9N0O5JqBXHKLdHyLZGyDdtL9sYWbw5PGvJspCxwxnoWZ68q6dP/IMIh0MUEInjiAW1PsHRJxTxgoaJ5wEK74c5e3CrhloBZf+JiYasWLFi9d8XC9CsWLF6Z3rx5LE0LW7GOO6MDwSbls7u6ziP4b24tQdvv2U7YcQb6yhDBa2R03WlhLoI1kSPK/FjSuywHDWWo9pSXA2Ol5KaUlJXThhUbb/nbJ3stdqDt3i8IDx4WtfN4xd0snpJhjYvXZcn1uXB0dkQoCWJagDQ+Una/GRgvSTNJBGbpRkN0qyGAjhx0FSYbgL0vC/tpQ1MCw6mS8Zw+7m3afhtUB5lNdPj+Q16/qMKtBQGRXTgd0lSNXnJ2txkfW4KbLKRLzblpphyks17UxrzxeZ8cCTFKEkxSlMc5WemEd7w4EPY3wNWoDO0+7O0BVkG6c76rJR1336xZJz3Em/XxV7OjenbiDN1iL6IAPSsLgU3KoCeKW05aSgnjDLMWI41KfGz9fh1A37bDEzcNCHnaqzGUnvlPrz+EHZViz86RVqv0pZr9NA1uv8y9aDJZipHdKWEvpwCAG1gbJJThnKqQYk1KNGmihZl/jFJsiEnTgtHEsbV5TMzU/IStfnA8QCgAUaDfR04siexNi1GGRUp2xIp27S9dENkyeaIjEVLFoz18BMyAO31TxYRvi44khBHMHQIsT21DfUhlkeY/QWOWuDwlD/uJM2KFStW70osQLNixerdiKLIjvt31gVMn+7JCfpswv5dMXZrG4H1EE/v2y82EU31lKmS1CsprYJWK6h6GVVfRtZDYobQrC4n62V0XTk0wD6dAtWqLu9OWzfBbbU7d/kE1/Q1we2XzU2lubp8sTZfrMlP1ealqPOTGYCGhgAtgdYB9JSkGCRpRrgIL91YAAMbL22AfgOg3yLgP0XPfx6gX5E0M61Qk5+iBYal6CQDwOW8FHNeSoMkxQSdbAQwCmMbw/TsAGgI3wVifSEc6aIB3pepKcjSSXdo96Rvmfb94rGeS7xEiz2dVJuXoCdq7GoA0KWw8AwAWlNG6ssxQM+AofXDhg9NMgRu5YiuBK09RFUeoioOgn3byUrkipa4YSJuNWA3TLbTNXZ9OQ4QXCejdOW0oZw2QoCGO2Y5YZITZoXFJL9RurshJ16fE6eBdWj4rwCGnhN1kgStNE4ridflJYA/FgJ0aqwyMkq2GQB0dOnGqJItEeLQhfO9AUBzfITOs8cKr58/8ycB2iHwlSNJnCQwhptx8IgdPciKFav/HbEAzYoVq3cjDEWvnDoa+sUHPl685dO/OqqTk1gfhXQTbZfQY1q6sQZOtjMoaZ2KVquoOhlVU0pXF1O1xWRdKVkHYBogtYxmtpROZdUoj6RG/zLBHQD0yomuu34NfXC81iARG/PStBJAoilw4WBeEjOiD9oxN9sBnTomOqwvAKAshi0sClKAYdfnNw27wkn/BXQedZoDoHX70t7wWwCtk6ZrC6A1UjEEaGjA0Mm6vCR9frIBOtEoSXoTnV8tHATvENCzoTAdWA8BWgwAWi3N1Eqy9LlZ4bOmLRnrsdTbdYkX5/eVAeiRakRTTGrKYZlf+6r8DEvIWnCwnNKUUWpwqUuIuiKyrpisLSKqi8jqYrqymKopwTRlqK4cM8hRuFJQYTPJMa2M1Mkp6HLKIKON5ZSxnGRMmeWUSUE0VjzWlpzITzHtiTOAjwP2tkvS5YPbmCQHQOsk8Yb8BPAjbXZCdUoMA9DbyzcyFegt4SnzFzgAepbQec4E15sXz/2DQSqsWLFi9Z8jFqBZsWL1bjQ00F95QBI42d1/onvkknltN86S2BPyWSt2+SjZWEebKiFAG1WUVkXDQXdyqq6Eri2i64qoumKirpSoLyPV5RQsncIKtEUtM8RuWTvBdZWby5pJbrvXhpyvLDTmppjy09QFqbUFyZDSYLEzRSuBo0YYgH5ZtU3WFcCuyZCh3wJoXUEa4xGG/nMAPeo04D9ZgdZLM3QFGdqCDI00XS1hgtHMG9blJzMADUAzUSdN1EuTGDv+hJcADRA/TSdNMzAMrXdMeCnMAACtyc/S5+0I952+2Nt9qbdoqafz/uV+iEmB68poHaBnOaRnfRlpgEVoWi9nDsqGqVpdRtWX0HWldE0J4GayppSqBvtlVG05UQc/BVIjxwFnA24GIK4BLyVnlg/KSBPA8TLKDHcAQ9NGGWVWIk2V1w7ubNgdb8pL1jN3BUz+BPwtAKBj9ZI4CNC5iZqd8VVJ0YqIKNmW7WUbokrWRxRv2pYQNHeup6uvgOMjcAr+ZPzdq5dYgGbFitVfQixAs2LF6t3ocW/3zsiNARNE8z4cm7HlF8uTdtzSZ3twBTluoM21tLGCNCoBQNMQoBWURkaoiyj1IaoeAjRZXwKpTl1GAwPI0yss9WWayHVrxvJXubusmeCauXROA5zfkWqWpNUXptQWJuskSYA+9cMAnfo6QGsYa5nJI4CSHU2UX9KzFuaJxQB2dYxHgzLT9eLVw5ejuR1PH3mWtgACNMwl/1mAhhXoemmaWgqL0I43DBhaB7YFSTqpw8Pv/zWAhvSsBwAtFQNDgJYChgYAnQUAWpebtW3WT4vHui/zFi71cCpeNdeqLSWNClqvAABNassofTlllDH0DA4q4XHAwXo5oZUBSqbryuhah8uBqbpyqr6cUJcTGvBT5r8BdcAKGs4jlNN6GQBowlRGmMvBFlagTUycw6zEDld2qAqO7k0w5SYa82EKBVbTJRCgddI4fX6cIS9evzdBvSOuMnG7PAJWoMvWR5VsiDy0cVvMnIAgDzc/octM/piff/qy5fZNkmQBmhUrVn8BsQDNihWrdyAcx+9evbx1foD/eNd5X3xwYHcyaXuIPbpnPWvED9dQ5krKqKKMCsowXAqlNGWkGkBzMVUPXOIwrS6hNSW0vgycOVRfVh/+2+qxglUe3FXjhGnzZphykk15YoMEQGRqvRSWnCGA5jvCG688knwYZlD9CPLCcMVo2IXWMIY87TjfMfOPIWb4LMDNkjRgiLCwDAyAGBhyLTOs+9WkFfhqTMvnkTV/6dqCDF1h+jBJM79dUwAAOvmlR5Inb77zkZ3hh8MQz7wNaTqg53pJula6U52boc/JCPP5YdFY12VeguVuzpXrliGAm8F1hgAtozUyBnwVtFEOu2fAPnRyyiCDhomOMvgR1JfCyw63I1aXguM0DIHANYgwCgJfR0brymnwLEOZwzDLYZJTZgUw0aB6pik+lZ/SkJcEANoRRDFIkwwFjKXxhrw4XU5cfUZsZdx2eXhk+ebI0g2RxRsiizaEb5/pF+Tq4cvnThc6bw31725vZZcAsmLF6i8hFqBZsWL1DoTY7SfNxkVff+433nXhD5/oqg5Q9l70/jnbkRrCrCJNStKoZABaRuthkIDWMKw2gs5MooDpWKwppgylpFE+pJExAC382d1lxVhB3KzvzHuSjfnpOgks5TpSEAx3prxpwMFveoSbdY65g29ZA2vGjF97lp6JeTiA2GE4CQUu4wMoDA2zyIVp6sI3RhW+DdDM9tXv1TDJ6TcYWvp3APp1hoYN7JgqOABonQSWn+vy0zWSLF1epnpX6uZp3y4cJ1zmzQcAbdq+EdNXkMYKuFJTx9yo6OAMFEC6tInBaMbDAK2DhlVquOLwTUOAZqyF50CY1jLWl8F7G10p3IEZaAUJ3KCgGpUWs+LSgaymvBSzBKZlDAXJxoJEIwRoQNIJRgDQe+LqxTEVsVGybRGlm8JLNkQUb4g4uH7bth99gkQes/m8Ga4uqRtXPe7rYQGaFStWfwmxAM2KFat3IKtlSCMvC5gyAQD0splfXjtjIAc6LBcbkMZKBp0hPZMj6AZpDLJaCVN+hhVomqmDwgq0tgQANGGSDelkhtjNa8aJAEAv9+Zv+fZjw65EYx4D0BII0IwdAO1IRAxbXwCjDiNmVvW9Bc1vAvRrC/5G/PII+Kl6n1gNtgwuA9cXpALXARfCrRq+/ojfCG+MBmgHZP8DgB7lEYCG5wwDdL5YLU2vl4IrkKGX7KjNStrwwxeLxgmWjeOv8HQ5mR6DGsC9SgVlUJJ6cK+iYCYIjgD06wz9OkC/xOW3DEvU2pcwXUZDdGZsKKNNMrpBCd2opA4rsabK+/L8I/kpDZJUozTZKE00AW4GliQaJAmG3DhddmxdanRFdGR5WETJxvDi9eFF68N//23zpm9/ChS5+wn4Pu5cSUpM/7OnbBsNVqxY/SXEAjQrVqzegQb6X5RKcmZN8PQdL1rt+13f/Qvk0+ahExqioZI2qmAddCQ5MAxkgJXhsI9iZsvQswOgdRCgSbPcapCfyIhZPU643N1lkRvn108naLPiTPkAHNO10pExgY4mFUyg4qXfBGiYdX49qfz6YJS3Afp1MzXmYYCuBy5Iq4fRkdcMjkA4Hv3EfwdAw4f5qdr8NE2+WFPAAHReVmVq7K/ffLJ4HH/ZBP6aD0QXspMwcJ2ZCAdpUBAGBZzCDQDazNDzaww9fBujh83pYHeOUX4J0OpSgvlHAQPQpRCgdSW0voQ2ltFmOUPPKujDCrxJ1V138Jg0tUGaai5INhckmaUJJkm8CdBzHuxwp90RU5u8XbU9AgL0hm1F67YdWhe275cN6778Lkjk5ifk+3oL5dI91qHB0V8sVqxYsfqPFAvQrFixegd69vjR7sToGWPdZo0T/Br0w4vum0TnTWtjNSA5uIiNYTVYxRyGMyat8cqO8jNDafoS0lhMNSoQk/LegT3rp3gudXcJdXVaPtlTEbfVLMk0vFyTx4QoNG9O/hteIDjazERux87fP2G0X9LzcAc6yKxiaIiwDMXmw4daYOnIU94cQAhzJtJ0uMNkPF5n6Dc8ktlwmOlm/QZDwxWNLwHaUXeXpmvzAEBnFEVtWvbRuCXjeEvGczd/NemKJJ0wMCsFdQpSPwzQMDbzFkDDFA3j4f8G/D2AhgEbdSlZX0JpoGktvLehdcWUvpg2AIYupxsUjgo0AGjssHKgUXVqfwYA6IaClIaCpAZpgjk/3pSfYNqbYNgdp8mMqUmMUkZFlG8NL9kQVrQu7OC6LdI1v6355PMgkaufgBs4yUOvKkfs9tFfLFasWLH6jxQL0KxYsXoHetjbHfPbyp88hQCgtyz06e+5idw7j5grKMcMDkhmr9Gzo/bssLoIPhwuc5YAOCMNRVSjHG9UPao8kPDT5wtdnUJcnReNE+auXdyQn2GUpAOABkSr3ZeuHikAj8SOR3Pw2377tFfr/Eb2IZRDw6yzriBdJ8kA1uanA2sc27x0da5Yk8cYdqaDkK2WiNVwgSM0s5/G+I1ud6PpeaTLxx8BNDzyegVakgp4vT4/TQcr0OLdaxaHTnBdOl4Q4s2J9vnybsleCNBapvGcTs4AtII2jAbo4Ri6o/z89zyqCE1piilNEa0dNgUZGgI0fFkHQDcp0UYVcrL+7MGdjQWvKtAAoM25CeacBGN2vDYjpjo+ShERXrZ5W/H6LcXrww6u35K/+pflUz4MchX5ClxCP510/mgjjqGjv1isWLFi9R8pFqBZsWL1DtTb1bEhNGiap9BnnCB82ZyB7uvW68cxAHCjgwGlwwD9Mr+hPgS34CAD0JS+mDSVkA0yslE5pClTbVgeIng/GNiNs23617rsFBNgRykTjWAAWrfPMabEQa7DpV+GhofHl4zC5b/n4TN1hRnAcOelARlLMzTSTGC1BHZfBtv6/HTgOmZbL4HcDIiWQWcHQ8P9kZ1UteSNgYV/BNCvM/Q/AGidJI2Jr6TDcYx7U1d//SEA6NCxvJAJ/Mzlcx6blIReRauVsPGcTk7qRzLQEKDlwzbCLhw07AwNWLns7xve6pTCVZ7QJQ6ApjSHaC00pSt6CdCUA6AblejhCvyM/lLZ3oaCVFNBilmaZJYkmPIgQJv2JBh2xKvTYqpio+Tbwks3hcEK9IatB9dvzl66LGT8uACRcLaAs2ba1613b5HsCkJWrFj9RcQCNCtWrN6ButpaVwfMnM5UoCNXBAx0Xx262oTp4TTp1+IBTEgDsvIIQ2uAi5gtA9A6CNCUqYQwlVINCsQgv5or/nWyVzD//bnCMcumeO3btMaYl2GUZmoBRO7L0O1nStHDM0oc2PqyDOyIIGc4wPotaH7dgJszHYb7jGHzZokYcipE5BGGlmbWA4CWZNRJMmol6bV54joJXNLn+KUAox1+HaDr84cB+o/8qs/0HzD0GwAtTYMLHKVppoJMadjqkA/cQieIQsYLA8bzzqqkg+eMuLGSVgOGhimOkQy0gjLL4Zo/h+H0k3LaAJtp/JFJLbOUcxidh+mZAeiDwBCgmQgHA9AwA001wkWE+Hnjzar9Zji5JsUkTTZJEk15iea9ieY9ifrMuNqk7RXbI2Rh20YAesuhDZuT5wbN8/Lwd+PPFnE2Bc181NP151YQgnNIiiRoyjG4+888hRUrVqzesViAZsWK1TsQAOiVs3+aCQB6LD9y+Zz+rsuDVxswPWzdMBwMgEvQGAOGhohWPBIJgKkAJl/L/NRQQhmLSWMJaZYRJuXjyoP5CwNDRJx5AqdgD+6Wn76qy4g3SbMMgHEB7w6Xn98A6JcI62DofwrQL+nZAdAMOqfrJelmaaZJkgF4Xb9XrNmTqt6dqs5J0+Sma/IzNBLI03W54HfB9XywOA39BsSPVKD/TtX5jwD6db8N0EwfaGaJZGF6za64sDnfzp8oXDBBOHeSW1iIj6X3xsD1o2hDDa2tpDVKSq8gYP8NJrNhlsE1f69jtKH8FTHrS0nGrwM0MAUZ2gHQgJ4hOg9bX+TIQDsAmmqooA6rsKYq7IL5Tn2REb7DFMjQ+cmmvCRzTpJ5d6JOHFcdH6mMCJNtDSvbGFa8fmvxxq2HNm7a/OP3Ae5CX1fuLFeXhLVL+589Gf2teksUiZH4IEX2U+QATQ1RpIUiEXB09HmsWLFi9W8WC9CsWLF6BwIA/cucGbM8hLO8edsWz+rvuGC52oAbXgH0Sz4bbuYAABpyczGlPwSrzvqSEZ4rpo2wCE2ZygGf2fXKE5mJK8a6BgvGzBU5h45337t2iSkv0yDNhImL/ZlwtDWczJdeLxXXS9IYi+G+VKxm4sgvV/W9jc4jhoXqVxgthY0+6rITiqM37v5lUfqiwJR5fgkBPnH+MxOCZictmJO6aG7WzyGSTauLojdXZyWq9w6XqJlt+kuUf7Wa8C1o/gcADYcd/iOAhn1FDIXpkm0rl3zmHfKBKGSCKPTzSZrSXMra2X/vtK2hlgQArVWSBiVuBgCthLnnPwfQrzM0NFOHZlwEuVl3aNhwEWHpmwBdgR6pwa403aw9pIchEzhe0ZCXZMhNNOYkGnclqGEDu23ybVtlW8LKNjAAvWnr/t/WrZj6IaRnIcfHnVu0S2yzDI3+Vr0piiIJbJAinlNUP0UN0pSVIq0kMUDiQxTL0KxYsfrfFQvQrFixegfq7WzfPN9/tjt/tid3y/zp/W3nrdcO44ZyWssANFOKZpqgFdMQl4GLHCYNhyjDCEPrmRMMJZSBAWiTjDCpehWHEqZ9G8QfEyhwnivi/vr5h4q4MJMkQwdj0BmaQmgHMdflpwJDhpam1Unhtt5RfnZMDRxuxJGhGe4ul64rhF2iYe5Zmm4oyDQWZFZmxRSErYkLnrn2mw9XfDJ++RTvZRPcl4/zWDbWbck4tyXj3ZdM8Fw+0XvFB+NWfjRp5dQP1n41dcuM78TLggvCflGkRatzxVpI0oChYa89HcO7ugLYR4/pxQFHHqqBC1IcHgHoVP1LjwboJI2EGfedn2TMTzVKxMZ9GTU5iWtnfjrvQ9HCD0QLJgpjVoQ8bL1K2buR9qvWxnpKX0MbKkijijApKLOShkv9FHA7nIR+HaDhBX8Dmkf+SzC84wBocJMDc89FsPYMPyA4KpI2gNdRQoA2V9INVeiRevTmyUvVBzT5Kdr8JH1ekj43UZ+ToM+O12XE1SZEqSLDZFu3yjZtK9uwDQB00cYte5f/HDphrK/IZaaI4ztOdFyvxtB/soKQIhCKeEFRAyRlISk7RaEUhdCkhcSe4aj1z8U/WLFixerdiAVoVqxYvQM97O6KWbnQz53n68FdF/D9i9ZzthtNhEEBR0AbYOiWmcFRzAQAiihjEWE8RBgOQXo2QoAGB4dLmw4bS2lTGWkuI43ywZpy5aY1Abz3AwWcBUL+Yndh7OwfNDvjDXCdX4a2MEtdmKUpzKyTpKkBMeenQEuAHd2aYac5HaRnx5jAdLgQUJqlLcgEMK3fD+nWUJBhLsyqzozZvXZR2MyvV34yftE4UbCby3w3l1B37kI37iJXlxB3l/kewNz5HryFboKFroJQV8F8N/48N36Ih2jxOM9VUz/YNO3bjJ8XysWxWkkWwGhdQZZOmq6XphkK0/UjwwvrC9PU+xiGLhxmaC0k5jQdnDLoYOgUrTRZy0z51kB6TtIUJOmkiQZpSoNUbJaItXmpCSsCg6a6BU4RLPhAOO8DUVONzG59SNj7yIf3rY1qwlBDmipJswrmN8yOCjSceOIYuw172JlkFBwoyMTNgV+GZ/6eYZBDX0wyhtFn8DnCT1NOg0/WCMvPtLmKNtXYj6rRB+dPV/9el5eqy0k05iQY9sTrdifosuLrk2NqYiJV4WGyzWHlG7eVrQ8vXh8GADptXnCwl8dsocs0kfOCrz66c/USQRCjv1VviiJsFNFPM7ENikSBaQqjAUmTQ5i9nyTw0U9gxYoVq3+bWIBmxYrVO9DTR307IzbM8eT7unNXTv/82YPTyJ1jqEkFBxCa5JTRsXwNkHEJbSohTcWw2TNTaYaBWpipZaCZWeIGa89mGWkuJ8zlmFlhM1Ze/33vlq8/mc93WcTjLeK7LPEWxgb9VJUVbQScKsnQSrPUcDxhujovRZP/0iPdmvOZ0d8FaUxf5wxN4Q6NdKe+cKe+IMNQKNbnp8gSw9KWBPzyzUdLJnuGePMXuHMBNy9yY9CZ2YKHAJ3neQHzgj34IW48QM8hEKAF89wFc914QW68uW6C+d5uoZPGrvry4/gQ/6L4sLpcsW5flnZfpg46Q7MvfcRi7b407T5mjAuk51QY8xgerAhbPtdLktRgO+yk+oIkbWGyHoC+JNWYm5K80Hf+ZPegScKAD0RzP/HK2LTi+ZMOu/0paXtE93dazpmt5mrKXEmZADGPMLS5AhpWix3N7GRwEaEepmUcAD2qCP2WmdMMpZSxjIIfkJw2KuDaRJOKdFSgzbXWU3q869pRVWH93hT97kRDdoIuO167M14tjq2Ji6qMDFeGbZVtCivbsK10/TbYw27dpsjpMwLdBLNEnB9FzpErQvs6O/7pEG8GoAdoEhAzSpI4RUFDhqZtqP0FgaPsgkJWrFj9r4kFaFasWL0D9T97uj8j0d9b4OfOXfb9R91XzOiD07aGCsKsIpjyJ5MfKKfNAI7LSTNAMaaWqWfq0xDLmGgBE9UlzXKqQUE1yIkGBdqgsjbVPW2sr0mNW+rtsYTHW8bjhvCdQ8cJogN/qs2MM0uz4HBvgMuSYQxVA3qWpOry4eBrXR5c8KcuyFQXwrZ3AKAB1GqkWdr8LINkR2VGdMaKeb99OzV0gmuQK2eeq8sCgMuuvEVufIcXwy0v1I033503zxOYDwAa7M935we784M8BAGeAn8Pnp+byxyRS6ArL1DECxTyQsa6r/nqk8SFgbK07TppphZ2x4Nb7b4MsHW0l2Y6TKfpmD7W6gIxrJ0PDzhMqQMuSB42AOjClFppkmZfau3umPRl/osnieZ5cOeOEwZM8YxcveDWpSYr8gyxPyPtjyl7L9J68UVTLWmuoo0VAHCZ2rODniFAg4fMBwEBmqn0w1uXlwBNw7L02/Q8Mr4b0LOpnDTJKHA7BClcScJPFjB0BdlQa73YQD6/21C6V5OdpN+ZqM9O1OxM0GbC8nNVTGRF+DbF1jAA0ICeS9aFFa3b+vuvG3757LM5It4skfM0D5ecxO0Dz5//0wwGjtloaggANElhJEWQNCBukqIhQGPIc4L4JwkQVqxYsXqHYgGaFStW70CD/S8q9uX6jxPNceMu/nLSeW0J0Xl58HAVBgCrsQL2O2sAMCenGhmDHdiTGI75gNuRmIGjqbDDVIOSMCtQc8XgkXrk5um+qydy161c6C5ayuMu4oxZwHcK8eJvm/7toaj1mr3JBjgpME3NMGgd3KbBMYFw6EmGRrpTU7hDCxcIwtbOBrCTn1mVkbBr9eI1X38cOsE92I07T+QSLHJZIAL0zF3oygcOdWPsymP2BSHugvkegmCH3fnz3HlB7rwAgM6evNkeLr6eLr5uHD+RS4DQJYDvEiTgBrnyAUav+nRK/Fzfg9Eb6/ckGwsyDZIMuAVvA1bEATenqR1zwgvhSPD6gpfjwR0YnQy2ainMogDILhOHbZ3zVegk8NvHzHfnzBvvtj5wxq3LxwdsDy3Ycwx9jtsfEVgf3n9/8Mphm6mShq6gGyspM7jylWCHbnxZhJYPN7OD9zDDAA1jzW8BtOMgk3gup4yQnuE/E0wKWN42qWAFGjC0uQJrrLHfPUkNNhsP7DZkJQNrdibVZyVo0+Jr46Mrt0epwsMVW8LLN24rWQ/puWj91pzlP4eOH+cn4s4UOvlOcq8q2me3Wkd/pd4S6WjBQVkpCqNopgJNEzSF0uQgjr4gCeyfIjgrVqxYvSuxAM2KFat3IKtlUKcoDprk7u/GDZ06rrZATDy61X+iHm2sogC9NQCYUznGPlPAjbDATMMeEcAOth4eCs1YCU+GdWslYq7oP6bBOq/hA213TxlSlgQvdBUs5jgt5LwfzB0T7MZf88XktCX+yrRwHVw+CGMPtQWAocXMiBNYftZKdugKdugBuRaI9ZIUVXpk5s8L1v/w1cJJXnOEnEChyzwBBxjQ8wJXbogbL8SNH+LOX/DKAJ2FwMGM57uDrWCeO3+uOy/Q3WWOu8tsd84sd+dZbs6zXDmzhRw/ISdAyIUYDc0N8XBd+dnk7f7TCjevVmclNkqzzAWZeqbvXp00DVylelh+Bu88RS2BhXMNjGuLYR0dPoR967R7U3f9uui3H6cGejnN9Rgz191prjdv9bSvj9bLrbYnQ/gLK/4CsT/G0Sco3kegnXj31X5zFWGqpo3ggoOLX0EdrgSGMM3cxgwXoWE36PI/BdDwNADQMsosZ56rhK8MXUGZKnBzhe1IDdZ1key/b96/uyEj1ZCRUpeVVCtO0CTF18TEqCKiFGHh8s3hZQCgmREqwAn+AYHuollCzkyR8+K/fXL17Ekcx0Z/pd4S04XDQpFDgKFpCoHoDDPQMBhNoEPghyxAs2LF6n9NLECzYsXqHQixWY9qa0M+nejvxgue6J6zbTXee8N+/YitqYo6XA1IDlZAD6uoJiV9RE42yanDMoDRDDqr4HEI1nIauEkBfVhJNcJ4gL2peuBCA/HiAYJ3Dw613T9nzt2wetk4twXcMQu4zsFcznwBZ/E40ZrPJsQFTcvduLQ4boNMHKnMilHtiKvYkVCZlVghjitPDP896rddvywI8/16yVSveWMFc4Quftwx/twxQXznuXznYKHLfDdusDtvvgcMaQR7Qs8btgAaoLOnCKDzfE/BXE9+kAcvwIPr58bxc3X2Fzr588cECJwCAY7znf15TgECToDAxV/AmSNwmSPg+As5871ESyaP/fXrqQnBs/M3rJQlbqvLTnZMadFL0g35YkNeGrA+N02fl2bMT9flpFSmby9L2LJjdciGH79YPNFjnrtLkOj9YC+XOWM5K2d8fkxdbnneaUNfWNAXCPoUQR4j2CME78WwHsrSZr3UaDfX0MYqsqEKP1xJHK4im6pIwNCApB1LCR3tOABDj9SYR6Ez7APtAGhIz+BMWHsmYekajjakDSraAOmZNFUgDSrbBT3Zf3ug+0pD4e5GcZpBnFabkVyTmqiOi6+JilGGR8m2RpQDgN4UzvTf2Hpg3aY1n33m58r3ETlPdx2zfVXok77ePxlfBpQMGJpEX9DEEE0M0oSFJodgbzsS/5OvwIoVK1bvRCxAs2LF6h0Ix9Arp4+vmfGNvxs3yFsYvdD30a3jRNdV22kdfrSWOlJDH6mmj1ZSR1T0URV1VEEeAawMrKSaVOAgdUTJPJRTTQrwkGyqwA9XoIerrKe09raLBNJpIbstRA9i7Wi73FSctG3RZK+5fM4CDmchhwNgej7v/cWevOWT3H/7cvLGHz7bOuObMJ/vw2f9sG3WDxt/+vrXb6cumzoueILA38NptuC9Wdz3ZnHe9+W8H8B1CuC+HyRwnufqMs+dO9eDN9eLP9dLEODBC/LiB3kLAr34Ad58fy9ekKcg2FMA8HqeG28eOM0dOlDECeKOCR3z/soxzhuEooix48K9x21wc1/B4y3gOAXxnOcIub4CQNguASKXOUKOn8h5rpdo4WTvX7/5ZLvfT+KFAdkrFuSuXZL/2zLpuuX5vy7dvSp054r5aQv944Nmhvt8u/qrKQsnewa6cucKOMEibhCAdS/uzz6fGyoLBwfaEPypDX1mR55j9keAnm14nwOgwbUiem/Yzpgwcy1+pM7eVEU0VZNN1URjJczSgNuSlww9PJWQKTDDZYWjPRJPh3kbZiUoMxvcoKL0Kho2+qi0m1XWE3VE+zna2txz+6Q5L7sxLd0gTq8RJ1cnJtRFx1VHxiq3bZdtjQT0DFyycRsA6JzlP4eM9/Z1480QOk13c5JJ99gsltHfpz8SRZEkQeJ2EreQhIViFhRSbP8NVqxY/a+LBWhWrFi9AwGu6Wy+H7dyYYArN9CNt+r7T8+oS6in94nWi/bzJtuJeuKEmjpWSx+rpo5WUEeV0EcAKyvJIxXAEKybFDQg6WOV2NFK+7Fqy4la6zkD1nyOGGrB8C4b0WMn+1C0225pf9h2/rCyMGae30J3t1AuN4TLCeVxQvic+TxA0mNCRS6hrrwFIv58ET9YxAPIGyTizOGP8eW/78t38uVxfLlcXxfuLCen2c7vz+GNgRwM3rMHL9CTH+jlgGaBv7dgjifP35s/Zxzfd5xLoDdvgQdvCfi7PN02T5oY/cnUzG+/y5vuU+IbqA1cdHL+ykuLfrm8cO2FBatOBq/Q+4fs+3567JQPV7gKg3mcII5zEI8zV8TzF8CAByDpIDduiKdw+Vj3leM9V030WjXZe9WUsSunjF0x2WvZB56LJ7iFjBWGjBXNBe9H5BIo5AaJeJC/vQSbgqZdOVH/9OldG/FwEOm1Y09R5AluBzu9NrLXjveA64PYu0hLO9l1bei0Yei42n68Hj9aQx2tIQBJO4rQDTBfPjzf++XyzeFUNNMFxdGr7uVDI0TnYXrWKymDijRVYA2Vg40V1jNqou0MPXSXtrXeP6k3Ze8ypWZqU8U1ySnVcQk1UXGVEQCgo2VbIsuBN0eWbgo/tGFL1MxZAR6uPq6c6a5OCz6beOXMiT+T33hDFBBJUQRbdWbFitX/K7EAzYoVq3chinr2qC83LhLQc6DQZcGH3qU7Y7FnD6iBVqTlwsAF89BJLXK8njhWSwKGPlZFH6ukIUkDdK6ij1bTYNsE9gE9V1uP1/SfVg9eO4x1XqEGWgi0AyN6EECHeC8GABrpRLDOoRf3bp00KNKTtv74/Tw3QSDfJVjIm89zXsB1CuE6z3dxCuY4z3V2muviPJfrHMh1DuBy5vC4fnyhH989ZOzk7bMC5np4T3ceM4s7xl/kEgDes6Olhhd0wFiRPyRpYaC3IMibN9eTs8jNZcuksXt/+qF+8dKTv268tiWqJTyxOzzlSYR4ICLDFp5h35qGbEyyb0i0bIh/vG773bVbz6xcVxE0P/ub79e7ey/hcEO5vGABuDJcfwFcaxgELhGfGwoscAHED15/kRt3gcglWMAJdnWBFXFXLkD/ua68AFeeDzNqJD9u65VjasTaZUV7htBeCwa4+SGC9iJIlw3vBjcYNrzHjnbb0G4U7SJt7WjH5f4LJisD0KTDTeAiV43ky0eGqrw+odDh10iagWlH4VlB6xW0Ds44BPQ8dLii/5wG6zhNDt6isBZioPm6psK4Y6c2OUOdLK5LTKmNTayNiq+IjFVFxMq2bJdv3V62CWL0vl/Xr/rkE19Xvo+ry0w3TsLapQ+7O9nsMitWrP5yYgGaFStW70Y2y5BBUTp/rDtMA3sLIxbN6btzGh9qJy2dWO9t6+3TyMXD2Gk9cbKeOF6HH6vGjzJuYny4mjhSTZ6oJ87p7VcP25vP4U/vErZO3N5FoF0YQ88o2k0gPRjWbcM6rFiHZbDtWcfNeyfMaml22spF63/6ZvUnU5aO9w51FS7g8+fzefN4XOAFQtEiT++fJ05ZO/WrrT/4Zi78pSZpjy4rP2TSRzP4/Bl8Zz+Riz8D0P6eAj9P/hxv4RxPQZCXcK67YKGX69YJY/d+9rlhXsj1tRu7w+KeRCQPxGVZEnbZEnZj8Xuw2N1odDayfQcWmUlEpBPhYjw8FQlPGQxPfrItsX1TzO114U3Lf6uYu3jHNz+Gf/zJmg8mzXUV+Iu4AcBC2K9jvpAbKuQuFLosFLksdIUdpucLeXOF3Llg6ypYPHHs2u+/SN/wc2Ploe6Wy4ODHUP2HgvSa0N7bVgP5Gasy0p02PBOK95lge62YN1gO4R1ItYWvO+6/YIZOwEZmjhWQx6ppgBAH64YWUqoGD3iewSgHehMvg7QegUFrcLNlcjxOvs1M9Z3gbDetmP3ULJtqPv6iaJ9+vSs+qT0usS0uvjkuujEmqg4VWSMMiJGHhajCIsp2xIlC4vauWjpPG/PWSLuTFdO0AeedSW/26x/Or/BihUrVv8xYgGaFStW70YEjt06f3rpZ1P8hS7+7vylX310TLH/Rcc10t5D2XuJ/lbi0R2y+yrReg6/fwq9ddR2/bDlauPgZZPlstl+/TB29yTZep7qvkI+uU0ONhP2DgzvRrAuHNJzD4L3IlgPhvagEKC7LFinFelE7N3IYPuLnhttl4+eq5Vr9+5WxSeVh20vWr9t/y9bCn7dvH9DWNHm7bLIpJrEnfrMwiO5irMHNDfkTScKKxZO+cKHz5/Jc/YVcP1def7MDMWZ3jxgsLPAjbfO0+Ogj+/x0BUPVm9+sS3JFpmORWdhUVlo9C4kJhuN3Y3F5OAxOWgMYOjdWHQ2Hr2LiNlJRGehURlIVKYtKmMoQvw8IrUnIrltW+LNLXGnt0RXrP1t1aQJfkIXPxF3loC7eMqUON+ALV99t+qDj5aPnbTEc8ISr0mrJn+25dtpO5asPBi2XZO952ytvP32qcFnD6zWriF714Ct02LvtqE94CLY8S4rQGcI0B3wpgLvtACeBheH6BrEO+x4B2ltJfquE/dPW87pB4/XIsdqiaM1cDUhU4SG6NwALIPNuV9GOCBAy0h9KaBnwlhOwH0lZajE9SqrQWVprEIumsi2M+TTa4TtNords+EtKN7Vc/2UIWeXNkWsTkitT0itjU2uiU6o3g4r0IrwGEV4HGBoeVi0fFvUtp9+muMmnO3G+0k0Zo3Pdw9uXCX/2QBCVqxYsfoPFAvQrFixejeiKOphZ3vS6qVz3HgBrvwFE70km3/pOHd46NE9EnuIYH12DOBvJ460ktYH5OA9vP8e+uIu+vw2+uI2NnCPsDYTtlYMGOlAUZjTsOPAXQjebQfGel7ahgKG7gakaEU7rfZWq+2BbaC1v/N2++lTt+pMNxWGG+WG6zLjNbnxqsp8o7LxVtWR2zUnb9ecuV174XbNxVsVp49KKhZ/+OVMHncW39lPwAU46+fBm+XlMsPLGWznufNiPv742LLVvRu2D25JtIeLATfjUTuIaMDH2XjMbjw2B4/di8XsRaP3oDF70LgcPH4vkbAXT8jBE/YAE/F78NhsJCrLEinuj0x+sS3ledSOvoScGyk7t37yqR+fA6jdhy+MmBN05lDFsTxZ467ixh0Hzem/N2QePLy77ERh1Xm5/qqmqevitf7e5iFr25CtfcjeAWxB4J2DFe0CAD1shp4dtmKdNmAcVujBFkE7UHA9B+5hD2/am89arzTaTmmRIzU405SDOlxBwX7bChjncBSkDXLKYbOCbFBiZgViUlgaKy1NtYMnNJZLjVj7efzZddxyC7HftmN37XgzgrQT9ofXGzTqHZna5FRtfIomPqU2LrkqNrEyOr4qMl4VHqfYFicLi1ZExOz7df3SyR/4uvJmuDpP83AuzEgYevF89NeIFStWrP4KYgGaFStW70xD/S8qC/OCxrkFuPGDvdwifadfUSs7rp9AB7tQ/JGNfGinelCiE8PaCLQNR9oxezuGtmNIGwYe4h0o1m5HgTvsWAdDzxCgIT2/DdCQoQFAd1jQliHkgdXaanve9vTuzeamkw/qj7fWnWqpO9sMrLnQqr3Yqr3UrL10T3vpjubyHfWlm7Vnju2vXDL1yxlc51m8Mb5Crq8718eTM9PTydfDOcSDH/Px1NO/bnoSkYJGisltaWRkJhm1k4reRcVmk7G70ZhsNG4PErvHFrvbGrvbEpc9lJBtSdxtTdpjT85Bk3Pw5L1EUg6ZCBnavj1jKCp1KDxtKGLn4+g9d5J3b/v40wC+yyyeywyBMHHx8gf6U/dqzt2tOntbdfKm7Ngd1albVWdu1J29Zjh768Slx23tloHuIXu7wxakg/mrO1/RM/QrgH7dVrQd2ALdhtjbiKEW4vEtrO0CevMYes5oPVZrPVJtP1KFH6kiGivxBtjRGTepMKMKNVVYTcoBs9J6tAa9aLLdP4F2nMcfXiOe3Sat9zHsvg2/a8Hv2IgHCN6K2jrwFz1Hy4vrMzJ0iWn6+DRNfKoDoKuiE2siEyrDEwBAK7bFysKikgPmBrq7zhQ6z3B3Dv5i4uVTR3HsX1w+yIoVK1b/GWIBmhUrVu9MGIpcOtb06/TvAj0EQe7ClZ9+WL9bfPe4/nHLVRx5aMf7bGSvjei0Y20Y1o5jHSjagaDtCNbmMDhuQ9sd/DcC0A6GZjAaG8Zo20j9lQHEZgv2wGJvtlvaLY9aHl67+sB04oHmZLP6TIv6QqvmUqvmcqv2crPu8j3jxVumC7fMF+41Xbilb1r13fczhRwfwfs+Qs4sD5eZXs5+nk4LRM5JH39y5bfw/u2ZWHQWBRyTRcbuJON2EfHZWMIue8JOJGUPIs61pecOpu8dAM7M6Xc4fXd/WvZAyi5LajaatodIzSGT9mAJO62xGdbITEtE9uPtu2/GZW378JMgAXeWwOVHAT/jt3X3DWcf1Fx5UHX1XuWlW4pzN5Xnr1WevVp/9rLpTPPlG4OPe6yWLgvSZkEAPUMgBvcMwLDM/Mqj0fl1gB5E2wfAU/BuBO3CrW34QDP54j7x6BbRdQVvO2+7d8Jyo2noSsPARePARdPAJfPAlYbBG032B6fRrov442vEi9uY/T6CPEDQZgRrseEPhoh7g+RdYAvxwI634ZbOJzcvG/bmqlMzdQnp+oR0TYK4Nj61Oja5Ojq5NjK5OjJJGZGgiow/uG7zyo+mzhZyZwidprk774ja+OzxQ3b5ICtWrP6iYgGaFStW70wkSXa1NGdu/CXQUxDkJggZ57Fr9bJbxpqWc0fQF10Y+tBOAIbuAgyN4JCe7WgnQ8ztNnzEryEgrEPDndcKrkzt+bUAAwDoFivWYkFarLZWZKjD0tfce+VyS9PpB4ZTzYbzzfoLLcbLzcaLd03n7x0933L+Ws+t+/3tHU/v3w+fH+Qj4sziv+8jcvJxd/b1dJrv4RwxacLJVRtsSXvxmN1UbDYRtxNN2GFL3GlP3Y1m7iX2FGD5vxMFB8nfi8miUryoBAM+VIRDF6MHDtoLfrfnFVp35Q6m7bSlZWPiPUhytj1xhy1651BE9pPtOdci07dO+tifx5ntyvtexJPExdwynmpWX7tfc+Vu9cXblRduVl24Wn32ivr0rePnH7e0oEMPbbZO68hNxcudP2+42hLttMAr1m1Hu1DoTszegdvacGszOnAffXEHe3Ybe3YLf34Hf34XPEQH7qGWZhRpteOtNrzNSrRYiVY70YYQbVa8eYi4P0TdGyLvWYlm8CEiT1uu19drM7O1KTv0CVn6hExNQkZdvLgmNq02OrU+MqUmMrkiMrEiKj5jwcJAN7cZPKcf+f8VNNX7pEkDbrdGf4FYsWLF6i8iFqBZsWL1zkRRlHVo0KSSLfx4YoArDzD02q8/Pbw//36Tsff2ZczyEMUe2vEeG9ltwwE6d9jQTive8cqQpF/BH8xywGprxyuGZtLPIzEGpviKttuxNivWZkFbbUgbYuuwP2+zdDX3P3jw+Oa9vqt3eq/eeXzr3ouW1sG+TsvzHtvQQ3To8dDDjqyNv8wSuvgJnHyEY/zcnELcnTdP8GxYsWpQvJcSF1DJ+WTKXix9j31XLiLZTxwqJUvLqTIZJZdTchmpkOHKckxZRqjKKWU5LS+lgMvLqLJSqqSELC7BDxbjBfvt2Xm2rBxr2i57wm5L9N4nsXlnNydsGDd5jtBlBmD3KWMbK2StF6+2nrreeuJ687GrzUevNh+/0XHh3qM77UMPe5HBPsTeabX/y9DssB13FKfhpbNi3Va8awiDzTqgwUGkHV4upB2DQZo2YNzOhGqQdhT+TwDeuljAhcXbAEajKGMEbFtsWLOVuM/kN9pQpLPz2ummvEJd6i598k594g5dQpY6IbMuLr02TlwfLdZsT6uNSqmOTi7dHLH2sy9mC3jT+WN+Er0n3rL66aNetvzMihWrv65YgGbFitW7FEmSrXduhi/wD/TgB4p488d67l676pam/u7RxoGeZsL+GMUf2skexxJAG9NHYojosBDDDP2K/xh6HgHoYRC0wdYTEKBfZn8RtBNhMtNWos1KtNpwAH/tmK0Lt/Sgg71If5+tvw+QKGbrQxE4asRG9NqRPsvT9n2J22eLeH4CDgDoAMF7a9z50p9+eJK+k9qzn87+ndy1n8jZRxYcIItLITSrlFSFklYpqAo5WSEjK8pxVSmuKgFbSllKK0toRQktL4MYDV0OIJsuLycOHcIK9tl35yHiXEti/uNEScPa8J/dvf1ELjM8eYumfXn/8qnBp939Tzr7H3f1P+oeegze2CPbi6fo0DMMeYzAcnuLDdwYvAXH/5KtRKcFXGS8Ywhvt8CL3GkFVwxpR+xtqK0dBRiNttmRVmCwg6FtKDTEaPCr7RCdWwA6Y3bGSDOCPrBjDxCsGbN3DD59cLJSbszMMSRnG5Oy9Ym7tAk7NYk76uIy6+My6qPTNdHptVHJldvj0+eHBrq5zxK4TBO85zdRcNxQy5afWbFi9ZcWC9CsWLF6xxrsf1G5Lz90yrhAV36gq3D1F59rd+26rdO1nz2NPush0EcIDlmWyTTDZhoA76zYsF+Get8G6OHVhG8BNIp0IeBZRLuFbLOQrVaixU60DYeniR4rnDDSbSc6bAT86QDZYcG7rQMdtYU5PkKun8DF19V5Lu+9LV5uR1evwSX7SelBvLCIOFhGlZbTsnJaIYfcDA12ZLSqnHJYWQbQmXKgsxIaPCShy0gFNKEoJeWlZFkxwGiy4JAlo6A3Nb88dOV8oXCGK+d7D86WZXOf99xD0IewnTN4qxj4K3oQtA9FH6HoQxRcHLzdjj+wYf8jgLZDDm4DtiKtFrTVCoy12QAu26ERGzwygLcOEG1D4PrAkEYrsA2DwRgr2gyNATMcj7Ta0GYbBhi6Bbe3YS/abx0z6/Mk5vS95uQcY/IeQ9JufVI2YGh1XFZ9bCZ0TLo6XixZ/cvyKR/6Cngzhc4zPTkpG35+3MMOT2HFitVfWyxAs2LF6h0Lx7C7Vy5uDw0K8hAGuAqCPD3TQhddr6i+ozc8vnWVGOrD0T4EADTeA/MYEB9fuuvvrYqDGYbXO3Iw9Ow4rR0ANIZ2I+B1iE4LCRi63QYMQBDudwxRnYMkOA7oudVGtFjIlkGqY4jotlk6T2uU0wQcPxHX140TxHsvYrz39agoYv9B4lApVibDFUpSJYfxDGg5rZQxdjxkrAAuoxWlNKxAl1IqaFJVRjAGGE0oS3B5MSkromTFNHjB/bLuHRLxjz7+Iv4PHpy/jeftjNuMDPXaYF28EyHaURyaiYZ3oVgXhnZgWBuKNdsxx83AsN9cPvjqfuOPjIDXYRIaqA0Ss83eakFarcx2CG0BHsRa+vHWfqJtkGHoIbx1CIfQDJdmotCD2IMBvHkAAwYnPxiCAN1G2Doe3718pOiQYVd+gzjPlLrXkJIDrE/eDYvQ8TsgQ8dlMVmO1C3ffe8vEswWcmaInEI+n3hEU4Ui9tFfGlasWLH6S4kFaFasWL1jURQ18PxZ9X5p6JQJc9yEfiLR0ilT61Ky7tbr7h1ufPLgOmbrwbBeFO+FXTVG6soj7ereJsK3AfrlOW12wIiOXAfebSXgUGsEustGwIcWEk4VsQFCxQCPtiNEp5XsthC9dnvPvQtNwR+OmwUHSjsHCt7fOtH7VkoSKZORCiVRWYFXqQgIyqWOkvMwNKughyvQIx4+UgG3ZAUwoGdYmSYVxRR0EaksolQyQlbRlbd/mZeXjzv3W2/nHz8SnWmsQm19dqQPRXsxrBvFYBc/BBr2wMaAHUgN//Y3LtGrJZWvVeL/yHAhJmx1Am1H2u32Nqu9zYK0DWJtAxisPQ+isDIN484w8dwO0+RM+dkCGBptZhj6PtgCbgaoPQiPtOBY59DDOxfrqhr2FjZkSRszJCZxnlG815Cao0+BRWhHlqM+PrM2MTNr4ZIFXh6+fOdZQueZrmPS1q140ttFkeToLw0rVqxY/aXEAjQrVqzevQgcv3/9aniwv5+bwM/VNcjdKz4g+EKJ7LZOd+/44eddd0j0EYb3OeYLIhgsISMwtNDNUPKrgqudmaj32sPRAA3wGtZlcYjOdmZgIeRRFLwsoPNeGw4MhxfiaDeJdGFw/HWPBRy09Txsvrx9YcB0V84Md46/cMwqD+Gp6EiyqoKqriSrK4kqJaBeWGNWlg2zcoWMgulnGVFRjleWE5Uyh6lKucMMPUOAplSOsjST6wAArToEno4placTkv24TtM8Xb4dz/1tySzL0wcAoFH0MeM+eAVG2vY5/hwbAduVvOqE/d8CaCveOUh0DQHjXRa004p02JAOKwKbQw+hEKMBTNsAVYMt4ujADW5XAEwDpG6BJI02I/Z7qP2+zd5sQVqGkBYb0ooMttw5aTy8b39T9r4jWYVNWQUNmfnG9FwHQxuS98AgR9IudVLWwc0RP3/8SYCQ58tz8hNxpgvfE29Y9ZQFaFasWP31xQI0K1as/i0aGuivO7Q/9MNJc4RCP5EgdPLEwi2bbtfV39MbW4+fGOhowaywKQeKQYZmStGQbiERwuwyg84AjmH91dEHenT5menp5uhQ8RpiwldzGL4gw9AA0HtQtBuaYXQbeIj0WJ48kOeJp48XznDj+AmcFgics2dNHygvo2prAUZDw9yzjFbJKOjhAjPl4OYq4HKiGhgAtIKugHYQNixFA4auKAUmVcVwR1lOKeTPS4t2+vnMFjr/zZMzbaqnWlmI23utVvA+HzEzGntH/oThavqwidH0/NJ/FqCxjiGi08KsI7TCi+YwM2MFtpce7jDNNJmGTVFg1hzuwOS0FboFRR7Y7Pcs6P0htMUK6Nna3n7x2Omy0mN795/cdfB41u9HdxY2ZkrM4nxTWp4xNdeQslefskeXsqs6NnnDd3/zF/L9+c7+XCd/npMP9/2gyWMT1q8+f+KIzWphY9CsWLH664oFaFasWP1bROB4860bCcsX+wl5fq682a4ua775omFv3gON6Y7W3HL6jOVRJ2p/ZAf4CNcUMi0ysG6U4V0E70Jg9ALOo36LHUdlPDrfAOi3DKEc5q2HK9wIDgcZ4lgvZum8dc4c8repPm4uvkJOAN9phZfr4ehIrLaGqqkmK1TAVIVyhI/lNMPHNCw2A2iWkVWMq8FDhcPgBIdJFeRsgNFkZSkBS9FKXKk8nRK/cpKnj7vz37xdlvn/7cHNk4j9oR19bIN//uj3/Cf9ZwDawdB/5yDD0Mwkmg6LYzgLA9B2aGbtpmPpIdpqRe7bsGY47hFrRy1tTx5cvlChPFFw8OSeg6eyi49lHTi6c//hrILGjAJTmtSQkgcA2pi2V52YIZ4fGuzlCeeW896bw39/Nve/Zri8953z//3Rk7/a36fy0L6BF89ZhmbFitVfVCxAs2LF6t8iwEZ2i+WkQfvLjO8BPc8WcILc3RIC550+WHJLY7hhMrecP2t53Ilgj+3EIwTvQ7FeAu/DsR4M64EYzTTQALYTo3LS/yOABq9mQ7swohezdw88vndoR8KcsSIfkfNskbO/wHnbl59eyEy3V1WS1dVkJaxDU1UqulIJzZSZaQDKlfJXrpKTVQpgqgoclzGcLacqYOka0naVnKiUYxXK9n3SmB++DPDk/s19zN8mCrKTwyzP2lDbIxR9Ykf7YKX8rbf9J/1nAHqU376AdmjYr2Ok80k7U/tvs2GwRwcT5GjFkE60v/3p7UvX6mpO7S8+mV90Mqfo5J6SY7sOHd114MgOwND7G9ILTOJ8k3ivLmVH9uLlSyZOhPQseG8G///zcf+/q/42JXiq50/C9//m8t6PXKeQqVMyt264c+UihqIsRrNixeovJxagWbFi9W8TRT1/8rg8b9e8yd6+PJc5XH6I9/jU0EUXFMpbesMtc0PbhQuPux/Y7Y9x/CmOP2YAuhfD4fpCgNQ26F5A0sgbDN31ZuuJfw2gmVwEnMaCoj2Ytbv9xqnYZfOmuXN8XDmz+GPmuXKjv//6cGz0YIWSqqkhKiupykq6UkVXvQRoJdyH9WbIyhCXq+VktYKqVtCQoR0nVMCed9UVVKUCr1Q2S3N3z5sT7MWb7sH5xst5wcwvb10+gln7UPtjBDZ77nvrD/xX/fayy3/ByMhAdWaOOmOIzm02OIawFeahcabVyfP2nktnblTXnj8gO1cgO5NfdjK39MTe0mO7i49lFx3ZdfDwjv2NTBjaIM7O/XnNz1OmzOG7zBGMmcX7Pz5u/ydy4U8na6Xa0h2rpn86g/++j9P7Ps6cOd6eUcsWNdRWWocGaJahWbFi9ZcSC9CsWLH6N4rA8c6W+7lxUf4e7r5cgR9g6HHjdqxYcVmpuqM33zYeuX30RO/tW0j/YwJ5hhFP7MRDG9FnJwBWQoZGMGah4ega7esM/a8BNBzgQnRbHMsNkV5rf/uV45r1c31mCDn+fI6/i9NcEfeXjz84sHJZ14Hfiapauqqarq5kaFjFkLTDIzVpQMyAnmvglq5W0tUqCpxZU0lWV+DVlXaV/E72juTpP4R4Cn3cOT+O5fl9PblOVmjp78KRJ3b7IzsAaOzh/xygXzL0f2PWt51p/QHp2dH+GW9hWkEPY7QdbUeQLtuztvYzJ64oqq8cqLhYoDovrTiTrziVJz+ZW34ip/T4HoDRgKEPHN5ZYM7aW7Bm3aqPPgoU8gA9z+H/lx///26Y9ukVQ4ml73x/37nzxqLYRX6B7gJfDtfHhevr6bZ6+rele3d2t7eSBDH628OKFStW/6liAZoVK1b/XuEYevvShbDgoFkCoa8L15/nsnzKB79v3nKnTn9fd/SO9vhd86nOS9f7e7sw7IWdeGKjHtuphygBFwJieB9KQIaGqwxH97xzgCPMAb/FlK/sAOiXXT5seLcFADQEVtimw472DQy0HqktXf3dFwF8bhCXM4fvPJs/ZvE4jz0B/jcyd1LVtVRtNVVbRTANOuiaSkDSVDVg6IrhaAeEZiVVBTAaoHMFUVOJ11TaayoHK5WHt0ckff/1AhHXV+j0o5vzjxNE+3clPe2+g9kfowCgkUcI9sSO/08r0G8z8b9oR1qjDaIzbJXdaiFamX52MNGBYd2AnlvOHr+orLp4QHVtf+2l/5+98/5qKt33/3/wXfeMCukJAew6jqNTPVOccWz00ItKb2LvKBAIReyQShcLnfSEIghIL9KTUFSkI3YpaXC/z7MD6ugp99xTxrvWfq332mtnsxMi5odXPuvzfB52QSMnvxY4NCu7PuF23bWbVVdvVF7JuHsp+e4ldvaJM8HffmdNwluTjC2JS6xJS+3ImJSDAU9aK/QvlfoZpfpVl6pOxDoeaLPSdAcOux2H2UnGun31OTPs5MjAozl0OgcKCsr/EVCBRkFB+fcyPz8/MzVVKRUF7PptFxFnjTOm4XG+mzaLzl/uk9ztF9X0CKu7pfeUFXWjPSr16wmd/plG/0QzN6aZGwVHpAJtyP/GMpHy87tJeW8FGhHr0Rnd2LRu7NWT/uq8G8d2brMmYGHbLsHYmoRxJhOPbdyY7uzUER87lZ+jExbqhYU6QYGenzfHzwOiPA/Cz4PezM/Vw+RpBflTBTmjmamV9LDLdlZ+a1cAe7YkLNtOMvplBSF8/76JgS7dzIRWM6nWTMD5G7oJNay1/1MC/d6Mv3f5yJL/RgamdY+m9QNv9A/f6B+8gTuiw+uz6iHt7PCbJ329VXcbs/JbMvLvJxfc5wmaOPx6bmEtJ7+BndOYcLvh2o3qxBuVV9MqrvBuHzt96IcfaFSSFXGZNQh+qRMVH/rrL+nB+0sTL421lutfKfWafs1M31hfbR4rZu/3X+4kYnbijXcSjJ0+Xxkd6NPTdl+n1X74AUJBQUH59EAFGgUF5d8OcOiXz58Jb6S7bv7cioCxxWLsKOSTFlYVSRn94nv94lqV8F63qKK7qHLoftvs5Nic9oVWP6meG5+dgwM6DAL9l4rQfz9vBVqDbFg4+3uBnkU6rbXq8ZknD2r5t0K2/7SThLEkYy3wRtZ4Y2vsMjcS7ux3X2Xuc6+mnxtM5c0I8/UyoV4qnBXka4T5WlGelp8LvFknLnyVl9V19WLhwaArNKvgTZ/TKLgd2M92Epb+Rlj6qwnmxB677obSOfUTxJ6fqDXjah0SPWzy/vht/yP50J7/IYGGxWYd3MT7zdwj4NBTuoEZ7aBmdhiI/vT4Q9W98uZsfnN6fktqYXNSYXOysJEnqOcV1HELGjm5jYlZ9QlAoDOqmSmCsKgTv/5ib0qxIRnbEJfZ4JfY4pad/HEL18Mr2SsoJTBIEE9/1CDTvunVzcGu65cTXdKMBJ+fvtpJggK9i2BEW0GNDfLtbmlEHRoFBeXTBxVoFBSU/wRzev3k2MjtxEuuG9dZE3FWJILdctMztjYVSZm9kkqg0X2iapWwUiGp7KtseNLTq349qdU+1ehhjVajHwPqPAMMeGHzwn/AON8KtGHHb3BlGjo00hgNx0WPzWrAT0e16tE3T/vaK0RXjgY4f7l6Nxm7m2hsQTCywS1zxBvtNSPt37Dm1PdfRf72I8vJ9ra/p+BIcPHpI6Whx+QnDhWEBCS5OzJ2/Hzs2y991q10MiPuBt6M+2wbcekvpGW715Ajgtx7WytmXgzMzo5De9ZOIAOwxzRwueQ/WX4e/tie/yGBnjHsPqh7OAVrzwOz0J5HdK9GXzzqVZaVt+QK2zKFrWmCllR+cxq/KbmwKZnfyMtv4uU3cvPqWTl1zBt17LSCcxGntv/mZE62IRvZEpfYEZY4EIwPf7OZ5eKWui8wdV9wkqdfUoBveuihnjrZzJt+rW5kTjf65omyuSj7hMPu3aaE3eB7CxHjuMqU4bevo75Wq9V8+AFCQUFB+ZRABRoFBeU/hF6vG3n0gEs/Z7PKbBcJa0nB2i2nnKbRStkpD6QVDyTVfaJapbC6S3Svq+je4/vtU2NDutlJ4Lhv26AXejmQnoe3+Ugof5f3BdpQhIabfhtWFgKB1ozBDVbeevn046GeelHa1ZOOFjvJmF2wDg0ceqkNDkjhMhvsn+zwS1woWM8VFJ/VVN+1Zn7rzL3XmO5bY+ZiTrQlGsG+BZLxTvyS7cSlvxKX/oT/zOmrtZmXzvW2lutmRzSa8Sn12AzSuQEEWqcdRWb2ffiG//F8aM//kEDPwpIz3McbmDS0Z7hkcGC0476qpKzlNr81U9iZIW1LEzeniRqBQKcU3E8uaOXm3+fmNfByq7k59zg3Si9cDd2103kl1Y5iZEtaQiN+Zof/LHD96msOjmmefohAB6Xs9ePt8+QF+RYnXemGDj2g043N68a0bwbaygSnna0tzYgWBIw1AeuwyizSf19PRytah0ZBQfmUQQUaBQXlPwewokc9ymuhJ+3WL7egGFuSjOxWUo/s3CG/zOyTVPSKa1WShi5xXYe4ukt2r6eibrS78/XkgE49odPBHfvUcEDH6Czw5jmo0UgFF+mNNnR3IFncg/BtFjYm1GpGDA49C5wVuU2jgUH2bRk1KDWyE/jQq0lVT9MdIefCaUcLZ/A+Sca7cEusiEZW+CXW+KW2eGDSS6yNP4PB/MkKt8QSt9QChLDMgmS0k7jsF8Jn26jGLt99nnAyuEFy+9lgm2b6Mfi9M9rRae34jP6JWjeuQQb26bUjOmQn87e7LSKbeC8EXvlofSSyY/nHAm3Y8Hxx2/MFOR5YHO0MrhiWWg7OwMDtacDJNPIQSrNmCPxxdOrR2RePnj7s7KupbBNJWrOF7TdFHZnizuuS9gxJS4a4KV3YnMq/n1LYystv5mTXJ2VVJ90qiIoLt7Z0WWliZ2JsS15KIy2lEZcFblh7mUZL8/RJ2+eX5hmYtMcvzcsv2dsrL/Q4/wJdlHSxWn57crRDpx6GDv3qcW/jnbhgT9pqc2sizoaIs19tFubjrmpr0et0H36AUFBQUD4NUIFGQUH5j6LValTt988fCbZaTrIAVko2opmRj/z2W2H0xR5xZa+svlsC0ymu6QQaXVTVU1M70afUTk3qtM+0wD7ngIOOqufGgINqdeM6/bgWBCrpuGETb7g3uGHCxkLG1Brkugb8aEGaDTt7a2EQ5zZshagf1ehhTwWQWuB2r5+oVM0lotTLVw/5+W79xsKcsA3/2W6CkTUeY4VdZoMxsjZeCoNZZmG8ZDd2qQXReAfRaKcZzn/nn5nnDpbz00d7G9SvHmlmDZVvQwP3GNwyBvF+rW5UB46wCD2k1iJlY/3gNLLtNjga1FYNA3UfdrAgij+tH5lZ6D9Z6AgHz5rRPzYE2f8cPsuwN4oaRDMI/72wAWZoVj+E3GzI0DSi6eCnc7NP5qafvBjofdxYrygqbS+UtOWI229LOm5J2m+IOm8IO2+K7mcIW69LW9LFTSnCpuSCxuTsxpQb/Mjo07u3u60m2VI+s6UssSMb2REx/hvWX6TZp3oBdfZP2+efstc/ZR+wZ+/0Q0Gi+LDCK2E5V8/lcSPvFHCHVDVzsyPzugnd7Fh/a1VMkJfDSnM7It6GhLNdTb188tDowMO5OXS2HQoKyqcIKtAoKCj/Uebn5zVqdU9766WjIU7rzG1IGFsSzt6M6v/dlqTDJ5tvC3tk1UppbbekrlvS0Cmu7ZJWqcprHja2PH3YN/t8VK+e1OkntXMgTzT6CY1+HMkYOCITLRB71sONwd8FqUnDSvN7heq39WlD4dkQYM9a8FAzBBxaox7SzA6+eqIcUdV33BNXi27kXou6dMTvpKPV/h0/+f/8rd+P3/h8v8lny2a/rd/u3/VzpLdL1oXwav71rjr56MPmV8971bOD4AVnEXv+i4FCD0f1DatB9LAODWvPcA9zoNRAbQ1ZmB9iKD9PLxah384VeVu9fhdYbH4beDMsNiPSDBwaXIS/TgPEfUyvfaJ5M/Z8oPdBU333nfIOUVFHnqwzR96VJe+8Le+4LWu7KW2/IWnPFLffkLWkS+5nSJtSBS1pBXW86xmHjh7e+qPzSoq96VIH6lJ7ipGDCX7/5k0Jzm6pXgFpXoFpngFAoFP3+qV4+6UE+glizoquRRQmhhWyw3KY0KFltxJ67pdq3jye003o1WMD7bVx/p6OK82sSThLMtZhwwo2/fST4cfz8+hsOxQUlE8OVKBRUFD+ALRqtfJ+c8Kpox4b1gCBtjMhWpMJe7/YcH6PZ3XyjT75vZ6iBoW0sUvS2CWu6xLXdEruKUprHtQ1T6iUs8+B+T3Xzj1Tzz2dNXgznHk3Do6wtWMO9njMAh+FvmhoclhQSUP3s2GH8Cn9KMi0Hu6k/Z5Aw2YPjXZYizRXGPor1OohoMLa2aEX493DfY19rRXKhpLOSnFzSX6DPKexJK/9nkjRWPyou/rlSJd26jG4E7wCrPgaZPcjb34/yG9fbMaApeiFaDVDWjUSDXz4rsEDVpEXHi7ejGj0Yi/1jBaJYcNF/fDU3NDU3MDU3KPpeThwY0Y3CJRdPzs6Nzs5N/P09cijx20tyrsVrWJ5m0DekSfvyi3uzi5RZBV3ZZV03i5uu1XUfrO442ZJa6a8NVPWlCFoySio5qQlBYcEffu103KyPRVjT13mQDF2pOAOf/9NoqvHdd/gdO+gdK+gtH0BwJ7TvPyT/XxzQ09Ir0QKEyP4rHA+J7yAE5HPoedxosSZV7sbirRTg/+tHZ9Xj/fW32F4u9ktN7GGw7ONnb5ck8W+Mv365YefHhQUFJQ/GlSgUVBQ/gDm5+eBQw+oFLcuX/D5/isbE5wtGWtHwbmuXn5ql0VOeGxbXpFKVtctbeiWNneJGjuF9R2Cmi5JrbKkrre6abCj88Xo49mpSZ3mqU43qdU/0S5Uo5EVh+8cGuopVEx4hLZqaIQw9EJM60fhVuHvxSDQamTmHZzaoR4yPGUaUdJZILW6Ea12VKMe1qlHNDOD028evZl6ODv7WGMYk2cY9KGBJV6D0c4gv/dvBOg1LCprYdlYrRnSGKRZDU9gwJX3yskfCDTi0IMGjUYeIn0gSHMz0geC7Lk4Nzg1PzADon+s0Y3oteP6mQnNy9FXAw+HW9tVd6s75WVtgqL2guLO/BJFXpkip0yZVabIutOVdaczq7T9dkn7rTttQKBvyttvSepTswSM8xF2NN+vvnAwIziaYx2oxk5UnLsZ5fTPP7I99mb4BV/32Z/hHQwEOt0zMN0zIMXH7+axg7JLkXImQ8SKFHAiRLxIIReGz2UUcmPEGVdbKwTTz/vndRPa6aHe+tLTztY2VKIVEWNJwXn/8n0pP3dm6g261zcKCsonBSrQKCgofxhzev3Y4GNBKtdv69d2VKwdGUMj4RyoVP+vt7BDjtffLFTKarpkTZ2Spi5xU6ewoUvU0C0GSl2nKK7rrWwYvN8x0ad6NT6gm5qc07yY0z6f00Gf1sCFehOzuvFZoNSwzxg2RhuOSJDeCR2M+r3y80IQgYaB0zmgc09DPR1BHHdBxEG0+jHt25thDwZi6kigTGthEXqxy+JDaf5YoJHyM/yNSFv2govPGtY7Ihb+QRYq1gvFdcPkDThPA47UWMhjRLXBV4hhjX5YBxu7R+e1k7qXY08f9gw0N6nKqrqk5e2C0k7+na6CO935ZYq8cmVuuTLnrjL7bnd2eVd2WWfOnfasko7bJW235W23RVWcNHbQ/kO//Oy6xtzRnOBginUyg/bsbEI68/NPyZ4+mf77M31DMrxDrnuDY3CGd1C6d0DG/iBBzNliZqyUxRByooScSDE3UsSNEnOixNxoETe2gBPDT77QVSPWTD3W68Z0M8M1wpuBW7+3JuOtiFgLKuGwk3V/dzu60TcKCsonBSrQKCgofyRzc/rnkxNVUn5coKfH+pU0MsGWSLAlkT02bDhlbZMdFVd3S9QlvqeQ1HeJ67slTd3iJoWkSSlpVEjqVPK6nrK6nsq6vtrG4Y6uV4OPZ56Oa1490U4/1WmeaTRPNbqnau2kVjep1k7odE/gWkOkQ0OnAxnS6h5rgV8iC/uQfFSH1sGbYWEYKTAjZjy8sAwRGjmsRsMjLEsbMozEcLJw8aOu64/yXkMz8ivARaTbBG74MgxXDcJ7RqehTy/sJgOXS2pG1MjqQGTp5DDsmV58Bdh/ohnVqcdmp0dmXg3PPBueGn307IFqsPX+g9p65Z2qTmmZQZ07C8oUBXeV+TCKvLvdueUKkBx40plT2plX2pFT1HKzsJKblnHi1EmLXV6b1zusIDqY45zMsc6mOFczgs+6VeHbfkvx9L0REHLD70Cmz4HrPgfSvfZn+O1P9Q28HhzMjwgtSoiWsaNF7CghlyHiMiRchowbLePEyLlxUm6ciBfHZ0fL0i73NhbNvn4wpx97M9krz2D5fLfZlky0IuEsV5pcPHFofPDxPLrRNwoKyicDKtAoKCh/MHCv7+mpntaWG/ExQVv/bEXCWxIw1mSsrRne55tNdAc3QcxVlbBcJa3uktR1yxq7gT2Lm5QgokalpE4pre4UVXTJ7ynLa3prGh63to0ou58OPpiaHNZOT2o0z9RaYNLPNPrJWc24Fg7BGNHqRzT6IY1+EBwRdYabAhraPwwzpw21YURVESVdtOf3K8qGSRrQkg1l44X69EId+m0+1OWP8n41Gi55XGjRHpmag8dZ8JY0Y1rtODzOQi3Wq8fmZkb1s2Mw06P6mQndzBP162H1K5ippwMvRvomH6ked7cPdHT0Nzb31zSqyqqVJfe6pBUdwrJOQXmXoLyzsKyroLwrv0xVWKnIr4D2nHe3K7esOw9JPrBneWeerJyddi0o8IyNhdc3XzisotgvxzmYYxzNjIE9e642O/Xjny/S7NO9AzP9Q276H8r0PXgd5kCGf0iyX0BqcCA//EzptdgidrSUGy0EAs1hSHixUk6M4HLYbcbxtLMHUs6GJEccvHX+tIgZXXr9mqpZPjv1SK8ZfTWmuhUd5rxmpSUBt5OEdfpyTUEK5/WL5/NoIwcKCsqnASrQKCgofzxAjHRa7ZOR4VqZmOG3z23TKkvTpRaUz2woxq5m5sFff3dxj5f8Mqs9X6aU3lPK6xSyBoW0SSFtVorre6V1KnE1uN4pLlcU3+0pq+ytvPegtmagqW6ko2m8v/PZWP+b54Oa6XG95smcflJn6OvQj2nn4GBppHN6YtGhF7uoF3cOX+jN+N0QDGSKHDLrAxn6gZSBkWaPGcR9p2HZ+F0+NuaPBdpwYnjlN9rhGf3ojGFYtW5UpxnTvBx4Pqp42FHddlckvs7MvBKZeO7whWOB54/4nz8ccPnEkcRzpzPiGKJkzr287EaRoPNOWfedio7iylZZZZuksltc2SWoUAgqFfxKRWGlEhhzQUV3/t3O/PLOgjtdeeXKgkplfgWw56488LAEeHNHjqgmJTP9+Olju3e7f7mWtpJoa461MzUC9uxkhnMzJwZv2nCRZpe0zyvdJzDTLyTTD1FnnwMZwJ79QlIDglL2B+aFnSy5FlvKjpVxGFJetIjDEPNihUzGjcijzINelwPdL/g5x/o4Mnwco30duScC+Fci7txm9neUq6cG5tXjw10NkZ5udsupliTcDoKR79Yt9WUlWg26QyEKCsonASrQKCgonwpAo9UzM30drbncKwesf7JdhbWmLLMnYR3IBOflZvu3bLm4z0t0/monv6hHXqOQ1aqKGhWyOhU4kd1TyatU8rtKaWlDVk4Jhyu8dKnwQlzBxRhh4kV5Gqu64Kaiqnioq+HNeP/czIRe+1SHtHZokIZpw0S89+vQ73VFjxh6jmfgBuDDb+bgNuBw9SESeAPUaFg2hiMv4KI95GiwZ0S4PzbmvyjQQJ1h1VkPFyxCb1aP6GaGta8G+lsr+LyLiaEHznjY7d/9894tG903r3NYZ267kmq3kkJbaeq4epXD6lXuX2zY983mkG3bQh0croUcFl5mtfFLOoR3O4UVSlGlUnivR1itLKhSFVT1FNxT5ld25RkEGkhzOZBpBfTpO90FpYrCovr02+nHT4XT7H2+3mS/nGprjkPs2dieauxAxXquNgvbtpXl5n7dP+i63/7rviAHM/0OZfgcuO57IB3Ys39wcmDA7bPH5FejSjixci5DxomU8pDaM+/8jeiTl4P2nvdyifd2ifN0jNlrH7XHLszVKmKP9eUDe7MvhJZls4d76vTqUf2bkfulwoBff7Ah43fjjHaRMecPB02MDKFFaBQUlE8BVKBRUFA+LfQ63fPJiZZ7ZSkx5/y2fm2/gkAzwdhRMPYUnNtK88Bvvo2gOd46x6hKy27j31EUVymKKzukd8rSMlPPhoe5uB7ZtStk609BW74N/G5z8PebQ77/6tAP3x759ccTljsY+9zS6KElN9IUtZVPHvW+eTExO/VUq53UzcFodBMgcFsWQwUabnkIFRkZ5WFQZMM+JlCdYQUa6ZaGKxEXdxSHxqx/t87P0P7xnov/1czoRoGUT88hr6wd0cwMPR3saC0X8CKPH3e28PrhC+cvltOWk2ypWBoZa0/GOJKxTiScMwnrRMS44I1ciEbOJGMHkpGDCc5lJdX983VBP/0c7uR+81x0TUZut6hMKa7s5t9V8CuVhfdUhVWKggrgzZ15ZV355d0Fd5WFd7vySu/flt5JTOMePHF8t5XXpk1OK81oVLy9Kc7OFGdvhqdRca7LKYe/+/oSzS5ln89N/5BM35DrfkCdDyLqDCvQGb4haf77U4KCbp48Ir4UIWczpLwoCTdSyo0yCLSYE8c8FhDv537Bx+2it2v8Pue4vY7n9zgw3G3PuVme9bA6H+iac/FsaRb7ycOWuZkR9bNHQu6VPetXW+HgtupOm9YUZiRNvX6FOjQKCsofDirQKCgonyDzOq1mfHCgrDA77qCX8wYTO9NlNMoyR5KxPRFrRyF5fL7h4PadFwP258Vf5F+5fPXgwUOWu103b7Q2p1pRSHYUoiOF4EzGupAwLiSsG5ngRiG4gKMZdc+6Nfu3bo318ZMmp7ZXVPU0tzxWdj0dejj9dGJu5tWc+uWc7tmcflyHDNlAGqbhtttq7RhcwIdIMxw7/f6KQ7gtIhKkDr2QhXEcyBaA+jGoxYhka2DGkP5puJMikiezmolZ/eQsMjlEqx6fevqgvij38rHAg1a/uXyx2s6cZEs2sqdiHUxg7IjLaCQje5IxjWhkT1hmT1jqQvjMjfCZK2mJEwh5mTMVZ08l0MzIDitX7Pvqq7M0x7RT4e15EqWwvFtY0S2o6uJXdhUCgS5TAHvOLe0pKG25niuIvnRxn9/hbTvcN2ywoVLsTAj2VByNYuQAxzzjnUzJ/hs/j9i5PWnvvky/oJt+b9cLHgTJ8DmY7h2S7rs/NSA4OTDw5snD4osRRexoGSdKwouE4UbKkhgSDkOYyLi8f1+8r9sFb7cLXq7nPV3i9jnF7XGI9qBFeNiddbc552LBOxGQfyXiHj/tzWTP/Mzokwdtcb4e9qYUSxzGgoINsbfo7erQoxM5UFBQ/mhQgUZBQflEmZ+bm37z6qGyU5zJi/By9PpmjQPVyI5oZEvCWhKxu0kEp7WrvL/9yu/7r10+X21JJe6i4CwpeCsyzoaMtSUZ0YhL7YlLHUjGzmSMOwXrQcR4kDBuRJwzmey6am3Q1u2ZUXHVeaLWkhplRUtfVfvDuu7B+4pRpeLpY9XLsb7XTx5NPR2afTmmnprQzsKxHjotyNOF6CZ1+ifInogThmjmJtQL2yKOG060+glk7/GnatgiMqbVjwAv12lBnui1k3rtU9hJMvtc8+bZ1Ivx10+Hxh921YhyLhz0D/7tJ6c1y21MCDQqkUbF2ZliXNZSvL9dd2jn9+fcLC7t9+CdCkwLO5gRcTgj/GDSce8rAU4nLP4csGW9yyqSgxnWyZzoZE5yNCU5mJAczU09N26KcHAVxzM7+aXAobuEdzsKS7vyiprT88svJaceOBZhaxPyw/ce61fRTIk0UwINmDoV60iFczY8Vprs3/xlxPYdiS5uqV4+N/yDgT3f9A254RNy3fsASAY4+hzK8D0A7Tk4MPPkIeGFMDkrCtizlE2XcOhiTqSYQ5fyGHJejOBK+MUAt3gflws+bvHebue93GI9XWL2OTL2OkR62Ie708JcrOJ9XQovnStk0hV1Eu2bx3PTw23lwuBffrAm4HfhMRZrzFIuxb1++QItQqOgoPyxoAKNgoLySQM0+s2rF8rWJlEGNzZwj++fN9HMCNYkrBUJt5uAtSTBWJCxuynYHSaY36iYnctxbt+uDdr57XH7rWcct520+jH4zxvcVxOdKUvdqUauFCMnCtbehGxrau713Q+Xgg7X5sq7YS91c4eooauoqbO0rruitruqtruyvqe6+UFj28O2tsGu7hGVcqRXNdLXM/6w7+njhy9GB948GZx+OjL9YnTm1bj6zRPN9FPt7DOd+rle89xwRPJCN/1c/frJ1LPB15MPX070vxh98GzowcSDnrF+1ZCqa6ir83FLq7LqXotcyjpzMnD7L7ZwHz68LRljZ4K1M8P5/LQh/pDrratnKgu5XVV5DzpKh/vuTQw0PB1sejrUNDnUNPawZrinsvtefkUuK51+6Kzjduc1ZLdVZBcTvAeV6EDE2pAItlSzwD//knk6svkWvyNfUslLv3nq3JW9Pie37fLd9KX7GnOnFWQHc4KDGc7BFOdIxTlR8c5UQtCXn0fu2sl0dU/z8s/0Dcr0Db7hux+o8w3fA5kL9hyS7hOS5huS4rc/OTAwK/S4+GKEnBklY0dKWBFAoKXsSDEbOrSEG1WScl58jR7v5wIE+qKfe7y3a5yXa4ync4ynk0GgI9xoEa42dHdrwaWzIha9+Na1JwMtczPD6hcDt2LDactNd+Gx20hYr+0/dTTW63TaDz8oKCgoKP9BUIFGQUH5P4Ber3v94tkDRUfR7ev+W7+zAtJMwFiS8bso2J0U452mGNdv1h6ibWPTD5VkM+tLb7bVFihaRKpmoaKusK30xt1bF5nHPA7u2uSx2cR2JcbGHG9jRrY0obh8sSnUZV8R50avrLFH2qyQNndKGtvF9W2iuk5BQ7ewuVtc3yGt7pDBdBaB1HSW1CjK6pR363sqG3qrGvurmx7UgDTD1II09dfAIBebHtS2PKht7a9t7q2uV1XVKKuqlRW1irt13eV1nSXVbfKKDsmdtnyJ8EIC3dXDZd16KzLRimBkTVxqvxIb8POGTMbBpuL0gZ7SyZG62VddenXvf889/u/5x/NzA3P6gTndwLz+8bz+0bzukX62b+Z552R/TU+toCT5/AU/R//v1rmsIDhQMbYmOEsizpJE9tz4Vayrx/Vjx6PsaYd+2uK3aYPbSnO3VVSXlWTnFWRHM4KDKd59pYnXulWHv/uGvnPXZQcX3j7fDO/g697Bmd77M4E6+xyA9gzbNg5AdfYJSfENTvILTDsQkh92RnaZUcyMlrOipCygznQZKxJEyoF7pki40eBdFXPjLgS6xvk4n/d1ifVyjvV0jt7nxNhnH7XXnr5nQaAjXC2El0JlHEYhO7JKmPZ6Qjk/O/q4o/aYg9VuKnknAbfbnMKJiXg2OYHuTYiCgvIHggo0CgrK/xnUM9Nl/Fy3r9fvJBrtIBhvJ2N+McM4blkbf9xHfjNBWS+ZeNSged2rV/frNP16bd+cpgdEP6ucfXF/pL/0fsV1YQo94fhe35+/sF1JtDLBW5uSbdYsP2ppXZqY1i+p7ZU2qqRAmpuBOqv493sL76sKG7v5tV38ui54rOniV3fyq7sE1V1CQ+51i+4phFXdwqouQWUnvwKm8G0qu/jgRzXgzk5RVae4sl1c1SG61ymq6ZYCQa9SSqrbc6T8iAuHft7hYLrSGk+wxWNsCEv8vlmVFhZYJ+I9eVShf9OpV6vmZlXz2v55de/zsabRh1UPlHd6O4v7OkoedZcN996dHKidfdYxP9v337P9+tfK2Ym2gRZpaUb8hf1ODp8TLSlLbCjY3ThjWzLJxdzs0JbvDm75ym/jaq/1K9xXUl3Myc7mZPeVpt6frzn43dfntm+Ps6UluO1N8gxI9gxO8zmQ4XngutfBGz6HrnsduO4dkgmu+BxI8w1J9d2f4ruf5xfICw7Ip4cWXY0pZsYWsaKhNLMjZewoKTMShs0QcxhSbkwRL7YkKZ51zDfa2yHGyzHa0xHYc/Rex6i9tMi99hFAoN3t6G42dHdL4aUzJTyGiEXPSQhX1su0U4PaqaHC5KuOG9dbEgg7CViPn79tqa1CR9qhoKD8gaACjYKC8n8DjXq2vaH6hLvdDqrxr8Rl20wx1ptX0g/vKZemPu6tmnqmmFc/mpt9qH6pnJpsezXe/Gq88c2TxqlnLbOv2nVTnfMz3ZqX7ZO95Q0CbqyPneMaMs0Ub2eCtaIa0VZQju3YKbuY2C+91yOpU0qaVJLmXmFzn6AJpEfQoOI3IgEn9UjqlAupVQpqFfwaJQhy8n7gT/m1vYL6HkGdQlCjENYoRHUKUX23sL5H0tgnrVcUlicdOB383U82RBMrHN4Wa2yHW+a/aZUkIWJSdXf2Rbtao5ybVU5Ptkw8qGi9d/ueNKksP7H49lX5jcuy61fk6ZeLrl+5c/NKRXZCZQG7Vp7W1yp5NlSnfdEx/7LrzePahw2F+VdOBmz93MpkmRXJ2IaIoxFxbqaUw99tDtv564mffjjx04/AmKOtbOPtnS47uzE9vLie/inewak+ISleB1O9D6V5HUz3PHjd6zBwaBjY8RySBtTZLzjJLygpICj9yMH86DPyxOgidowMLhxkwLWDLLoUaDQzSsaMkkCBjhazGXJubDEvLjvudIwPkGa7aE8HmL32iEDTIjxo4UCgPWwu+DmIL4eWcmEZO//aOXHaxSeP7+u1o+MDbWfcHGwpJrsJuO1mxMtnTzyffIIWoVFQUP4oUIFGQUH5P8CcXj/4oDfuqL/FSsKvxD9tpSxx+PO69KthD1R3Z6ZVWnWfbrb/xVhzX5ustSKrQZZWL+Y1iDjNEt79orSuituD98XPessfNfJvxR+J8rLy3bLWeTnRhUpwomDsqctophgHc+qJXRZVvMw+WbVK1qCQNCjFDb2ihh5BvUpYrwIODVMPw69TCeqALi+mZjEfXlEJa0F6BXU94KKwVgEiqleI67sFtf2yxh5BRdrxcLd1X9iSiNY4jDXWyJ5gZIP9L9cVuGhPm4fNUt20akajGn5Q0ViSUZpzhZ8SmcM8l8cMz0+IKEiI5CcwBAnRggSGMCFCmBhRwIzI40SIMmLu5F9rr7g50iHTDtfrhxvGGgV3kqIDf/7C0sTIhoR1oBBcqCTvtauZe/exPf243vtTfA+m+x/JCDiW7g9yNM33SKrPYaDOqd6H030Pp3gdSAUO7QVM+kA63CclJNU3ONU/OMk/ICk4KOvMSfGFqCJWTBEHmbnBiYIT62ADNB06NDNKahBoJFJOjIwbJ2XFpITuZ3jSovbaMvbZMfbYRu2xpe+xoe+lhblbR3vapZ0OKEoIL2XT5Sz477p1ObSm+NbU6wd69WjxjSSn1at2EfDbyThYhK6p1GrRIjQKCsofAyrQKCgonzrz8/PPJsaSY8McNppvI/3pF8pnHr98Ici8OD5Yr5vp1UyrXo43KxoFd/ms4puXZGlx8pToYpCkqNIURnl6/L2bV1oKec357CsHXDz/vNrpc5Id3I8a771uuecacwcKhkbB2pkQnVetojt4NNwQ9MjqgUB3SxoU4jqFCFgv1F9DYBUZ1pKr30YlqFbx/1IE1T2CGhghMOkahaimSwxS1yWpU4hrlKKK5KOhezZ9bUHE2uKNbHBL7EAwf6Jh/2SF/X80c0ykN+1hc9HIg5ryQrY4NYbPoRcygTdH8BPogoQoYQJDnBAjTogFR0kiQ5QQKUiM5LOARocVciIkSfQ7meebC1lKWdqju1kP7+aKrpw7sP1bayr4ZxKcTMmu5ubn7V0ygk6kB4VmBICczvA/le53Ms33ZKrPsRTvoyneh5K9Dqb4HEz2DknxOZDqCwJXCqbATVKCUoKDbp44IoylFyfElbLPy7nRwJsXB24gqwZZwKEjJUwGiJgVLUIiZsdIObHAoUWJkWln918IcGbstYn0sIraYxXhYRkOTrztk08HSq6eK+VElrAj5MxwcWJEzuXQm4nhD1VVTgFB1QAAgABJREFUupmhif62MDcnSzPqdgp+53ISJzoM7YRGQUH5o0AFGgUF5VNnZnrqrjB/348bd1CWbiX9l/Vmag434tVEi3ZaoXvTPdZT1iBLll+PE/GixFy4ak3OjSriMYp4UXeSY8tTzlekX6xIib8S5OTxjbnDWhxtFdZhNX7/T5syjwelHfQ7sOVrODjZhGhPNXFbu5Fz4EyvpK5bDLcK7xIDk65XiGu7RTWGdAmru4E3C97LBw/fXa9RGiJasOdOcW2HuK5DXKuQVJdxb3h8+bWVCdmKZGxLWOpMxZ746evjWza5mmDt8H+yxP4XbRWRddinVXxTwouBi/DYUWJmpDgxUnSNLr4WJUmIlibGSBNjJYmxUuDQwKcTo8QscA9dyIwQJp4TJJyVsMJKkqLuZpyvzU5syGGLr4QH/LTRzhzvtILiusL85C87UgOOp/ifSfMPTfc/neZ3Ctqz78kU32MpPkeTvQ8leR9M9glJ9g3h+QYlBQQnBwQlBQamhgRnHjskYJwruhpTwoor5Z0v4kRLOZHQntmGRIpYIODNQHV+a88wbOjQEliHjhFei8iKPpp8yp95aO/VYNeEgx7s496ZkYeEV8OK2PQSDh0IdBErQpJIL7h67vqFkyW57Jlnffo3I6KURMevNgCB3k7BBln91tPRqtfpPvy4oKCgoPz7QQUaBQXlkwYY0gNFZ+g+J0tz7HaTpdabqImRweMPKnVvOmeftwx1Sur4CfJkuoxHl7AjgDrLOYwiEF60nBddlBRTmhxbwotJPenr9e1K53VE17V45zU4/y1r8+hH7mdxm29zxbFhB378imZi7GhKsDc19f92a2lCpkoEO6GVkkaFqF4J69B13SDC2m5BreJdYBs0uNgF/BimFsnCebcYWHitQlyvNLRtiOu7JI2d4AUlDa05pTEeAbam5jYknB0F67bGNGW/tzwurCQ+PCVor8dKoh1hiS3ZaM96s8LIk8WsaBmXIWNHSZiR0sRISUKEOCFSkggeMkRMhpAZLWYCjY4RM2MkQFiZUKNFTLogMVzIghGx6bKk6DupF+6mXbxNP3Tc4gf3z03d15iH7tiVFngkyedoqt+xFL+jKb5HUnyPJoP4HE7yOZTkczDJ9wDPJxjYMzcwMPlAUNrhkJsnjwoYZ+WXGKWs2FJunBxRZ2jPbLoEyC7StgEsH9iziMV4582LEbKBQ8NeDhGyslCaSBdeDuXHnyo4f6wg/gT/SqiYGSHjRMo59GJORDErXM4E/1I6/2pEzqXTOZdD+xqLda8GhlUN++127jQj7iBjrdaYFqYnT7958+EnBgUFBeXfDyrQKCgonzQz01OCjCSHL1bsoBpbrCPFHt/3SHFHP6VQTzYOtORX5VwsSoqQccOLuPQibmQxJwraMydGzgXeGSPnxZRwo3MYhw/8+qXLarzHasKe1fiAr5bfOO7blcvt5qd2C9La85Lz6Ye9v6Q6mRo5UPFO5iujXbw780p7xHUqcQPQX5UIHBsUwgbEmOvfS4OqsAGcKAQgdchxIUphgyEqUWOPqEkphoHDPSTNCnFjacJNn80/21NMHckEp+XkhEDP+gxOS1bK/Vu8upRriT7OriuINPIyR4pxlNWvssthEuCpsLIOe4tFrAgRM0LIogvYUXxOZCEnis+O4bNiBKwYETsGUVWGmAXEms4HGs2mi9hRYriwL7oI+VPkRh255G0f5bjryl7X1KD9Sb4hSbDGHLyY/VwkPD+QoOSA/ZmHj+aEncqLOiOMC5ddYhQnxJSyY4vYUXJ2FHhLYna4hEOXsiKkTGjPiwK9YM/QmN/r3xCxwRUGeD9AoCUs8GUgQs6kFzHpcmaYnBkug0OjkeF3MOFy8JqJEaIEuvAavfByaH78qZLrV18Md2hfD6RfCLdea7aLDL5NYU/scRp+9GB+fu7DDw0KCgrKvxlUoFFQUD5dgBuNDjw87WpvZYrftYLgZfvD/QaBZkqled45UF9wL+uinEeXc0EiYfGSG1XEZRRxo+Vc2Ccg58UW8WKlV8IYrjudV+HcVxP2riZ6ridH2m3tvM1W8VMV/NQufkoHP6XxRsKVvXau5gRnE7yDCXnvF5vKWOm90joFUGcJcN96JTBpIdDiOqXBj98KNB8INBDrt2lUgghhFOAoAmlSCZuBQ/cg512S5g5RbdKxCHuzVXBDRDLx6NYtd5Ov3c9Nb85Oas7mtdzmVXEvnrP6lUY2cjXBBqxfnhd2SMKMkHKiROxIMTjCkygxGx6FnCgBCJch4DD4bIYQGmq0EGmWELKiBKxIITsS3Ias7WOAyMG3C3Db5bOFsadyGSdunj2afCiYFxLIC/bnBvlzgvy44CQkEFzMOH7o9tnjBVGh4gt02bUoWSKjiBVTDNSZxQD2LGPDQXULteeF8vNCBRo6NOwkYYiZiMojJwvV8QW5j5LA0ME/Ssaky1gRMlY4VPD3XgFuwgJvoIsTI8WJdNHVc4LLobmXQjur+NoXDxQ18r1bv9luittBxTtuWl8hEWlmZz/83KCgoKD8m0EFGgUF5dMFuFGlWOC2ca0NlWC70fxyzKGXLxXa6d7x7vKqG5eKk6LkPNjuLOfCwFYHYM+8GBkvFgQINDDpvKijft+utjdd5rGSsHctyedLs+zQ4H7RdaUgtZuf0lmY3MZPactLFkef3bdmhYsJ0Z5MsDM1TT12pr+4TiFpUsCacd3b1YSwl0MImzfey2LhWVgPq9SiBjhqQ9TQDSJuUIihN/cKG/qEsJLdKW1uEVQetba3phCdyTg3CoHtt/d+fkZzXkpzDq85m9OSzbuflZwfcdKWZOxigttjimf6OBezwL8uGnozN1qCRAbbJ6IlnGg4IY4LrRop7jJgERrWoRlIH4XBud9FAnupGVI2MOloOSdGkhjFvxzGjw/jx5wriDlbEBtaGHuWHw9sNVx8NUKaCGc5y9mwJQYZTgfbSIA6I3t0IwL9LgvF40X9he0lEuDNiYzFwHNwRcJiIPaMCPSiK793bohhiAc4wrZvCTNSnBAmuHI259IZSXr8s4fNrwbao4L37FhF3m6Kt1xuwokMf/H0CbqzNwoKyn8YVKBRUFA+UZDhG+PsiDM2yynW5kT3rV9Wld7UqB+8Gm2pL+SVQm8GAo20O8Oqs0GdF+xZyo2VcWOBLKYe93FYbuxoZuS2HLdvLTnkz+vrUy+q+GkKQWpXYXJ7QVJrYVJ7fkoN98rBP3/jRCXRKARrE/Ipa/t+eY0SCLSo0dADDey5ezFwIB2St9M5kNSBIN3StbBhWoRot6S+W9LYI6rvFdWqxPWdsqbGgjs2az+3NSU4mRi7mhGKL0S1FmQ05Sbdz0tuyeHcByfZqQ1pLLfVVGcqzt0Ee/yXr0tZ0UVwBR7DINBSbgwssSMCDcOFBWn4U+jTsWJ2jJgdLWRGghgEGtywGAa4Hwo0sq0JDDjhxBWz44tAwAnnfBE3DlbugaPzoqU8hvQv6PKHkXFgpIvT6xYF+q09LwRe/FsCjQzuWIjhnijY0p1IlyZGCK+FFVw7l33tXGtZ7sxwVyH3gt3m1duouB0U/H7rnX1dHXq9/sNPDwoKCsq/E1SgUVBQPlHm9PqHyu7DtN2W5kSr1eSDLjsmh5tnX6uUNYWlSTHFrEgZN0oKNRoKJQxU5zgZ7zw4SrkwEnb01QBnG5PPHE2NXEyN964hnbP8oSOLrRKmdfNToEDn81rzee15Kc0ZnEh7KzsTgp0J0YpC9Ppmi6LwjkpUrxI3gqNSVGcY5PzWoRdMGk64q1EJq5UiOG1DBY7iGsVilJJapbReIW3skdT1Sep6pPXdssbKTMGvJIqtKd7RzNh9Nbn1dnJbwfXW/NTWvOT7eTxwbM1Nu3875cCPXzmZ4t2o2D1rKUVX6MVMIL6GkjOUYFiBRnb4gw/hCLmFWcsSTqwEOnS0iBUFBZr1FwQaPNfg3zDcGOSbxnnkj4b83eB3Dyjl0MtBEDN+T47pHws0Un5+dw+cFsI0uO/vHRq5+JFAv7Xntz9aDKLgEvCUBCDQ4QImPetyqCTt4vO+xq67Qq9fv91hTthBxtqsX1EpRbs4UFBQ/tOgAo2CgvKJotVomipK7Tcst1hOsNpgeiHUXzfdP/m4oezG5RJmVAkzEtizmAtXyEmhC7615/OypHgp77yUFy9lx8bvs7OlLHGgLnOiLnNfiY912tmZzVEJ0rqQ/o32/KTWXG5rblLzzST2ft/dZKwVlWBBIbh+vrE2JbdXXNsrauwRNqhABHD/FIXwd1EiW6WogEOLat+PUlyrEteppPUqWYNS3tQja+yX1ffJG5SyRtGV1G0EMo2KdzbH+H61Rim4BQS6vSCtNS+pDbyZ/JQWINBZKRF2O53MCS6mWAdTY370qZJEhhwINLIID4qyYXcSDkP0e4FGys+wAr3QwsGKFLEXxzPDwOcC8zb4NzRpoMu8OAnvvAQeYyW8GEOF+61zi981ZrzLe7XnKMO+g++rMCLQhiAObZBpmIXri00af82ekVr1+00gCXRRIp2fEJF3LSzrSmjvPeGL7rrTrla7VhB3mOC2m+LTLsZOvXr54acHBQUF5d8JKtAoKCifKDNTbyQ3UndTsbuX4+2+XlmQcUE73a+o5QPrKk2MLGXB8rMYLo+LQZoZYqVcKNBQnZNA4mW8C1J23Pm9QKCXQoE2WeayHBPvaqHIS1by07r5qe15vPZ8XlseItBZKdmRZ7ZTjHeZYHeT8Y5r18kucnvF1T3C+h5ho0oA0rBg0u9HUNcjrOsR1cHdCuG8jvoeMYxKUt8jaeiRNiqlTSp5S6+8uV/e0C9v7JU3ZdOv7cCR7U0ILstxh37+WinIai/IBALdlp/Smo80cuSlt9xOueztYm+KczbFAIG+dTq4OCGyCG7mBxQZaWVGAv7tIi4DMWNkPBw05reDLwwCTYcC/S6RcIUf+LtxoIsj3zpiEG+Ok3JjJdCbY6TItxEpYsZS2DMNVwqKWYtPR44S2E4NYxhj9/tq9NsmDUMV+XfqLGbSQT4oYBve0ntZGCANlyEaitBwZl+UIBFuJZNzJbTyNvO1opZzMshqDWUHFfsbBXPCw/Hp2OiHnx4UFBSUfyeoQKOgoHyazL98Npl49qiVCc5iBcHxz2vb7hVMP+2syGNKEsOBQBfD/oQoCQ9WTJFAgZYCF4T2fF6WfEGWdEHGOX/Ry8GOusyBauxoYuRijr3kYa3KT1UK0rsLEYEG9pzDAQLdlJUquhy90xS3ywRjYUKwX70qN/J8r+werChDh0bsWdTYC+dpNEGlFsL5dODEYNVKZI2gStzYI4FRgqOsqbeopQemta+45UFxY39RU6+8MfNM/G6ciROZ4ELFhe76RcG/3V5wvS0/FQp0Hu9+bhIU6KwU7gEfINAuZlhHM0zqYa/iaxHI+AtY7l1QTyjQC10Whh7o9wR6cREhCyrvB7VecN1QwF5soUaCnEOlRmbeLSwfZEfKwFPYkUJWxNtK9u+NHOaD9uX3dPnjAIH+cNWgGNl45b28myEtRGZdI2VscBLFZ9ILEsPB//ijKqGUFWP3uel2KmY7BeP67RfK+43ojiooKCj/SVCBRkFB+UR5MjJ03NXamoq3WI5327rhcXf5aG+lNDVaxoooYUYWwUoq0gTMeefQEl4sYs/x8pQLwKHl3PMJQe62pkb2phgHE2OX5bgre+168lNVQKALUjtyee3Z3LZsTktOUmN2ijThvOUK0m4TrAUFZ79qxfUzYUrZXYW0WiGuUUnq4FJCOBm6fjFQl5Ep0fU9QJ1FDUox9GaVtLFH2qSSNvXIm3uLW0B6ilv6SpsflDb2lTb1FDVkno3fhSU7kwguFFzozl+VhVnt+VCgYQ90Lrclh3c/B7ZwpBzydzQnuJrjnc0wSfs9oECzIqWIPUOHRk4WZmvAIjEs9yLz42DhFg6PW6jm/oVmibequtA2DWN4EaQrA9F0xJ6j5Ky/INAfBr6f3/Uu/yVpfpuIjwPL5H/BoaFGC+FOMYYhHtEipAjNZ4YLWfT6XO69zIQ9363bQcX8Rja2XGUiz74+Oz314QcIBQUF5d8GKtAoKCifIvPz86OP+n1++96airMwx3lv/2qou1xRky/hAc+LkLHocC8PqIBRsA7NjZbCqRHREl6MNClOlnxenhIPj0lxKSf8bYBAm2HsTYyAQF8FAp2XoipMU+SndObwQNpyuM3ZSQ3ZKXLWxd3mRAsg0CSM3Uqz1NNnlKUVnSVVnUWVHbKKTllll/xel6y6GwRYtbRWKa1TSGqVklqg1ypJvUraoASRNajkDT3yxp4ioMuNquJGZUmD6k5dT1mNsrxeWdZwO/rKdgzegYhxIWMPbvmmV5gDBTovtTU36X4OpyWb25Kd2nIzKTnExxkINBXrYoZJObAXCLScSZci/Q8Swwmyd4loocC8aLHMaCRv+yj+lkAvaPTv7zGoORxXh5SfwUNgyX9LoOH2Ln9XoD+U5t8LNNwXRgRHViNhIfNDEI0WMqMQgY4BEcHzSGFiuIgZUZp8virj6hHrn3eaYYFAb6diOVGhL58++fAzhIKCgvJvAxVoFBSUT5H5ubnBftXenzZbUbEW5ljf3zY/bJLV87liboSEA/d8RjwPaQuGGocseuMxJNCho6VJsbJkoNFx8uS4rMgjTquJNKoxDbZw4M47W6hyU1QFqV25SR1Z3I5sbms2ItBZKeKrcTtg+RlrRcbSVpnmxMVMKnuGu7oH29oeNDb21dX3VNcrK2q771R1Fld1yquAT3cXVStl1UppjVJWq5LVqeR1qqK6nuJ6EFVxnbKoVlFS111araqo7qupe9h8f7C16+6NrG04jD3JyIlktHft8h5BdlteRmtuyv0cXks2uzmL03Qzqek696qns6s50ZWCcTbH3DzpX3Q1XJYAN/yDO4wkwi1IDA4tfs+M/4cCvdjs8U6gP2zJeC/wyt8UaLhLC7Iw8W1+79MGew5H8qE6GyKEAh1u+BUgQKaRQI1GwhABe4aBe4CLkQ4QKSuyIv1yrI+D1WrSbyaYbWRMZKDn2ODA3NzCloTgwzM79ebFk7HJkcGXkxNajRodFI2CgvKvBRVoFBSUTxHgQAO93e4/bARGa0HFeP24QVWeW55+XooINFzExo6SIqYIF7cZTI7LgEVocEQEWpoMj/wLof5bPrcxWQYE2skUc2rbd20Ziaq81K7spM6spPbb3NbbSc3ZyfW3eDfCT2wnYawpeEsSxmn9SgkncXZ8TPNicvb58NSTx28mBl6NDrwYfvj88YNnD/uf9fc97emdVKomO5VPOhQT7YqJtu6J9m5w/qRTOdmlAnmm7H3R++DZg74XA32vRh++nng8NTk61NZstdyERjJ2IC51NCXUJCfez01ryU5uzuY23GY13mI3ZHLqUhLP7PjR2Qznaop1NscV0o8WX6VLr0FvhrsSvleBhsv7kDbixSC7AC7UlT8WaLhNINxMGwR2TSBBtPV3QQrbbyOGVeEFk/7Inv8HAs36OwItgl0ZMHCXcvjbDUodIWTSEYGOEjKjhYnRIsNADxYswIM/QmlSXPKpQIcvzH8zwf5Kwhy03fVQ2TXz5tVgT3eFKC8lJuLi4SCG7166t1t0oOelkwf56dze9paZN69Rk0ZBQfmXgAo0CgrKp8jc3NzjXqXbj5t2m+CAQ+/5alUHP7UE7tkRIeXQoT2zoqWJMXBaMBA1pJ0DGWxsSAxwaCjQKXHia5FnadttTI3tTOBSQq/1ZrKoUz05aV23UzqyUtpuJbfdSm25nVSbmRjpYbeLgremkKzIeJcv15bdTH0x+HBO/VynGdNpRrUg6hHt7IhmdkwzM6aZHtVOjWhej2hegQyrQV4Mq18iMTx8Nax5A+4Z1U4P62aGNbMjs+rR2dnx12N9x2122BEwjnhjGhmXdiSoNTutISupPotXc5PdcIvbkMEsuUDfs9bEyRzjYIrZt8FcHh9eeo0hu0KXJ0aKE+iSRCCRERKk+WExiPUuBPquQXwXhmYgGm2YpCGCDc2wxCuCXgsCnwLLvUjgosOPYngu9O+FsvRCw7ShZ3phXgf8+78NvL64phD+onf5yJ4liQaHXvwR8q4MD5HQRcxIETMK2jOynSEsmSPfHGTsqNy40+7frN1ugv2NZOz65TpJekohJzHa2z3o52+cVpvaUvFWRAwMCW9FJXp+u/Gcu73kevLLyYn5xUI1CgoKyv8aVKBRUFA+Rebn54cf9nn+tmWXCW43BeO8nlrGjimGrc+IQBtab5nIfAY2XDBn2KR6cXOQGCkvBgi0NCVOzolNPh7gtJ5iSzWimSxzNsXQLbfeS4jtuMFru53cfCO5JTO58TpbEH/G87t1lkCgySTg0MG//dwgzB9/0KNTT2p0wxrdkFoLMohk2BANzMjfy7Ba81irfQyePqMdmtaMzL58lHuZQTMh2eMwNCLu8NYtd1kX6m9w6m5xa29y6q6z7rEvxLtY0UyMHM0xjstx4bRtxdfoRQmRMqjOEXBr68U1eYhf0t/TzXeBJrogvpFSJvhDQZ2F7cUwC7YKXy0RSupis8RC8/HvS8iwivx+PhhC99fy9v53FeW/LtB/L5GixChRAnRoOJQDjppGesETo4K2fbeTit1BNAJfsQJ/3uL19QaaKc4Kv8Qat8QKt9QSu2Q35rNdxkt3Y5ZZ4JbammD9f/o6Iz5qqL8XHdmBgoLyT4IKNAoKyifKk5GhQ86WO0yMd1OM7VeT0477lXGi5Wxgz3QxBymyIgVXWDo1ODQLaScwjGbjxUhgETquKOm86ErEcasfrUyX2VGX2lON3FYSGbQdZZcZrTd4LZm8+9eTKjkXGa4WtsuxNmSMDQlvb2bKOnSwtUj6dPCBZnYC2DMi0AZ7fifQ/8PMah9rtIMa7dCsdngaOPfMUFupYO/mz+0IWHsCzsmUdHGPY1MGp/46C6QuLYEXuG/PGhNHKsbJHOe+lpJ+wlfGDJOxwiSscBEzDFaRWeGwCpsYuZgFFf4wsEqNdHogtxmW9IkSoXMb/FuSCANOBO8F6TN+Wz9eqCL/Qw79wc3/CoGmixIjRQlwWxahoYsDvoeoIk5cqLOlhSlhJ95oF36ZBWGZFXGpBf6/rAh/Av/FAV+tOfzz5pAtX3isNbUiAJn+L2v8EivSUvdNa5IZYU/HRtA6NAoKyj8DKtAoKCifKK+eP70Sevg38hIg0HbLieH2O8tYscUshhR28dKF7HARsvhMgDQhGDp6YfsvG+6uIuZFS5JgEbooKa6UG5d2KsDlc7KNyRKayTIaZdmetdQI621ixpl7rAvlV2OYfh7u681sTJbZkZbQSBj/r78u4yS1lZS+Gh/UqMf/GYGe1Q3P6OCztNohDSLQs+rhyYetp91sLIkYOxyGhjPeu3759SPB91gXa7iXs04f9PlytR3JyNEE62iCO/zTV+KLZyScMCk3TMQ6J2KFCWFgPzGiv39ToN+FLk6Em/l9EHECvC5MjOAnhhsiYIYL36rtR978dx3649sk/wqBFiVGwDecAB1aiBTgkTcQJWfFXAraa2lO3EUwssAvsyQspZkaB3yzOt511/XD+7LP+BfSD/DpB2+fDIh3tfDeaEYjLbHGf2ZDMvb8ZqPsRjrcvBDth0ZBQfnfggo0CgrKJ8rM9BvBdd5vpKUWZIwtlRDw7aa88FPyK9GyhGi4dhCWUcOEzHABMgdtobUXLiiEg+2AQ0t40bKkmGJeXCknVnQhNMxum70ZBtizPRnqqcdKyolfvrvoZhNJ2+61cbUtcHTSEnvSn5xNCZc89rXniTvLK988HdZq/2mB1g+qdVCgtZrhGe3QlGZodmpAnJGw0wRni8PY4zC2BOPAzZ9fdLVN2OsY/O0GGtnYgYR1JOMcTQgJe13L2XFyXpSMixSe2RECJhRopAj9dlme4fyvJzFc9C4GH30XQWIY/70IF1/2YxX+IP8TgYb6+y8Q6PDfCTTysjJOlJwdm3wyxGY5ZTfBeDfs0DCm2/6afdq/5NKpisRz5YlnK9jnqrgRVdzIO1dDU0Lc/DetsCcZ2YHvLWR8mLvTw+5OvR5t5EBBQflfggo0CgrKJ4pWo26suOOwYaUFCWtNIrivWpWwz7Mg/FwhI0J8iSG9ypAnMsQJhnVmhm5gZNEbG64plBh21ONEF7FiZJcjBdFn0g76nvj1eycq3omMcabg3KgEVyrecy3VbQ2RZoKxh9q6zJG81H/j+rvXOB2CElVNw8yLEa129J8VaN3QrA7as0Y9NKsZegOboYdH+huPO1laEbF2OIwdAWNPwu5ZaeK5xtSeZGxPxDhS8PYkQtCmL6/v3y+NiyxKjCllny9ixUrhNtdITZcNAkz6nJAVJkJ8GoYJI2SGiZjIReQc+LEw8ZyQuRhEkYXwi4fhR/BYmHDOED7y0KDaC4L7kRN/nL9mz4Z8LNCG6wuvD1tNFu78WJ3fE2ikCJ0Iu7QNFWg5+P9lx96KOGG/ytQCb7wLu4Rmirl5wu8uM/wu62w58/SdxJOlzJMlzFOl7DPl3LDia6dZfg5e68FfGGuLx7itW1mSdWNm6s2HnzkUFBSU/xmoQKOgoHyizOn1j3tVJ5zsdpPw1kSSA9ksbIfV7aOnsk6ezg07J4imSy9Ey65GyxKjpcxoGUwMCDiHDxOjZQlAsqMkFyLzI85knz6adfxwSoDPqa0/eJhRXEg4NxM8iLOJsSN1mQMF2LMxEGtXUxLLy7s7X9ImKutvbtFOj2s0g/+MQIPM6KBGa7RD4KXUmsEp7SBw6OnpR/cEmV7fbrTEGduR8DZ48AYwi8E5Ukje69ZfcfG4EXzk1uETeWHnpHGxxVcvFCXGy5ixEhbD0MEiYJ8VcsJ+N+ZiwVPDoSXDrowwPtTic9ChEZMWJJ5FpPkcDPIj/r9CoD+++DbQ+N9OxHv/uuH1F+357ZWPI1p4S+AcjhAxvAjcLpEVmxt91nX9KksCBgi0LdUoKzSwLPFcGfPMHdbJEtaJYubxosTjRcyTcqjRZ6UXTp7escWJSqARcdYkzOWjwc8mxv77v9EuDhQUlP/P3nu/NX3v////wvtz6oCQxXJXbWuH3VVxoCBTRVyAQBICBLI3YSM7DK0DMlkyMhlq3XvVLUOtyNJWT1sHZMH3+3y+gojQ9vT0nPbU63rervv1ul6EJKbvd3648TiP5+PxR0ACjUAg/r78/ORx5Y5Mf2/3tSRiEMGd8s6HFbGJ1Ux+NUdYyxPtF0rqU8QN6aLGLKkuR6bfkQoCbnTZKU0ZkoZUYZ2EX8PnaVlsLZOlTWJWJSVXUCk5gQG0dxZsnekZ7knY6IHb4D5tPWnqeuK0jR5E9ldLTpRXXGs8dKX5aH/HLbtlwGLt/g8FemjUoeE7WK3dg/aep9j1x/6bpl35oXNnrgECTXADVreO7BZKct3gSYp5592CsC1V8dyqOL46jquK52qZwnqxrCk9Xbcj3VAIB7rBQ4GYMZvL0s2lMHB/ijMlafDUXbFMXyzTFafo5FJ9MYyhSGIoFhuKwVWiLxaD6OQi3Ut7BtGVSnSlo80eYy0ik5343wo2O+9XBdo5zfq1508UaCkm0BLsHo4QwT5SCrB2INAN2ZJt7y/wJ7iuxr211n1qJSvyYIngYBn/QDm3rYzbWsppLeG0lHBby/itpYIDJeLi7aHhs0jBRNcAkmv8mqU9dztGRtBRQgQC8UdAAo1AIP6+2G3Wb08d3/L5h6vJ+LUE4noP73S/kBqmoJopqkoSViWLNEyehs3VcnlVfL6WL9CCK4+n5cAH1Uy2KpGpSmCpEzkgmkS2JpFVw+ICjd61PSIjcA3j0/fDvQgbyNM3EKeEubtEzJvdIEq/sf/gpaaj3x488eKHHrul12r7TwXaijVyvHD0DMFOaNgM/dza/dzeM/TiwY/3r+8WsgJmefuR8IFEtxASLojoyvNZUkmPr2WJahnimjixhipU0gTKeIGKIVCzBBqeoEoiqksT12dKGnLEjTskhvx0I0hBBoipMBPEjF1N4EfwYGGGoTDNUJBqzE815aeaC2SmfKkpX2IskJiKpEYg1nJJo1wE0lQCBRp2gIwK62gL9WQn/rfyrwUa2/U94fHxAm0sdX4YcC/DBFo6JtCNOdLtHy/yI7quxk/xd5+yM2Fjm5x/sFx4YCdwaH5bKb+thN8q5x8oE7bI+a3FQhUnZss89xCiSxDJNfKz925fOofm2SEQiD8GEmgEAvH3ZWRk5Mn3j/L5SSu8cGtIbgEEQuTb75RFUKqSxVXJUm2iRMsQa5KEIOpkgTpJoEoSqBl8VSJPlcBTx/PUdK6KzlUn8FUJfHUiT83gaZm8aja3hsuuTKQmffVRqLtrKGHaBtKULTPxhZs2XtMYrjeeOq8/cfvsRfuLh3brg/9QoK3WXpu1Dwj08+GeIccD8IY2S7cF/GjrGbL2Wp/1dJ8/nhG1zd/LI4BECCLhAgmu8Z8uVicz69iSWkZKTZxMS5Oo6CKYBKEyUaBM4iuYPBWLp2JzNRyOlsetEvJBqkWCGrGwViKCV7EI3DhTA5IirJEIasX8Ogl/vxRcubUS1n4ZR5ctNBekAIf+DwV6vP5Ozu8QaGdReeKvXgl02ZhAwwYVI7RnuM27uSyrKVdG+eKjNUQXX8Jba9z/UUwJBrp8aJfoIEi56ECp6ECJ6JBcckguNhdwddlMDTcmcqHXOpJLMNFl86J5Z79ps1qGJn7nEAgE4neABBqBQPytAYpzos246YtFq8iuq91cA4ik+E++qIhjAoeuTpZUJUm0yRJtklibDExarGaINAyROl6oiRdq6UJNnEBNF6jiheoEkRJcE4UapkDL5lZxmPmb1m+e6xlEmLKOOG092YXz5ecn5btv1R/5tunkedOx/s4Ox9CAHeoy3IGC2bBzl4rz/vfGagMC7axA9w46emy2HrsFvGfPC+wooXWw50Vfx4lqNW3ZEn8yOYhMDMDjQj3JjM8/3x1Dr2FIq+lp2vhUZbxYSRcr44FDi5VOjU7kKxO5qni2KoGtYDArGSwFDAekMpFVmQD+PGArQBJYFQnMfYnJ+xIYlfEMZXyiCiQxQZEYp2TSgUab86FAY53QYuxMIeycntDCMSGTNXeyNE/Iy33jEx937lMc3wY9+vyJ/+jYh4FbY0xlzn8xtbk8qyk/le7zqR95+ir8/60h/19+pP8huejorpTDO2WHy2VHymSHS1IOF8haMgT7xQw1l6JI2h773pz1JFwIyTVs4cxjJp1laHDiFw6BQCB+B0igEQjE35qRkZFHfT1lqcLAuZ6r8C6r8bhgTy/OshWKeGYNS1TNlFQxpcCh1UlAoCUahkTLkGgSJNoESVW8REMXA5lWwYg1CVJNogRWqZNZRVs3URbNDyFMC8FPCSFNi1rwdqMoo732m6v7j13WHb16+PjzH7od1j547A9OcZ6oxf9W4DJCrIsD5OWPcKkKiMXSM/TkXueJw1UZGVsXLQ4keQQTiUEEl1B3t/jFHxeHR2voMk2CTJkgUcZLVIkpwKRVCRKg0ep48EeCQBXHUdM5ini2Ip6joHMVcbzKOF4FjVtB5eyjsCspnEoKax81eQ+VsZfCqIxJVEQnKKPjlbFxlVTqXnpsrZRtKpQZ5CnjvXkskyz2NYee8OMfzuSXT/7nxuwZ2wUDfzQ5R3+UZTUWpCWs/MLfw8UXCDTh/1KDlulTkg/mSr/JTzuUn9qyQ6xPZTfx2HWJSao4WkVcTAUtOm7ROxtIhGAibtP7c0+0GpFAIxCIPwYSaAQC8XfHZrXeuHhesDXM191tBX76agIu2MuDv3KVgp5cw5ZWsVK0TKkmWQIFOhFErEmUahNTqhJTgEmDH9UJIhVdqKKL1ImCfXGMrHUhMYvmh5JdQvBvhRKmhs3yLImKvaY13dh/7ErjsUvGb+5cOmd71muzAs0FAv3vlZz/rQxZe2zPerq/PXehUbcrWRDiNS+I6B5EdA0mTgshuUUveDcneAvQYmWCSJkoBhqtTkxRxEuUCVIVXaJOEKvoAhWdr0zgKOO5SvA0LAoar5LKqYhlV8ayKmOZFbHJ+yjJFTFJiu0MRWS8IopeuZ26LzZ2Dz1GlyU2FUGBnqDOv8ehx2fMeif78b/M5FdNfv8JAg0+GNYDnYYJdHriqiVr3fFrcNP8cNMEPksUVEoNg1XP4u9n8aqTWZpEhiY2URvNqIymV1Bou7dHUd9ZGEYmgf8jb/v4ncsnj9islonfNgQCgfgdIIFGIBB/d0ZGRgafPztibKL6Llnp7rqCMH0V3mX9jBmsL5eVRdK0THE1GxahYQtHokjDkGgY4tFSdKJYlSjQMAQKOndPLCM3bAt76ZJtC2eFeEwPJr0VSpoaNoOcFb759F7tbf3RbxuOXNAdvtT2zePu2/ahXqv9waCtGzr0JPH9L8Y+9PDxdx1X2w6d0Tblb6OHz3onkEgMIrkGEqcEEqZGzZsn8fXfHctQJPDgOUIgzbAULVHGS5XApOOdfR0CVTxm0nFYqDwFhaOgsBUUloLCrIyBUUQnK6KSKiPjK6Li9m6P/Tpmu5bHMBemGeWp2JLCier8BzR6Qia78i9m8gt/KWMCDZ9vKJE4Bbq5PFtfmJW0avlaEsnP1c1/uhv/S5+9EXGq7SxNNE8dzVNFs1XRLHUkWxPFqYhiVMTEl2/ZFjlndggBF0TGxfp8fOfm1eFhx8RvGwKBQPwOkEAjEIg3gJHh4Z+e/GDQVEYu+3i5+9SVxOlriG7B7h6UDz5JCwrbS0uqShZWsYTaJIEmia9m8NVJfHCjYfAVCczdFHpWaBhrydLt7y3cMJMU4j41xGNKMHnqOk833qqVJ/Zqr+sOXzMev6g7ct506NrJY5afH9itPRZ7NybQf2IF2gI7pAeGfuy/dvT4NfPRs5W68ljuhhlv++PdAklTAwj/L5gwZYOXe/IXX2WFbKigJmkZfE2iEPxJoGaIsbI0DCy6x0vUdLEqTqiKE6iofBWVp6RylVSOEmh0DEuxnaWISq6MZFRExO2NpO6Ojt5LpxiypS0lGcaSVEOZDFutMtGbJwv0Lz44/rcTHpmsy5Mz+X0mxzSxGxurQJelN5ft0OdnM5YvW0sk+Lni1k53E3y+vGJrvCaSq40QwkSC8DXbhOpIoSKKXbE9Pjd43SZvrxASLtDdhbvBr7/73gja5o1AIP4QSKARCMSbwfCw48mjhwbNPpr/V77err4kFz8Cfi2RGD53Dv2TT/grVqYGBuasX5e3MbwgfFN+eHjOhvXpQcEi35VJX366fdHCsNmeoZ64UI9poe5TQshTN8/xFKxa3ryj6JbhxFX9ycuG4+eN35xvbevt+NZhAV7bbbXdx8rPf45A27HA+37L4MO7V65caT3RbjpzSdVawZCyffxCvT0CiFODYB162joPQuT8uezPP8/wDyjauGXXdooynqlK5GiSeBrwB0OCuCpBoo0Xa+lCNV2gjuOpaTwVjauMZVdGMyuAOkckVUYw9kXE74mg7I6K3k2JrpNwzEVpzaUZOjmw5xRdqVSHLV6ZbM+/JtCTdXnyI5N1eXImvOQX87pAwwOF4IXm0oyW0lxdbnb80i/8iC6rXaf4u0wTfOlTuS1eEwEEWlQVIa6OFFUBh94mVkWIKyM5FdsT+EuXbfAkB5FdArxcd6cJwJ9kE79kCAQC8ftAAo1AIN4YRkZgHfqosYG7OXC1t9tqgusagos/aXqAu+s6b+KmuZ6RC2fFLppH/WA+5f350e/NjVo4e8s8z42zSetmuIV649Z5uqxzn7qePC1m4dzUgAA1m3+r4cAN47krhjMXDcfONR+8efrYi8d3HNZuu+07m+2+1fbA+q8E2mrv++1YxsV5lPD19A1ZB5703b929PStlgudxks3ao8eLdUWbqNEL3p/LcE1GC73nrqONH2ju1vkLG/awvmMxR9IV63ICQku2QpkOmZvTIKSxlTHMVW0pIoY+u4ISml4ZOG6LQWhW+Qbor7eTN2zOX7v1vjdEdRdkTG7YqK0XEZLQbqxSGYqTW8qTgECDRcWlsAVKuNGcKQYS1KMcinImDHr5ZLx+UWNfmW9k1x5gjT/2uOTM1mgzWWy5jIg0HlN2VnbP/7AlzhlFe7/fF3eEi1bWRmZoInia6PE2kixNkqkjRKoI0TKCGFFBLMgdPP2BfNDPPCBHi7RX71/5oDJOoRm2CEQiD8IEmgEAvEmMTIy8uLpz+ePHkiJ2uTvRVhNmuZL+n/+5ClB7tNCPKdv8HIJ83YNn4ED2Yhdw2fiNni7rgf27IUL83LbPtdLtOTzwvVhFXHJLbk72w2nrpsuXTGeu2A8evHgoUd3rw8PPnBYv7Pb7gGBtv1XBNrxKpPsufeFvecFcOjnD7+7ev1627n2lst3TN926s9fUhkbpLkS/5DwWTOC8VPXEaevJ07fSHYNJ7tu8nCLmuNJfWdOwuJ3kj/7kPPV5yKfpUKfL4U+nwuWfsr78mPWZx8xP/5Q4uOTH7yuPBw4NO3rbdSdwJ5jY1ScRGOutEWeZigGMpqmk6fonBu/sbwS6BKoztCeiyWjN3K4v3BshSG8B4+M0+tfEN9JivzHBBp+GCxQ4rGlKqZSWXNpZos8r0osCVvw9krClJW4t3xdpktXrlVEsbQxEs12GYgqSqzeLlBtFygiOaUbohM+WBzqTlhLmh44061EkPTwwf2RYbSGEIFA/EGQQCMQiDeNkZHBZ0+/aagNe3eeLxEI9Ft+pCmB5KnrPFw2euHCvXCbvd02e4Mb103g3gu30cNt8ywP6qKF4mVLioJDKiOj1dQkFUN4pLyqo/n8VePFy8YzF1oOd108a/mxe9j6wA7V+Tu4QuV1gZ4sx78n/0KgHT3P7A+s1oc/9nXfOHL2Vtul9uYrt/QXOw3nb9UfO1aq3kVJ2L5g/joyKZSA20jGbyThNoP/HE/w34jbMhO/dQ5x61xi5NvkqPnk6AWk6IWkmIUeMQu84t6dI1n2VVFo6K4tUbu2UnZFUXfGxGh4ScYdUnOxDDpxicwglxlKYAtHY4lkdJX3WHV5TJeLRld/O+/H59XjWDV6ovW+tOTJD4796l8K9KidOz8P+GAlEl2JGFyNJSnmkkxTQc7uJFbwzFkr3aavdJ2+2gWf7hemjBFoY1O1Memq6FRltAT8WBGVvCMgLOGDj9e7kwII09Z6TGOsXXr5xDeo/IxAIP4TkEAjEIg3D4fddvPC2YjPPlpJdFlJmLYaPy1m0QLqu/O3z525fbZ31CwvkOg53tS3Zyctelf81VeZfmuL12/aty1Wsz2+OpahpbC1TNlZpe5WyzlgzxfNJ26cOPVT3x2HpdcOVw/et8A4h0CPCvRkM/6d+W2BHnTAJYUWa7/t6cMHV27cPHjuhvniTdPlW4ZLt3TnbjWcuKzU1XJlMr9Q6qKPtsyYtdnDfZM7YZMHbhNw6JngDwO3rXPx2+a6Rb1NiJpPiF5IjFngTlk4k/PZR0Wh6/Zs3b43irprO3UPLa5GxDXskDbDsRtSPdw1CMQUmHSaTi4dE+imYrGuWAyF+JeMeXLGBPo3HPrX8tsCPVbYhmsR5WIQPfR7cVOJCNwAgTYVpzdkphXH0IK8Zqx2c1k5fdrq6fi8kAg1RaylpGpiU9WxKYpYYXFYLP+rFdHz315HcgsiTQsgT4n58j2zeu+zH/+Jjg8iEIj/BCTQCATizWN42HH3xrUYny9XEt1W4HFrCPiC8E27tkXmB4Vmr/bPWuWXvcov1y+gOHjdrg1b9m2JUcUkqmOYmmhWVTSrOpqlpXKruRnXdYeutZy6YD5x6eCJh13t9mcDdqDL9vtD9u5BxwNnhl7OgZ5sxs7Ybb0w1pex9dqwJ1vgb/tBflugX4AM9w5ZeocHHz0f6Lt39tur5jPXmy9c11+4CdJ4pr3h5M3qg+aM8oJwSvqadZzPvkpY9D5l/pzI2Z6bZxLDvfHh3oTNMwnbZpMi5pJp785OXrxIumxZQcj6vRG0yu1Je6MT99DodWK+uSDdLE81wWV+Eh3c1y01FKcYimQ6eUqDXAxTLGoqFumcDu30Y5BC0WRvHm/P4wX613o5fjG/R6BH+61h0wj4YDBNcng1yFN0+bJqiWjH5qggT28/t+m+094KJpD2bqfXJUrr4mWqWGH5Jnq63wbqosUbvNyD4HHMfwSS/rH1/Zm1JTu+73sw7EDT6xAIxH8EEmgEAvHmMTI83PfdXbr/qpUk/EoCfg2eWLI1qpElrqayNdsZmshEVUSCOipBG51YHZNYFZOkjWWrYznqGLY2hg00WknjVguzuw6evdx67Pw3R+5e/9byc7/D0m+Dm1OAQEOHHrKP2rPVirVw2HtfqTCcoTFqz8PP7lkfXH5+4/jzq0de3Dhu6f3W9vyuFT5twGIbsNkGftuhB2H6hoB5D/U7nj962nv/9vFzV1tOXzecu2W4fLvh0s39Zzvqz1xVHtQysiqiBTvDafL1EfnB67PXBqevWZu22l/muyZttV+GX0DW2qCC4DD5+q3lm2K+jojbHZm4Jzp5Hz25Rsxtzk9rkaebSqCnGsqwCrQca24uBpIKe6AboZtiJV6nqhaJ9IUiI0iBENyAHyfH2QwN+6FfVYv/iECby1P/hUBjn6qpSAgC/2ng9IUp+zPEah4/NWRjkLuXn9u01a5vBRJxopUrUlb5i77yZS5eRnv3o82z5wSR8UGEaUGEf4R6TN3+yXzljpT+7+447PaJ3ycEAoH4N0ECjUAg3jxGRkZ+GOjnbApd4e62koj3dSPI1gQ3sWR1ccLaWEFNNK8qmgtdOYaljWaCaGLZKgpHFctSxzKVFOY+Okcryf7u5KVrx0991/7tsx+7gb/arb02W7fF9p3F/h2m0UCgoTrbMIGG9+MkGCiyzd7nGOwevHXq6YH9L4yaF42KZwbVD4fqHl/9xv78vs0O1PmRxT4w3p4nC7TToeEbwjJ2v2Pw4T+777afOHfNfOam4eLtpis3Gy7crD3TUXe2RaZQxqapY8SaGL4qlq2MYSlj2IoYdiWFqaCwwH+dmsJVx3CV0ey9Ucl7opN2RifsoTPrZGJTgay5JNUklxlKZUYg0HDaBuwnhg6N9XJg3oypc4kEaHSTXNRUDFRVqCsEEcCbX4q+WDSaP6cC7XxbHfbBGouF4CM1FgmgPRdImnIk1WKBksXlrwoIIgOBdvHDT13t9laIJ36dJzGURAzG4wPxbmsJLv7EaYGEKeu93Zh+S/bvLOy912VH9oxAIP4bIIFGIBBvICMjPz15nBYfs8IDt4KEW+nmFr/4ywZmSh1dXEsRV8cIqmP4VbHAoWE0MVxVLFwsoqCylNQkRVzSXkZybXbOT51djx/cG3zaa7cM2K19Nku37VUDtLMC/QsC7byxDvcDgbb8s/PxwcbB2kp77V579W5r7e5/7t/bb9QM3b8ybO23DD98Ntw/NPyr6jwq0I4ekCHHA6u9x27rt7949GNP990zV260nrumP3et8dz1urO3as6ckRvVtB3qWJkmVqKNFWhjhZpYEYiaKnRGQxGqYwTgv3RfDHMPlVHBYNZKxOaiTHNpqgkoaWmKvlymc059BqKM9TobS+ERPdiPIZc2FcEidCPs5RA2yIXwClIkaCr8hbzm0L9vsN3k/E6BbpSLGuVC4NCNhQJ9gUifK6mV8dRctiKZnfDZ0kCypx8eCPS0NfgpawhvrXF7y99tylr8tECiS5AnbsN8T+qSD8t4jFMt+h/6e1HnBgKB+G+BBBqBQLyRPPv5p12ZKT4erstJrivwuM1z36lKENTGi2tpkmqKqCpWUEXha2J5mliBJlaoovIVcVwFnVlJT6hIoFdwk0xfFw3/1Gd/8dBhfYjZc4/N+sBmu2+xQXu22GD/xpCtz2Lrm1yBdsYp0A9baodqKxzVe0eq9gxrv35Rs/dhg2Ko68KIpXfI0fd0pG/o12vPWIA9P3gx3A0y5Oi2OIBDP7QPfv/sUX/vjdtXD52+bDh5tf7U1doTF/cdrGYWKimpamqKliLSUsTaWBCJhipRg1BEqliBMpZXQWHuoyWpmMyGNElzQXpLaQasOoOUy/RlcOoznFUHrnAUnbghl1clTVDzqfvY0ZUCSm0ms6kQSrPTnutBiqC2Nhbwx2e8Q8NgLj6hDv3vFqTHZ6x/A2vIdtqzoBGqvFCfL2rMEqj5yQpm8r54xvb3PlpLJK92m76GMM2PPM3Pfao/eUqgl8vG+d7xyz/Lomyrlu842azvvddlGXwxMoKG1iEQiP8aSKARCMQbydDgC1O1cpmnqw/JZQXRLcR7VnlEXE2CpCZOUk0TaalCLZWvpmJr+eL4lXHcfXRWZSIwy8QqIaM2i/dNden/N9QDx25Y+2DzBrTnB7D8DLs4nMM3+oZs/b8m0LCFw9Fvf3H/6fWjTwyqZ3V7LdqvbdV7fqzf9+ib/fYfbjpsvc8dD54PY+VqeKZw4gBpZ15WoB+8cNwfdNwfGu4GT7bZBhzWJ5an3w/c6Ww/eeGK6dS3umMXtAfqZeUV8SmqeIkmTqilCTU0kYYmVtOE6jiRMk6gpPEU8WwFg6XlcZsyJc1F6S0lqebyVGN5irEMSwmcoGwsltTncCu4MQUx61LXrZT4fSn0WcxZ8j53+UfitV8qebHGAqGxSKSHjc6jXRxOY54g0K8c+uXsjj8q0HA3yvjAyRslsPX5pUDzG4t5TUV8PfgwO4TVEraClVjJYJRGxWyd/64fgbjKbXrYwtml/GR1Xro6L6OuNM+k3HOqxdB17fI/v39os1rQwA0EAvFfBwk0AoF4I7HZrBeOH169wMvH3WUF2c3fwzMtMKwqUVQVL66iCzVxfHUcV0XnKOOZykRmZTJTyWZWi9iNaTxdDq+xUPBNnXzEcs9u67bZerA8sMIThGP23DtZoMeCCTRs4XBYe4d/6njefvzHE03PDtQ8P1T34xnTi+/OOyzd4GnPh3teOHp+TZ3HOzSsdtsfYBVocO2xDfdbbQ/tth+sL75/OtD7fcedB9/euHvq4oWmluqULA1PUsXiVyXzNYk8dSJPlchRJ/M0TH4VV1ArEdWnifW5smZ4ZDDFVCYFMQArLZGYS6WtJSn1maxS2sa0dSvZSz+M/3g+9d3ZtPne8fO9qHM9Yud7Rr5Nzlq/6kChuK1IYi4Sm4pEmElDS57cxTFBoMc0erJD/yuT/g2Bdk7eEDQV88HHMOSL96dyVRxGZVKigpGYvT5s45x5vgTCCqIrZ0NA++ULP/3w/U+Pf3j645PBZ0+tFgvak4JAIP48kEAjEIg3kuHh4bvtN6lBK5Z5AIHGrSaTkpcsB0KpZQg1iXxNEl+dxFEls7TcpBoxa38aryFLYMgVmgqEhkJeQzH3YH2hw3rX7ui223usWDB1duaVQFt/SaChQ7+cwuGwPnA877I8umJ5cNbac8H6+Mbwi+8cdvBaOF5jcJIuT0qfxQo1Hd6Dz+CAgUM87H3YEI9HDssj+4tHlp8Gnv/Q83P/d2caqupz0hozpE2pknqpaL9UXC8TNqSJmzKlupwUQ77MWJwKN6SUykzlKYYyCXRoubRZLm3MZpdSNkgCvkr8dD71vVnU+TPi5s+gvz0jYf6MxHdnJrw3K2nxfMHyxfsStn5TktomT2mWS8xyidE5Qu6lQ78y6fEHCsfZ8y8K9CRjHs3L374ebPAzsGc9NnlDB3ushYZikalQ0pQp1PKZymRGRUICiHCNX5C39wqim487Lp+X+PhhP6o0IxCIvwwk0AgE4s1kZOTxo4F8QdJyb9xykusqEiFq0QdVLF6DKKWWL6oVCGrFgvpUgS6HZ8jnGQqBhIlNxUIjrGVyG+Tctv1FDvt9m73HNlGgx1YPwgboXxdoOOzZDn4LBz/D3o8h2x2L7Y7N3u2w9Q5b++0WEPBa8A6Tpfk1gbZa+62jDu1cvDJ+Xl4/NlW61+oYAJ5ttw7cv3asqSzDVCQz5wNdlhoKUowFEmOh1FiUYiiWwt3aZSmNxSJDeYq+RAwcurlEos/mlceFiwO/oi2eu32hZ/Q8d+oCr7iFQKC92R/Ol638PC9sza7YMA2XUi9LapWnHNyV3lwuM8GuD3jc0Omy2Gw7qLMvpfnlYOYimAm1539VYB4LFG4j3Cz4WqBAY8cTddg5RfD/ODP4r9shqRGxVclJioSkfXGJu6hxcV987ksm+JBwy2eSVCW5z376ceI3BIFAIP40kEAjEIg3laEXzw2aSv+3PZeTXVeS3EJnzdyXGN+6I9uck2HKTTXly0yFUijNcoGhRKgvERlgLZOnL+Y1lgpba4qGrQ+sUE+xui9sougZZ8+jsY6bwjHRobGdKRb4274hR8/gMNbEbH8Axdo64LD0jwz1DQ+9HCP9W4Hq7Kxqj2+zdv4rVtghff+F48HQMJDsnsc9l00VO+AI5yKxES4LlBiLRIYiuJ8PzkuGy66hlZrLZGZgtPnCPcnb0tetoH88L2Khx5Y5hMi3ybHveLM+fzczcFnJliBVQkS1IA78jWEukhzanXVwT3br1xnNu9NMu1INu2T6nSm6MthN4Wyo+MVM7tyYVGmeLNCvvZtz0eCEjM3IA/ZsLJLqcsS1Yg6wZ2V8koKWvI+aKI+K3rjg7eVE12VkV793Zp48YLZa0GpuBALx14EEGoFAvKk47Pb2by9FLftkhbvrKpLrWk9SamhAa37WgeLM1pK05lKpqVQE1FknFzbJhY1yEbjRFwtAmkrFzdoi2/PvbLDo24sVfV8zYyzQp622nt8QaCDHQ1ZMfOHUju+w4Xc98Le2fht2NtFu7fntCvQQdohw9Ao+w/DLOEYPF8K1iMPdz4Z7no/0D9p7Xzy5faimFDgrXBNYJNEBjS6SgHu9cyMgHF4hNZfKWuQpdWlJWZvWxH+2IGq+x7bZxG1zSVvnEOMWz80NX6PhxDSmM035ogNlaW3laa27Mpp3pbXuyTR/nW7enW76OhUItGmnDJ4+HGe9v5YJbRu/JtDjnu8079Ea9qt50k5jHqfRsBpdJG7KEVaJWGpWUiU9UUljKqmsClpSRuiGtV4ePqTpS0jTw79a/F3nbdTxjEAg/kqQQCMQiDeYH3/4vojPXOWJW+2O83fH0z79sDFV1JKf1lqSai4TG0r4QKCbikX1xaIGOdzH4ezibSyRGFUFL/7ZabO93LZtfzVm7qXdwo4OINDOEvJke7Y4i9NWWKW2wmJ2t83+YAiaNBBo57v1WOwPJkvz6wINLXl0bTh06J6hYRjncGinQIMHXwz3PR8eGHL0W59+d0xXoZOnGItT9IUSHVymnaIvkuqKQVIM8hSzXNZaLKuVJAj9voh8x3PzLPzWmYSts4lR8z1T1i7Zl7jNkMM7WJ52YHdGy+70ZpCv01u+zmjemQaupp1pzV+nmXemNoOUyZpLU0DMZaMS7NTfSUIMjfm3BfrX1HmSQGMNG5g3w8glJrm0KVdYLWapWAwlI0kZl6SEk7yBQCcnLfHx9SD6kKcvIU8TU7Y+efRw4jcDgUAg/kyQQCMQiDcYm2XoqKEhYL7nag8XfzJu87w5X1MojSlic25qc7HMJBeBNBUJ64sF9SWCBjhOGA5iaygSGypzn/RdgxOgMYcesvePnfnDhBjcYE0dvzlDY1x1GdaqrVjRetSMncGWgf92sKL1y39rrBz+Mlh7CSxyD2Ef0jrUc+ZATWNxKjwsWJgCvBnYc1OxpFEuaSyWmuD5vzQthyZe/UXEPPdNM/Gb5xA3zsLTP1tQEBHcmMk5UJratiu9ZRcQ5XToyl+nNe9Ka9mVDgT6tZSnwpTJzGUy06QejEmZaMym8QFKLYfrWmCKJfpxIztgisR6ZwsK+NumWAD/J4ISEbBn8CpTsUyfJ62WcFTMZGVispLOVMYlV1KT9lEYO6Np2957b5U7wYfs4jPDtWpn4YtnP0/8ZiAQCMSfCRJoBALxBmMZGjwyTqBDPTzFK/1VSexaoaAxXWTMk5oLpYYiuF2vrphfX8hrLOA15fPrC0S6PTkP2k8N2/pfCnTfoL3XKdA2OBbaqbbjC9J/Vca1QcNOaMfYacW+Iex6+YS+QZ5mLE4zFsn0xVIdrENLm+QwZrmsShTPXbY4ap7H1pnEzTMJW952T/L5oJIdbSoQH/o6sxWqc5p5F2zSaN6Z2gKLza+r8840czmcHg3yckfgqzaMX8lvCbS5BI4BAeqMdTa/PB348gCiDthzodAADwvCWXU6uQC2qsOXyPS5KTVSnoKZpEhkKuhMRVyygppcQUncS03ICN0QOmf2Snf8MrJL4PuzTh1qtlosE78ZCAQC8WeCBBqBQLypOOz2jqvfSqK3+nrjfckufiRcAJEc+fai0giqIpGl5nBqJfymDLE+T9pUmFJfKG7IFzTlCXR5goY8YUNpWvv5lhFLr9UG+zcGHVCggS5bMXt2CrTzkYmC+2dnokDDK9ar3TeEzc67fr61Xp5mKMIq0EUSfRH4C0FmKJYBn66SMtgrPtk6h7R1NmnzLMLmOURp8DKNiH6wNO1AeXrbrnRzuQyos3GnzLRTBu6by2Vjujwh45Zsp/wrh/4tgYa1ZFh+fnU0cHQoHgiUZoG+CISvK+JDgYYd6mJgz8YCWa2Uj9mzs/bMUtCYCkpyBTVpT2x80ldL/Tw9VpDdlrnj2FtCvuu8PTyMdnQjEIi/FCTQCATijWR4ePhRX0+ZTBAwb8YqkstqkssaIs6fQAwieQtXBlbEsSoTOEoGR8PmVEuEdemS/VnihmyxPkesyxY17RDvzxdfaqu2P/3OAruQe18MA4f+BYEe/HsItBVT5yF409tx5TAm0FgFuijFWJRqLEozF6bps8UCvyWb5pCBQG+ZTdy20EMWvKwhnQXU+eCuzNadsLnZtBPWnoFAG39doMep8yuB/k2H/lWBdrYyG0fLz6ONzroige6lMTcV8XQghZymQq4OThgUGcHfA3kp+2VCNYsFa89xTCWNpaKxFVRmJZUJNFq+dXv42wtWEvHLSK6rZ3uoS/N//vEJmgCNQCD+YpBAIxCIN5KhwRdt+zWbP164huy2huTqR3ZdTXBZQ8D7Edwj5n9QFkGvoHEVdJ4inqNI5qo4fI2QXysRNMiEjanChjRhXZbwG1XJ84GbVrgCsGdw2DkNAx4ZBPYMx2v8zQTaeQ8E+t7NE/uL0/UFaabCNEMhuGaaCzNMO2TFkRu3zPXcNAMPK9DzSGnrVjRlcQ6Up7XtymjZmd68Kx3YsxFr3vjtCvQkgX5l0pNc+Rczzp5LRmvPLwUatmpg9gy9uamI2wTVGYQNfgS/NRRK9DskdSkC8GePisFW0jkKKltBYSuprEoKs4KSXBnHFK0O8Hf3WI7HLSW7bPr8g4snj9ps1olfDgQCgfiTQQKNQCDePIYdju/ab4oj1gV4u60l40JnkOmff7R+tpcvAbeGQAxynyFdHbo3hqWkCRRxfAWdX5nAUybztGxeDY+3H5i0iFcj4+kL0nu+PeqwYIf/YPkZHtd71QD9PxJo2DTyukBj3uy8h/vDu9tP7wfqnJdhzMsw5GeYC7Jb8rOq+cn0xe9t9iZsmUHYPJvA9/20IYN1YGdG6670lq+hOpt3phl3jtaeX6tAT7Tkf5FJujwxcBDHuJUor3duwG4N2LNRyNMXcnWFHH0RV1fE0RVy9YUCI5xYJ6qV8rQcjprBUcdzVVSOisJVUjkKChTofZTk8u20iHc/WEkkLiO4Lvdyy2LSv+/vGxlBA+wQCMRfDRJoBALxhjEyMvL86U8Ne0vD3p0R7IkL8XCjLX5vDz2Ws3LZaiLOF4/zI5K2v/Nh6VaaMk6goAkraQJlvFCZwFcz+FVMXjWHX8XlVot4dWmSM3WKocddDlu/HWsyttnh7u6x1Sf/k0OEvy3QdvvA/Vun6vMzDDmZppwsY26WKTezZUdGRrD/llnuW2cAgcYnfL6wWkg/uDPdWXg270oz7XLaMxRoQ3kKHPBcDrsyzLA3Y6Ii/3YmG/OEJ4wJ9OuFZ6c9A3UG4RsKBQZ45RqASRfwjAUCQ75QnyOqk/I0bLY6ia1O4KppXDWFo4rlKCnsSgprX2zSPmqyLBD8yTTDh+i2lOwS/OG8b4yNlqHBid8PBAKB+PNBAo1AIN4whh2O7s7bwk2BQV4uoZ6uW+Z55oaFNElEZdHbw+bO9iW4rsG7Bbt7CZb7VcZxlHSRMk6oogvV8QJtokjLEGiZwiqOoJovrJVIDYW53ReO2P753Yj1od3Wb3MMQFWdJLV/ZX5NoOEHswPRf9h58UhDXrYhK8eclWvM3mHKyVAmx0cvnLPZm7DZ223bPNJexraDJamtO9NadmWYdqaP2nM5UGdoz1CgX7Y1Y5moyL+Wyer8i4OfsQdfa3rG2jZg5wa05wKBLp+vL3iZfL4xX2TMFTdlCOvEXC0Hs+dEjprOUVOBPbNVsazK2ORKKhPY886Y+NjFn60kk5YQXZZ4uvCjwx/c7RpG+1MQCMT/AiTQCATiDcMyNHjUUB++aGawh+sGL7fEz96v5bGaJFItk5u8ZJkvztWP4OZPJG55e2HexghVgkCdINLEi7TxoqoEINBibbK4miOt4kjqBLKG1IzzNeqHV85Y/9ntsD6y2gYsjn64WRDT6JejnSc67p+ayQJtwaZwYOP2BhyWR1ePtjTl5pqz8pszCk0Z+Q0pIoHvsjBPYM/4zTPdMkJ8WoskbWWpLXAmXXrzrgzzzjQT1tlshHnNnmEpepIo/4YxTxLlX8wre3a2bTiPDMK2DSjNUKCb8vi6PIE+X6DPExpyJE1pwjohT8tma5LZGgZXHc9RxbFVVJaKwlTGMivh8A1mRRwzfV144IxZS4luX5Cm+S+aaahWPH/6Mzo+iEAg/icggUYgEG8UIyM/Pf6hgEMP8saFuuM2zyLnbgzWp0j38yU1bHH+xogQT28/An4NAR9Ado/79Ms9lOQqIM0JohqGRBsv1DKkmiRJFSuliiWr46btF6YfkpfcNhv6rp4f+qnHZns0ZB91aCscCA03EU523D81vybQsEAO/P5Z32lTgz63qCWzuDW9tDmzWB61ddNcrzAv/KYZbomfztelJbcBOS6VNu9KM5djDg1XoqSaS2Uwo20bo8Gq0RO9+TfseazePEmaXwWuGxy3X3CcQEN7dgo0tOdcoS5X0JDFr5fya3ncahZHk8TRJHA08Tw1nauisZXUZAWVoaAkjZWfYxZ/toJE/Iro+oX7dHbk+vtd7aj8jEAg/lcggUYgEG8Sw8OO++03432/CPbErfckUt9foGLENYgENWxhNUu8j5ac/KWPP5HkR8SDhM6YKVodqEkSaBmimmSpJlGsTUrRgDBlINXs1BpuqiF9x5Wa+hutrb3XLw/+2Ge1fm+1DViBRsPu5wdWO9xjYrX1DVmdJu3cNQiDbRmED8LNhWPBJng4S9fOxYSvFg2Oe+3rgTvDx94Ta7zGSuCjAt07NAw+A5D7Pof14dOH976p0rbk72zLLG/L2NmcXkT/aNF6T1yYF27jTNev48IPQlFOMZbL4MHBstSWsjTnSUHnau7R+RhYDGVSfZkUK0hPtOfxAm3AnglTKtWXwKvzBt6PGrPkZV5u6oaFZ2DPzh5oIRzz/LL8DHud84RwmGCWcH8qr1rMruaytEy21mnPdK6GzlPHcVVw+EaSipZUSUmspCXtoSaK/YPXes9YSnT7kuwS+OE8U6168PmziV8OBAKB+KtAAo1AIN4kbJahMy2GqPffXu9B2DjTU7Jm+X4es5bLqmbztCy+IpFdsCUy6t1FfkQ3fxLOn+S2ed78zJAwFYNbzZJWMYE9yzTJqRoWFGgNK0XLltUKMs/uq7mha7vVdvj+xcs/PrhnffYIK0X3YYPt4KYVm73fac9D1gdD9m4sDwYdD359Uzd0Yit2Bc8ci8XudOVXscJ0jz0TvCfc3gJ3u/Q7M2jvGRx+YHE8sNv7HC/6+65e/maP+mDuvoOZu9uyyivjuRvd8eEeLhu8pycve7+lUNIC3LccC7aIG3rzTllzeYq5VIoFOrRToPW/ItATqs7Y0yT6cgm40ZVKXqXkpTeP7Rd0rkcpgisGnVsGdfBxgaEIztxwNmzod4j0WeKmNFG9mF/D42jZLA2TrUliaxLZmni2Jo6jpnHUVLaSwlJRmYrYRAWVUUFLzN24efM77y0nEr4iuvrMImVzE3rv30PlZwQC8T8ECTQCgXhjGBkZefHzzw3lxZtne2wg4bfNm120JayBz6phJ1exWCoGszKBuZuWkBYUumne3AAyfi3JLYBM3Dp/YWboxmqOpIolrWanVbHStGyQVGDPIFXs9LYduzsaD93Wf3PN9M3tIyd6blx59rgbOLQVKiwsBmMH+HqGbN1DtvtD9vsWWzfmu9Ceh7AN268C9wXCiXjYULzJxeYeq/W12EbTC+6dr3LOznOeHXQGOLTF0eOwDTwbuHtZ33x0Z/XRPNXhrL0HMkrEqwI3euDDvFy2zCfvSYo4UJ4Ga8bYeUFYhAZCXJ5qwqY+Q2kug+VkWHt+ecVuJgr0BIc2jBWhgUzDwrNkNHKprtgZsa4IZNSbGwuhQ2N1aHh2EM7cKOAZCuBhQcMOUVOGcL+UX8PnVrHYWtjxDKNOZKsTsIODNDawZxWFpYwF9pwEQ2WUR8VQF3/iSyItI7h9RcZt91t28eQRq2Vo4pcDgUAg/kKQQCMQiDeHkZGffvh+j4S7wcNtI4mwff68fdTtDTx2LRRopjoJCDRjDy2+PJoiWu23cc5sYM9rifgAEjHynfeKt0VXsyW13LRqTloVFGgYcFPFTG0U5l1VGbp0R27qvrlmOHil9WDX+TP/fNBle/7QbntowYTYYn+ACXQ3Zs9jhWeoy07lde79Ho2tz4Jlol7bYDfIa7H2OSz9dsuAzdoPX4KtGxwa7h0a7hnEMuTot1gf2mwDz5/c7zp3+qSq4WTZ/lMFVcezK8zC7Pj3P97ojQ+bhaN/tqAlX9xWItMVCOvzeA15/KYCgbFYYi5L1Zel6MtT9LDknKID9zBQiJ0bT5yW/GsCDZueS2SvIk/RF0vHoiuSgDSBFIKrGKZQ1FQIN3XrgT0XwoODhkIhVOdckT5L2CDjVQs5Wg5Lw2SpGSzgzZpEjhb2PXM0wJ6x8rOKAsvPilhmRQyjkpq0N4bOW7EqwN3Dx811KQnnv3B29dclT3/8J/gqTPxuIBAIxF8IEmgEAvHGMDIy/PDB/RzK1o0euHASPnbhvJrkBBWduitq267tkXuplMqE+L1xcbuptJLIaI7PinVe3oFkINBuQe7kmPc/lEdQ6nipwKFrgENz0kGq2enVzNQ6dubhvL1d+w92NR29rTt8XX/wqvnArSPHBm7eeP6kx2pxzofGWpxhRwcM7JB+mTFvtsCGaedzoBmDWKxQmgftrzLBp4E0A3W2WQesNqxnw1l1Bt4M88Di6LHbHtmfP3r+/YOOc6cvGtpOVxrO7TScK6w7lb1vfyI/5u0F4UCgZ7imBixtFDNKo9enBPuwfT9mr/pYGupTTNlQLWMY5FIT0OhSoNEyXfmoQ08Q6PEOPabOzv5mgzzFKAfqLDMUp4Doi6T6IokeU2ddISbNTocuEoMfdYUiXQGIAHgzTAFfnytsyhTWy3g1QraGw1QmJ6sYyWpYdeaoE7iaBJ6GztXGcTU0jobKgYOfKRwFHF3H3EdhgGQGbwibPWelG26p2/TlXgQxZdv9zvZhh2PiNwOBQCD+WpBAIxCINwaHw3H35jWW39Iwkms4yY2yYG5RWCjni0/j3n837qP3Ej/7SLTap2Bz2K6Y6D1UWtGWbQmffhriSQxyxwONDiSTqR99WhpFwxw6vYaTXsPOqGVn1LDSa1npTYLcC1/X3Ws82tV4tL3pyE3D4WuGwzcPHL936eIPD9ptzwYcQ48cVpABuxWuA7Q6eoccPSBWbL221d4Dz/nZe+zO2Prs1j47MG8LHIc3NC7w0KHzoCEW+NsxBX85c8PiwCzc0Wu39dp/Hnjc0X7n9JlL+rbL+w9crGy9uKv5grzx5I6KPRGUiJkzNnvhw9yn8778ULzs09gFM7bMIK13nw6yeRYh5r1ZnJWfFFPCDHmilrL05rJ0Q6kMq0ADgX6t0XnMocerM4gO9jdLoTq/rD3riuGDo4H27OzcgC0c+kKxoVBiKJTq88WGPLE+V9SQwauVcqr5HKDOquRkJSNZmchUJbBV8XDRoIbOV8fxNTQeiJbK1WD2DNemxDIrqMy9lMSCTRFR773vi3db7uayhDAtcvlnJ9vMlkG0OQWBQPzvQQKNQCDeGBx22/WzJyM/mBtGdNlIdNvs7R69cG6YJymEjAt2xwV7uK6fSYxeNI/j82XO+pCvY6ILN4VHvft2IBmH1aHxIR6elA8/Ltoas1+Qvp+fUcfNqONl1nIzqplpNawMk0x+U918r/H4Hd2Jdt2x26aTN0zHr7cdaz9xqvfa1X9+d2foSb/jxQ/D1u+H7Q+tsNeixzLsFGinQ4M8sIE4wLXXOXjODoc399owt7bZYOx2TIttPQ5rj8MGO0NejHS/GO4eHO4eGoY1bBvcljIATH3Y8uj5w7sDV690Hjp5XX/weuM3N2oOX1MdvrS77eJOw6lChXjlmvAZHuEebusIU7fNIG/xIm0i4ze5E8PJ+HAP/EZPtzBPXPgMoNGz00JWKViU+nSOoUBiKgGWDGMoA8FanMctQxmz51eWDO7l0ia5pKlYDNJYLAJpko8GOyYIzwvqi6A9GwukxjxZU7Zkfyq/RszV8lhqFkudDNvTx9RZBQfV8TRAneMEWPhqKk9D5aliR8vPCiqrgsYsiYyhffLZaiJxmds0H8J0//lempL8n548Rs0bCATi7wASaAQC8cZgtQydbjWsn0PeQHDZQHANJeFCyPh1HsT1XqR1XsRQL7cgD1e4XWUGKfq9+cKVy4o2haWs9Q2f4x1AwgW5EwKI+CB399gPFhdtja7lpuznQ42u5WXUsGE1uo6bczi3oqvu8D3dyS79qXbjqdvm07eaT91sPnGr7WTXsbPdl6487Lj908B9y9N+mxU4dD+wZ5vjIYjV8XC0cgzbl3uHHL0WR//Q8ADsYHbAcjUMJtk2+JI+YNh2e58d/Gq4Z3Cke9DRPeR4AN/N1u8YHHC8eDT4qPvJndv3z51rbz16W3f0duORjvqj7bXHbmqPf1t56Pxu46G8PVvnL1zvTQ4huwQRpoW648O8yLRF7+SEBOZvCJH4+kQtnBM2kxTmRdjo7rZtlgfjk0WiNV+lrV9dwaYYCyTm0jRjeZq+FNuuMs6ex2bSOe0ZVpfl4ka5uKFYBNI46s3QpJ3Ry8XGYqDOYkOBSLdD1JQp2i8TVgm4KhZTkcxSMljKRLYqgaWMZ4Oo6BwVnaei89V0gXrUngVqGl9D46uAQFO4SiqnksKqpCXvpSXyVq32d3df5jrtK7e3Vs0iZCVTUfMGAoH4+4AEGoFAvDEMvXhhUu8L8savJ7iuw7sAawyfPSPpi89Fq1dxly+lf/Lhprkz1s0AMk1Y703cPNsz8ZP3s0IDxKtXbJjpEeSOX0vEBZDwQWRy9KIPirdFNwjTgEMDga7lZNRxMmvYmfW83DNltfd0J+4aT3eYTrebT3c0n+0wg5y53XzqVtup20dOd5290H396sDd20/67zz7scfy4pHN+thuf2JzPIImPfwQeLMFXh8NOh4NDj96MTIwONw/FqDUMMP9luEBq2PA5oANITb7gN06YHna++Jx90/ddx7evtl97sKdo6faW4+1G491NB3vbDx2p+FYV92x29XHr2mOXKgwKVmyQC/vYC9iANnVn+SyfraXJNBPzWMdkhceLZe35GVVsOJTQv2i3p0X7kna4kXeBK4zyFtmeyR+8X4FM7a1JN1clmYoe7mkEBPo0Z6NceVnOFUDqrOwoUjYCGQaPigxFEuxTugUfaFUXyAx5El02cL6dF6NhKPhs5TMZEVicmUCU5HAUdC5MHFsRRxHCdeqc4E9O+N0aCx84NBKKlcVx6+ksCtprH00Rua6sA1z5/q4uSzBTVnqMZUXEXr1/CmrxTLxC4FAIBD/I5BAIxCIN4bnz55q5LlrPXGhBJgt82Zlb9igYXJrBWItm7ebFpceHEz5cNGmOd5hM0hh3oRNM0mJn3yYF7ZesNJnnTc5kIxbS3QNILoFkoixHy4uiYzF6tCZ9dzMek5WPTerlpmplxRfU5nvGk52ms+0N5/ubD53x3y+y3Su03yuo+XcrZYzN1pP3zhw6uaR052nz9+79O39q9f6Om4/7r7z9FH30E+91hcD1qGHNssPVstjEIvlhyHroyHrQxCLBYv1odV5P9Q/9KLP8nPv0PfdP/bc/aHrdt/1K92XLt09cbbj0KnOthNdLSe7TKc6DKfa9Sc7m47fbTzaVX+0ve7YjZoj32paUtdHBXh4BboT1pJcAz0IOZs3NmTIju7ZdXTv7mMVe05W7j2t3N1SnLM3IZa79IuI2TO2ents8iCGuxM2ehGYSz8Gyttalm4uTzeVvRJoQwk2k26cPY9OpsMmbOgKJYaiFEORzFAg0+el6HKkjVmi/amCWgm/is9Ws5MVyUmVjKTKeIaCnlwZD6QZ2DC4cpV0nhJc43jOjDn0mEkr4/gKGvxVBZVdQWfu2Lh527vvrsC7LHObuow0lRaw7ESbYWjwOdrajUAg/j4ggUYgEG8Mz5/+XJGb4e+BC8K7rnMnCXxXGDOyWnOKzJmFxox8nSy7TiDdGUsRrVq5bd6sMG/iRm/C5lneyZ9/VrRpo2DVsvUzoEMHkt1gKZpMinz3vYzgjVqGpJGX3cDJbAQOzQYanXMod9/1mrau5tPtzac6m8/caT57p/l8F0jLpY6Wi+3NMLebz99qOXur9eytttO3D57qPHLq3qlzPRcv9V379uGta9933vq+q/37ux1P7nY+vnv78Z1br6Xr5vcdNwZuXem9fqn30uXes5fvnrjQdeQM8Ob2tpMdzSc7m0/faT59z3zmrvFMu/H0bSPQ6BN3mo50Nh7uaDh6u+HoZU1z8vLgIPcZQSRiAB7H+OwTc1bGQXlRa4m8BaS0pK2s5OjushN7yo7vLNalivM3bWB+/skWb49wd2I40OhZ5B2bg5oLU8ylaUCgJ7RwYOr8KsCbdYUpunypLlfSmC1uyBTXyQTVYm6VgKPhMmG9mcGqTGBWxgNpBlemgs6sjEuupDGVNKaCCq6cMXWeLNDKeBgFnV9J4wLV3kdj7gjbErXog1UE3DLcFB/i1OgVn7Y1VD39+UfU+oxAIP5WIIFGIBBvDM9//lmRn+VLdvXH40LcySXbtx/IK27OKjalF5nSC42p+aa0PKMsW5PEzgwOiVzw9novUpgXadNMD77P0j2UWK6Pz/oZXoFkvD8J50d0WYOfHjZ7Dnvpmp1RiQ289EZOJtBoINCN4qJDxerr9Yc7ms90tZ7rajlz98CFzpbzXa3fdjZf7mwG12+7mi91mi90ms/DBg/T6XbTidumY7ebj7W3Hes4eKLr8Kmuw6e7jp65e/Ts3SOn7h45OZY7R07dOXyy65sTnQePt7cd6Wg5DnS5swXkDLyaYbpATKfvms7cMZ3uMJ5qN57sNJ3o1B/r0B1rbwI5fkllpH/pG+juFUgiBODdSrZtPZibeyC/oCWvoKWg0JxX0JxX0Jaff6Ag/4i8+Hh5WXNuloqTnBK4duu8eWEenmGepJhFc5Vsmrkow1yaAQ8UOo8VlmCjNuCIOqmuUNpUIGnMB9IsbciQ1slENWJ+lYCr5XJUTJaSkVSZkFRJT6yIS6qksSppnMo4NgyNraCxK6ksTKBZMHFsBd3Zy4HZcxzfGSUMz2nP4FeVcdzKOE5myMbt732wmoDzwf1jBWnKls/eaazY+ePjH1DtGYFA/N1AAo1AIN4YBp8/q99dBgR6DR4X5O5euC3iwI7i1kx5S0axOa3QnF5oSiswpuYZZDl1fEnOxk2b585d7+m2wQO3Zc7MzKB1X8fE8Vf4bn77bX8izp/kssbtLV/c1DVEcsS7HwJ1U8Vzm/iZDbzsekFeg1T+jbz6VtOJu63n77Sdv3PgQlfbxc7Wyx0t33Y0g+ulzpaLnc3nO81n201nOozAoc90mE7BmE91wrr1aUyLnfcgsK7sjPPH0ZhBTnUBTcfitOexQI2GJn2yCwr0yQ7jyXbDqXbdyQ79yStac8JXvmvd3dcS3QJIhH10eltOTltObtuO/NacgpbsfJDW7NyW7NzWnLzmHfnNhfmmorz9GZnpG7dumDF3PZkc5kXgrvjctCOjRZ5jLMkwyNMMxam6wpSmfGlTrrgxR1yfKapJ5VdLeVVCgZYnULM5qmS2MgkeClTCQ4EsRRxTQUtWUJmVVM7LsGGgQ3MUsHnDqc6cyngo0Fj5GaqzmiYYc2igzhXxvAo6dzclKWVt6Nb5C33dXJe7vbWU+H/blry3f7f8h4G+EbSyG4FA/P1AAo1AIN4YrBbLUWOj/yySL94lgERk+yxvzcxrywIOXWyGRegicDWmFRjS8/XpudWCFIGv33ov4np311B3fOSChWWR0btj49ICQ2Pf/yDYg7gGN8UX99Yy3NTluOkh3t6Jn31ZvCW6miXZz8+sE2Q3SIqOlVXfMZ2+d+Di3YOXutoud7Z+CwS6vflyO+zluNDRcq6j+ext6NBAoGEdGqTTPN6DMXueqMW/4Mqv4rRw06tXdZlO3QE/Gk/B9zee6TCAnL61/xBzeYAf2d2PhF9LIuyl01uzc9qALmfltmTlt2TmOdOcscOcscOUkaPLzm7M22EqKm3MLKB/tiyE5B5Kxq3zJlQkJTSkS/dnSurSxXVpwlqZABhztYSrFXLUPI6SzVIwmUrozRzgzYoElgJ4Mx0EyrGSxlbBGrNTl7mj0gy92XlecCywN0MB7JnGU9H4KppATROCG/CjggYLz3viWMVRNJaPb+is2SvxuKW4t5Z7TN22/MP9+0ofP+wbRvaMQCD+liCBRiAQbwwOh6P96mWK71erSNP9CK6b5szZS4tvyypszSxszsAEOqPYmFFsyCzWZRQ2puXvTmBHLlwQSnYLJroGkdwEK5ZrGLB0Kt8SzVmyPMzLy9d16jLcP5bh3vJxneqLd9309nzuitWlUTQtS1zHT68XZZ/YVX235ey9A5fuHbxy58CVzrYrHS2X21sv3W650N5yrr3l7C0z5tDmc+2mM7Aa3QyDue9opbnLBPsxXgvWoeEMMGZnRu+NL4M9Mhrj6ZcCfbbTdL4TXPXHU9ZFrCK6ryER1xDcCrdsacvOac3a0ZaV25y+oyUj35nmtFwQU1q2LiNzf1aWLq/EXPB1/jZasLtnEAnnh58qCfBXsdlqLk/N4cCwORoWCFedzFExgDRzlAkvA6vIzuoyC7Y10zgqKkdN5aiAN8c5g5WcgVhj0qyKx+Icu0Hjq6kCLEIQ4NBKGh84d2Uce09sUua6cOriz4I8PJe7TvPBTVnhMZ3i96W+quLxowFkzwgE4m8LEmgEAvHGMDIy8uT7R7uzpP6ziKvw09YS3RI+/ayKxW/NzG/OKGjOLDJnFhszSwyZJU0ZxU0Z8lpxTop/cDAJH0CYFkiaFrVgrio+uSpRpI0X79uelLY6mPL+B4GexBX46T6uU4BD+7i6+Lu7R7z7Hn/lmoLwbXtpiRpuyqnK+vsHz98/ePnugcudbZc62oBAX77dAs8Rgtw0n7sFc/6W8dwtE5Tp29CkT2PtHCc7TCdfOTH04PHB6soGmEm/gsHs+UznaE53mMHbnuswX+gwngO/Uguylrm5ryKS1hDwtMWLjanpB7JzW9JzWtNzW9PyW9IKmkFS85tT88yybH16Zn1Gdn12cVPOrn1MybpZcwNIbn74aeCFKgZbkyRQJ/HUDJ4Gi5Yh0CbwNfECNV2ojhfCGRpY+7KSxlVQOUogzVSumspTY5ObwT02YQOrOsM4f+Rh856xkc9wUJ1IQxsNLD/HCRRxvK9jGHkbt/GWr4lY8I6fG87XddoqtylrZ+DZG/wPNFT9+OSHkRFkzwgE4u8LEmgEAvEmYbf9/+ydB3QTR7v3773frd93730TuisQQt4UUklCQgppFJveSSjphWIMGPfecO8VU91tcMG9YINt3CTZlnvvuPemrt39ZrXGMbvWSrKNgbzzO/+zR0jPjFa74vg/o2eeEVSw8s/s2bxt5bIdaiv2rV6p9/U3wed0Ui85p9q74wsK7XADHWfnE2vrHW3lfuWkzpG1f9+jtny32uLv1q72PfFr+Fnz0FNWYactAv/Q8z3xm/Wu/X9s2Lhn1UtblVU2KytvVVHeorxiz0urjq17/dTHG3Q1tnucPp/k5l8RndqcXihJhi6uSy2uSS6uTiqqTi6uSmRKxKpKYFUmMKuAjcZVWBOPV8+oAf44YZokdpkQntD8SJJX8wk9ZqMlaRv1iYX1yYV4RepkRl0yqz6R1ZjMYATH7Vz71hb1VTvU1fasWul24ofUSw7AQKfZOKXZOCdbAuvsmmTlij+wdEiwtouxcbht6x51ye+mvs13b63foa60Q3X59+veDNTSCz1nGqJtTChU2zjsnEnYWeNQLZOQM6ZAQZIyc7hOGQQC04xrct8TfOsTIDx/Y7LCxs1TxOpAQ9AKmG9wDDoDjibBZ0yCTpsEa5kEnjG6dkrX+bufLn6t8f3b7+1b8/IO1RXbVZZoqCw68s5aTwPtkpx746PDGFw1CIFAnm2ggYZAIM8X6MTYaPQ138Pvv66htnSn2vJDa4CH/iro3AU88Rd4aHvPBDtgoL1ibb1irD1Cdcx+fOu9PWrKu1SXfLf2Jaf9RyPOWoaesgk7ZR122iz8jHHoKUPfY6fNNQ+e+vjLvS+/uk1VbQu+jm35NpVlGipLd69ZdfT99ae/3uz0yx9Jbn7l0en1yfm4kU0prgUeOrGoMoEBTHNlPLMijlkZz6pOYFXjRybw0NXxBbXx+bXxubgSgPDdDR8pX6LJfxL505N69E/JNDaIKcATrFNw1eK5Isy65KJ63EnnGRw49s3KNdtXqm9XU/1l/fsRevpplxxSrYGcUqycU6zdgIFOsnRJNHeIs7CNtXKItvGIsvW9rmv93TsfaKopaaosO/76uqCz+mHnzYCHnlIYOGqbhpw1DdYyxY3vGZPA08Y3TwEbbRR4yujmScObfxjcxHcNBDK4edJAko9hNBlw2lgSDDy0scQ6GwcBG33W5KaW0Y0zhtfO6Dsf/UVvy84f3/tgz0svbVFathVcZLVFmuov/P7NhlC3S621lWKhgHzDIRAI5NkDGmgIBPIcgWIoIuRzW6vLrH/5bueqpXvUl+5fufzbV1af++xTt+PfRxiYJNu5pNh7JNl7xF1yv2PjGnrR9Od33t+tprJHbcXRtWtwA61tHnraMuyMVdgZs/DTppGnzG+dsQg5Zez/yznr/d+d/uyLg6+/ulVtxVbVZdvUlm5VW7ZVfbnGSpXda9f89tmmSyd+jbB0yrocUR59Hy/BkQTcc151Qn5VfEFlfGFVPKMqnikRPgldnVBQHQ9eBcolqSYxT14l5NckFuAGOhXfyaU2mVGfWlSTzKhNKYj3CDj68efb1NU11dV2rVxpsE0jzswyxdouxdohycoxxcY1ycol0dI53twxzsIuxtLhtqVLlLWn31njA2+8paGurKmy4ud33w89bxymYx5ywSzkvGnIeROg4HO4Qs6ZBmubBmnhCjxjchPPuzC+eQZ30jdOGuI6ZXDjlP71k/o3wDMS4TYahJ0xCgTSMpJYZ+Pgc8Y3zur7/Kplc/DYhc2ax995b/fq1RoqStuUl25VXqSh8sLu1S9qffF2lIt5c1HuQEvdcEfzRH83b2xYyOMgIhEsYAeBQJ5NoIGGQCDPLigiFosEIh5XODHKGegebq/vrSvpKM9vzk9LcDHT/vydvWovHli55OCqZQdXqfz01jqDzZudjx6/pnX+tolljOWlaHObq6fPHnvt9T3qqnvUlI+98orXsR/DtY1CtYxDzxqH4IkKxhGnTG6dMYs4axKO20d9719/N9m147u3X9+iuhQYaImWaagu36q8bPOK5TtXr/lpwycGuw65/HI22PjS/cuhxRGJ5bEZVXHZVXEPKuPyquMLquOAmQaWOq8qPrcy/kFlQi4u8EDyuCoxD6g6KR9o8rHkOCXipakna5IK8Lzq5ILalMLa1EJwrE8rqkkprEktKE/IDDAy3/XKKxor1bepKO9/eY3Zjp3B53WSrC4lWtolWtnHWzrGWTrFWjjFWNhFW1yKsnC8Ze7i/OPpnS+/rKGupKGyQv8bzTAds7CLlqGEh75gChQMrgP+wCz4nFmQtlmgtvlNLdObWiaBWibgeOMMkPH100bXTxtcP2Nw/ZT+tVMG108b3sBlgBd7PmuIS9sAyP/Xsw5HvtfX2PHHJ599u+7NnatXbVFetlV5yTblRdtVXtip+sL369Qv7f48SudnZoBT1a0rFZFXKqOv1yaFN2bGteff7SrJ660u6W+uGevt4I0MCjnj4JsgFgrAtwLmeEAgkKcLNNAQCOTZAtgjEZ/HGeof6WjurS/rKM1rL7jbcj+uKSW8LvZK5S2v0jC30hCX4qt2MXq/XPz0zUMrFx1cufig+rJDq5QPr1l54o3XTm3YoPfNZvPdu20P7tfb/MX+l9T2rlQBBvrEa6+6Hv7W9/sfvU784Hn8R/fjP7kd/dH18Peuh447Hfj20p6Dljt2GW7ZcnrjR0deW6uptlxDdZmm6nINlWXb8Tzd5RrKyzVVlTVVVXasVN/7yt+Pvbf+3FYN6+M/XL5oHG3ncdc3iBGSUHUnuyY+tzoxtyohpyohuyoxpzLhgcQK51YkPACqBI+TgPIJgX/i9jox99Hz08y05J/VyYXVSQXVyfl1qYV1acBDF9SlMqtTCmrSCmvu5pXEJtv/9NOev6/dpqaiqaa8/6XVpz/+2PXYiZALurHm1ncsLsVYOERZOEWZSwy0md0tU/vzm3dorFLfvkp51yp17x9PhV+0DNOxDr1gGXrBIvSCeegFM1w65qE64BnLkPOWQYQuWAbrWASeN795zuyGtsmNs8Y3tCU6a3RT2yhQGxwNr5666PerlscPvzt994PF7gMXv9n6+4aNR998c/eaVRpqSrh1VlkKrPPWFf+7W/3Fn99ebam5MejkkfuW2iwHwyInI5azEcPJkOFsxHQzLfayLPG1Lb1sX3rdtSzUpyr6Wm1iWMPdmOac5HZWdk9l0UBj1UhHy8RAj4AzPmmpIRAIZAGBBhoCgTx9UNw1CwWc0ZGetp46disjs+5udEXsDXa4T0mgK/uKfZm/dYWfRYWfaflls9LLZmVXLKuu2VT4W8cb/Gb45btH1yw9tHLJwZXLDq5SOrBS+cAq1UNrVn336ssn1v39yKtq+9es2LdKZd9K1W9ffun0h+tPffjuHx+88/sH7/72/vpf3n/v5/fe/untdT+8+frx11458vJLB1er71ZV2qm6fKfaiu2qy3GpLNulprR3pfIu1eVAO1WBn16qqbZMQ23ZFvDqmlVH3nn3t8+/1N11wPbE795aBtf1rSJs3OJd/e/6B2bfiMwPiWNEJLFupbBupxZHpZVE32XH3GXHZpTGZk6p7A7QvbK4e+AI/gleZccA3S2JTmdHZZTcTiu6nVJ8O4UVmVQYGp8TGJt9IzrzWmRaQHCST4DbH7/vfXWt5kpVTTWlnWoqO5SVvl+37vwXX146dMT3t5Mh+qYRppciTCxvm1reMrb0/V378Otvbl+ppqm+4rePPgw6px96QZKqcdY4SBvISCLDQG3Dm2eNbmjhunLaIOC0fsBpPSD/kxd9fjvn+bOWx0+nXX846XjsV7tvf7Q5eMxs90FDzT0Xvt52+pNNP7//4fG33j7wytrtaipblZZtUwZajPtmpRc1VRbtXrnk53fXWO/adOP3Q+nmWkwXoyJnw2IngyIgR32mgx7TQZ/lAB4bFjsagiPL0aDIARfT0ZDpasLyMGf52pRcc2IHeZRHBtQkhDblJLYWZXVUFPY1VY73dQi5Y9BMQyCQBQAaaAgE8jRBEDF/YmSoo6G97EF9Vkx53PXiEDfWlUsMHwumpwnLy7TY26zU26zcx6zSx6zK17TC37zc36wiwKLyilX1FdvyyzbJFlrOh7acXL/2yEtLD64CWn74JZUjL6t9+/LKwy+rH3xZGWj/SyoHVqvuX6myHzjp1Up7cSnvXa0CtGe10u5VK/asWrF75fJd6st3qy3frb58l9qyHUDAKCu9uFttke7XG5yP7DT46qPf3n3lwKplu1QW7VRdslMd2Gt8ilpTdYWmqvLOlSv3rll78NU3jr393s8bNp7e9NWFrRq623ca7D1gdPCI6ZGjZt8eszz2vdXxH6yO/2h94ifbH34hdOnH3+x//N3uh19tv//Z+sSPVsd+sDz6PZDFt8fNjxwzP4zL7PB3pgePGO8/ZLT3oN6ufXo7917YvuuchubZLZu/X//OrtVqO9WVd6or7VJV2qWitEdVef9KtWOvvfrH++9f+Opr4x27rPfvtz9yxPbQoVMbP92prrZdTUlDednxt944/+XXF7745vymr8999tW5z7489/kXQNqfbdL69PMzn3x+auNnpzd+9vtHn/z20cbfgTZs/P3Dj3/9YMMv73/w4/r3T7z73tG33z7y5roDr726Z+2aXS/hRak11JS3Ki/fqrREYppxaaos3q78t51Kfzuwaukf775iu+uL0DPHMqzO5TvpM50NmM7gqM9w1it01mM46RU66jIc9RngJSd9luQIXDXb3qDETr/YXo9lr8u0v1hod6HQ4UK+/flcxwv5rroFXkYFfubMK7bsINfq6CuNd6P6a0uEE6MwxwMCgTxRoIGGQCBPDbFIONrZ0pqbVB13jXXTvtDXlOFlxPAwZErE8jQq9jJhe5uW+piX+pqV+ZqX+1mU+VuUXbYoC7AsC7AqBwIe+pr9AxejsPPf2+/76vSHfz+6Vum7NUpH16ocXav63Vq1Q2tVDrysfGANrn0vAd+8Yu9LK/Y8Ev7P1cv3vbRi3+rle1cu3aO+ZLfa4r1qS/aqL92/avnRV9VPfvCaze7P401OFbqbp5mfi9D63v2wpuGXH554ddV+4LnVl+1UXbpDDRcw09tVlkmyPoBWaKiu2KqybKvS0m3KS7fhNT3wsh7bVMDzSttUlYDR1FRX0VBX2aaurLFKVRNYz5Uq4MltakpAW1VA2+W4EwWtVJeDJngrSSfAr29XW7FDVQk/qgPTr7x7ldJO9RU7Vy4Hjn8nLuD+l+9RW7FHXQkcd6mt2P+S+revvnz0jVe+fX3t7pWqeFvQp/KybUpLNZTxvBTi8bYVSx5p8dZHAv/csnwx0OQ/l+PPaCgt2bJi8TdKi79RXvy18pKvlRdvVl6yRWXJVpUlW5QXbVVetE35RQ2VFzRVXtwJLuaqJT+sU9f7Yr3roW0hp45mWJ7DkzScDRm4b9ZlOAHHrFsoEcNRj/lIrCk5ABEz07oMIEedQscLhY7nCxzP5Ttq5zmczbfHVWB3ttBOm+FwodBVnx3s9rA4W8Tnkr9tEAgEMn9AAw2BQJ4aQs4YcM/sq7bFPqbALhd5GBa5G7DcDXAD7WnE9DYGKvIxLfY1L/YzL/GzYPtbsi9PqkQi9mWrsgCb0ss2bH+bHEf9Wxd+cD+yzeTrD85/9MbJt9f8+Jra0bXKR15ecfjl5YfXLD+4ZtmB1Uv341qyDxxfWnrwpaWH1yw7+orS8ddUflyn/vs7L2t9+Jrupvdsdn7hfXxP0Knjsfq/37fXKfa2KPWxKvexLvW0KnQyTjPVDj513PWQptHmjac3vn387TX7Xl6xQ22RpuoiSVG2JRqS1YdbVfGJ2J0qi3cqLd6xYtF2pRc1VyzSVFqkseJFjeXgiPvRLSsWbVFevAUYUKXFW5UWb1NZvFUFP2oQR+XF21WWbFcF7nzpDpUlQDtVF+9SW7Jbdeku1SV71JbuXblst/qSnWqLdq1ccvAVldOfvvPDu2v3r1mxS33x7pVLdqkt3qkGXsVn03eqL9+hvmw7viASt/jbVJaCdwQ+GD8qLdqs9CLQlhUv4uez4sWt4MFy/LhtxaKtKxaB4zYlcOaLNVcs3q4EtAQ/edBQefFWZfyENXDT/MI2pb9pKP3vdpUXDr68/Pu3Vp/66A3jbZ+4fKt54/R3d4xO3r+kl+toUOACrLNBoZNeoZNuofNFBpADLuCPWQ66RY56uMCDRwJPFjjq5jtdJFSAS6fA6UKB4/l84KEdtAvstZn254EYdueAgc5zupjrbVqfdUfAGSN/2yAQCGT+gAYaAoE8NUR8bndFYc2d68U3HFn+Viwfc6aHMdPdiOFmyPI0ZnoaM7yMGd4mDB9Tpq8Zy9esCNhof4vpYoOjn1mpv2Wpv1Wpn3Wpr1W+k0Gy0R+3zh6/8dM+v++2exza6nZgs9v+b4Bc9n/tvO8rJ6C9X7mAZw5tAW7b4zsN7xM7/H/cfe23AyFnjkbp/JRkejrLTo/pYcH2sSnxsSz2MWf7WBR7mrA9TUs9zYHKvK1KvK3yXIxTLLRv6/12/dQxz+N7bPd+rf/Nhj82vH7irdUHXlbavXLpTnXcwu5TX7JXddFu5Rd2q7ywW/nFXcov7FD62/YV4PgikKYS8J0vaAD3SRhQ5UkPCrRD9cVdaouAPwZWeA+Q+hLQ1YFVSw+9tOy7tUonXlX75c01f7z7itaG185/+qbpto89j+2MMjh58/Qx5yMa+l+t//51lQMrX9y3ajHw1juBk1ZfskNt8XY1YM0XaeIGHZ8n3qr04lblF7aueGHLir8BbcX1wtblfyO0bfnfNFa8oLH8BU38bBftUl68R3kJob0qS/eqLt2tArRkn9qSQ6uXf/+autaGN4y++chu79dex3YGnvw26uLPaZbaOU6GBR6mBe7GBW7GBS4GhS76uHt2xt0zODJcdBlOFwslAg+YTrpM/PinwJN5uHSA8nHrPKlCR50ChwsF9kDngW9mOoLe9Ao9TFjXHesyogfb6sUiIfnbBoFAIPMHNNAQCOTpgaICzvhoV0t3dVEb815jVlxtclhl9BV2kFvxlUtMH/NCL5NCH1NgoIGNZvqYAg8tmYrGxfadFDDQbD+LEl8Ltq9FKZC3RamnWbG7CdPZoNDBoMBBP99erwAIPHDQIwQeFzoZMl2MmG4mwNsVeoH+zZjeZsDBl/hZsv2sSoB8LUt8LFjepkU+pkXeJkVeJsWPVAKO3ubFvsC7W7F9rIo9LJkuZrn2Bunm52N1/wjX/unG70f9fjjodmSn4/5t1nu+Mt3+mcGWDXrffHjxq/XnN7179rO3z3zylpZEZza+eerjN8HxNK51Zz5Zd/aTNy98/o7Opnd1v3rfaMtHpts2Wu3cZLvna4d9m10Pa/ic2H3l5wOBv38bcupYpNb3t7V/vKPzc6Ler5kW2oVORsWeliw3szxHg2STUyEnD/sd32635wsTjY06X67X/vzts5+9deZTyRt98uYp/H3Xnfx43R8fr/t9wxuE/tjwxskN605JdHrDm2c+ekvr47fPfvy29ifvXvjsfd0vPjT8coPRVx+bbv7Uctsm2x3f2O3e6rRvm/d3u6/+dCj09PFYvd/TzLWzL+nmOegzXY2LPU2LPUzAcKjQ3bDAVb/QFbhnPaYzkC6evOGsiz9w0S100S14JPyx88XpAj5bMussmXgGptnx4pQk09j6hW5GLH+bynDf2sTQ1tzU3poSzlAvIhKRv2nP3FpJAABDJklEQVQQCAQyr0ADDYFAnjoogoiFfC53dHC8r3OorR7YoI6i7Na81KZ7sbilvnO9/JY/O8SdHehUdO1SUYB10WWrYn9LQkWXLYv8LVl+FkVAPubF3mYlQF740sNSL3P86GNW5mNR7isRXsrDstLfqvKydVWAdUWATWmAdekVG1wBNmx/a7a/xDr74o4cuGTQIQt4ay98OSPL01Rio02LvYGBNi32MQMxZT6W5d4WZV5W5d5WZT42ZT6Xyv3sy/zsS3zsGO7WeS7mmU6GafZ6ybY6STYXEqzO3TE/G2N2JsrkVJTxqSgjoJPRhqdiDU/F4DoZY3TyjtHJRJMziaZnksy0Uiy00yzOZdpcvH9JL9tev8DJqMjdnO1pWeZtU+FjU+FtXQHe18uizNOszMscqMTTFIjtBT6+KbgCTHfj+3Y6adbaiWZn4kxOxhmfvGP8B+g/1hh/oxijP4CiDP6I0v/jth5+jNY/GYPrj1j9k0B3DE4BxRqfjjE5c8dU647Z2QQz7UTzc8kW59OsdDJs9e/ZGWbbGxW4mLE8LIs8LYs8zIs8zZnupuB9WR6ShBwPA6a7PsNNDzhjpqse00WvyBkXC8gF/yfDBX9JMiH9pybdM3DMkgcM4kngocHRxQAMeBi+ViU3XCoiLtclhLVkJXaW5A011473dgomxhCxCN9tBwKBQJ4w0EBDIJBnCRSvaCcWCkV8LvBD3JGB8b6u0a7W4bb6gYaK3ipWR3F2a35aU3Z8w92o2pSwyrgb5dEBZZG+7DDP4iCXousORVcvsS5bF/lLHLaveYmPKdvXtNTPvAzI36Kc0GXLClxW5QHWZQE2ZQG2ZZeBbEr9rNm++KQy28eS7W1Z4mVR5IWbQpanWRGQh1mxJ/Cm5iW4QzWbdOreZmw8xwNP8yjxsSzxAf7busQPCNhxO/Zlu+IA25KASyVXLrGv2JUE2JWAZy5fKvK3LfKzZfnZFvnaFPnalvjaFuOyJoT34GMt6Q2cAy42frQoBfK0kKSRWJR7mpfjvhmME0zZ3iZAJbitx1WEJ44bs7xxFYFXfcxKgdH3syz3tyq/bF3mb12Gp4xb4UMFP6ti8GElb8f2BR/fBjwGH7/UxxoMBsCR7W1V5GfD8rNm+FoW+lgwfCyBCr3MGV7mhV4WhZ7mhR5mDHdThpsp080EiOVhygAG192Q4Y5bZ6a7HhDDXbfQTZfhis83M511Jb5ZnwGsMC79QuChXfUKgFxwFbrpF7gbFHgYMXzMmOAmXrMrDXIpC/esuOVfFR9Yn367NT+9q6ygv75i5GHTRF+3YHxExOeBrwwsuwGBQBYSaKAhEMhzATDWCCoWAWPNnxgFxnpisGe0p334YWN/U1VffXlPTXFHWX47sNeFd1vyUppzEpruxTSmhtfHXauN9quO8KwMdS0Pdi4PdCi/YV9+0778hl3Zdduya7ZlV+3KrtiVBVxi+9uw/XDh/tXXCpjXIi8Llhdwz+ZM3ENbABXhwi11MTDWuIc2LfYxx9c4+poV+ZoX+VoU+VkCFftbFeGyLvazKvG3/lOS/iffwgeYV2uWjxXTx5JFyNcCCO/Eh5AZEJ4r4m1RgsucDcy6xLuzcZmW4iVKTMAIARdhoH1w4QknhI3GZVTibcT2MSnFRxFAZmxfMzCcKPE1A8JPWzKPLpEl229y6h0MBtjgn8Q0vA8+Dc/0NmV4mTA8cRV6GAExPIBRNmK4GbFw62zMdJXIzYjpash0NWC46jPdgIE2LPQwyPPQz/M0yHM3yHMDR8N8T+MCL7NCX8sCf+vCAFvWTUd2qHtFlF913PW6pJCG9NtN9+NaHiS3Fdx9WJTVXV7QV1sy0FQ58rBxrLeDM9wv4E4gYhH4NpC/IBAIBLKAQAMNgUCeV1AcRLLdt1AsFIgEPCGXI+CM8cdH+GNDvOF+Tn/XRHfraHvdUHPFYF1Jfw2rt7KguzSns+R+R1FGW0FyS058U2Z0Q9qtuuTQ2oTg6js3q6KvVkUFAFVE+pVH+JSGerJD3IuD3IoCXYtuuhbfdGVdd2Jddyy67sC8col5xQaIEWBVeFmiAGsG0GVrZoA1C3/JmhVgVRRgg8+Ig2cuSyy1v02Rn3WRnxUQ09eK4WtV6Gf5SBZADD8Lpq85Lj8zpp85yxf3r7gkZhdIkgtuMqUiP9wH4/KRpGv7So4SsXAZF/kYFfuZFPubFl82w+UPjuYsPzOWvxkLfwtwNMfljwu8I9OfkAVDcsSXb/qYMbxNC7xNCrxN831M8/HHpgxfc4aPOQOYfvCJAi6VXHUoueZUdtOlLNC1LNCtPNi9PMSjMsK3LOpy2Z1r5QmBNWAwkxHVmBXXkpvSVpjxsDirszSvu5LRW1860FI90tk01tPOGegGd403NgzGSELuhJDHAfcU2GXcMSPQMUMgkGcIaKAhEMhfHRTFcJ8tQoEVEwnEQp5YwBXyxvnjw9yRfs5gz3hfJ3BveKJIR9NwW/1Qa+1gc/VAU2V/fVlvXUlPTXFXFauzgtFRlv+wLK+95EF7SU57cVYLM7OFkd6Un9KYm9T4IElyTGzMiQcesTH7TmN2bGNWbFNWTGNmdGNmVP3dW3XpEXWpEXUpYTVJIdUJQVVxNypjr5dHXy2LDiiLvgzEvuXLvu3HjvQtjfQpi/QujfQCx7II77Iwz/Jwj7IwIPfSMHd2mHtJqAshdphrSZgbO9S9JMSNHeJWEuTKDnbFj0GTR3aQCzvYuRSPBHIrDXcvDfcojfBkg+Mtr7Jb3vhbRHpXRPlVRF+ujA2ojLtWFX+jKimwOjm4Ji2sNj28IT2y8e4t8BEa7kXX34upz4ptwD9gQvODpJbc5Jb8NNwNs7I6S3K7ywt6K5n9NSX9taUD9eWDjZVDLbXD7Y3DXS0jvQ8nBnu4w/3gmgs5YyIeBxHyUbEQQ2HqBQQCeS6BBhoCgfzDQ3g4/IhPaUvcthi4bSAxbrhxiQR8sYAnEnBFfK6QzxHyJgSccQFnTDAxyp8YEUyM4NPe40O80UEg7sgAsOa4hnu5Q73Ao08MdOHq75zo6xjrfTjW0zbS2TLS0Qz85VBbw1Bb/SAQMO5ALTWTaq6W+PjqQVxVwNAPNBKq6G8sJzTQVNEP1FjR11De31DRV18OHuDH6Woo628g4vFIiSr7myoHW6oHmnGBB8NtdUPt9SMdjSOdzaNdLWA4Md73cGKgkzPQzR3qAR+B+Dj4pxsDGgI+WPLBR8EVwKeKuRxwWcRCPiIUICIhIhLh+2njVxK/pOSrDYFAIM8/0EBDIBAIBAKBQCAKAA00BAKBQCAQCASiANBAQyAQCAQCgUAgCgANNAQCgUAgEAgEogDQQEMgEAgE8jyD8DBBIyYewBduQiCQBQEaaAgEAoFAnhVQfhcmGgammPyCdFBOIdqti45FYego+TUIBPJkgAYaAoHMPyiCjA8OTgwOkV+APG8IuLyehsa+llaxUER+DTLfoAhP2GQv7gjEhAPk16SBIthwCNK6Cx20w8Sd5FchEMiTARpoCAQynwDrzE5MCdc1DjxzASjSwKz6fg45CPI8IBII8sNuBZ29SNzKUB3Dyrv3yEGQeQXld/GKD/DLfkDGa8ivSQMVIL2OSNOXaJ82JqyBhbchkIUBGmgIBDKfZF29Sfit6arNySXHQZ55Mv2vUW9leepdchxk/kBGmNy8j7kP1iNDOfImNIuH0c4LSOMGtOc4xmeAf5MDIBDIEwAaaAgEMm901tRSLRdQpKEZisjnBiDPBj0NTdT7CBR6wUDA5ZKjIfOEqCOYm/UKN32RuOsWhgjIL88Eyq9F239CGt5Hu3dhvDQM5ZEjIBDIEwAaaAgEMm+wou9QLReh/tY2cjTkGaY0OY16Ewl1VMmdXQBRCEQoqDPj3F02kfQvwkY7VCBXGjQ6noG2HkTq16OdW7GJIAyBCw8gkIUAGmgIBDJv5IVEUP0WoYYCBjka8gzDjIql3kRCTcwicvRTgjs62lJU0ljIbC+rEPH55JefO4RDgtJjE6n/NZH0T/zS4yinnhwwAyg6eB1p2oLUvYd2bsHGXTFxBzkEAoE8AaCBhkAg8wbjVgzVbxEqjkskR0OeYVgx8dSbSKghv5AcveAgYjHjdkywtu7UWYXrGtc9yCPHPUegiLg/g5v7wUTyvwADzc1aK+pNxFAhOYwMgvbaIPUf4wa64xtsRB8TVcN1hBDIAgANNAQCmTfYCSlUv0Uo+3oQORryDFMSn0S9iYRqc56yT0URJMPvCvXEgMrTMsjRzzQohopQXpu4L0lYb8Er+JyT9j/APQNxUv6dm/+xoNZI1B2LcltQsZT5dWQY6TiH1K3HDfTDr7GhXzAhC64jhEAWAGigIRDIvNFYyKR6GkLJLp7kaMgzTEV6JvUmEgIvkaMXlroHedSzIhR09uJIdw+5wbMKMl4tqLnIK9jEyX6dk7F8IuXfCfc8qeR/5dxdys1+jZv/qaBKCxktw1CKM+ZXoe0/AveMG+j2L7DBQxg/Ha4jhEAWAGigIRDIvNHX3EL1NIRiLGzJ0ZBnmNocqSb1qWfjJDm5Uc9qSkV3EsgNnlUQfpeo1ZPH2MzJUJ5I/rfH3POkh/4/wEMDhy1stEc4zdTcDHQsBWnZN2mg2zZhA3sxTjC+pzcEAnnCQAMNgUDmDT6HQzU0hMJ1jcjRkGeY5qIS6k0kVBARRY5eWEJ1DKlnNaV7l6+RGzyzoGJM0IuMlYq6owW1+tycNyeSH01CJ/8zN+ctQfUFUWc4MsLC9/eeqaodOhCANm2eNNCtn2P9e7FxJ0wMK95AIE8caKAhEMh8EmFgSvU0gZLf1smhkGeYjqoa6k0k9NTT2SP0Z/6OEcq6Fkhu8MyDinkIr0PUEcTNWQesM54DfX+NqP0qym3DEC514nkSVIR0WxIrCHED3fIp1r8HG9XFhFXkSAgEMt9AAw2BQOaTWCt7qqchBPdSeY6gyca5632ZHL2wZPpfpZ7VlKoys8gNnhNQfie/5CAn5T+BgeazjyDj1RgqxToTiHqQDm2k7v1JA928EevbjY38iAmYUj03BAKZJ6CBhkAg80mio9T8VJTeDUCeJQYfdlDvIKEUVy9y9MLS09AUpKVDPTGgCAPT53ijREQgqDWaSF8CDLSg0Q4VDpIDSHCLkbYTRAkO3EA3fYT17sSGj2C8BAyZIAdDIJB5BRpoCAQynyQ7e1BtDRBwPORQyDPMSHcP9SYSAmMkcvSCU5WZFUjx0KE6hj0NjeTQ5wgUFXWGcLNe4dxdJuq+jaEzJD1PA0WGQpBmDcI942r4EO3Zjg0dwjhemLiTHA6BQOYVaKAhEMh8kuDgSrVcQMHauuRQyDPMSE8v9SYSAreYHP006KyuTXJ2n/p23bt87TkqYCcNZKSIl/8pL/8T8VAecMjkl6cj6kW7DKcSoCUG+gO0WxM30KNnMVExrAYNgTxRoIGGQCDzyR3rmXOgQy8YkEMhzzA0M9DAtpKjnx4CLnd8cFAsFJFfeD5B+T189hFB5SmU00B+7TEQbCwFbT04lb8h0Xq0cys2dBAbPorxgjEEFrODQJ4g0EBDIJD5JMrUmmq5AmEZu+cNGgOd4vaUc6D/wqCIQNQZKu5Pw0Sj5NemI2xHu4yQhk+nuWdJGvTDr7DB/djwYWxMBxMyZCWBQCCQ2QMNNAQCmU8i9EyolgvolpE5ORTyDDPc1U29iYTSPH3J0ZD5AxUMYKIxfI5ZGsg4OngVadZ8fPpZYqBbPsMr2QEDPXwUm3DGRA0wkQMCeUJAAw2BQOaTYG1dquUCirG8RA6FPMMMdXZRbyKhuz5PuYzdPzQoBx2ORFsPIXUfkNwzrsYP0R5JGjTw0CM/YVxfTNwMPTQE8iSABhoCgcwbYqGI6rcIJdi7kKMhzzA0Zewy/a+SoyELACpGhQ/RwetIy0GkfgPZOk9NQrdtwvcjxCehJR6a44EJyzGUR+4NAoHMDWigIRDIvMEfn6D6LUIwcfb5YqD9IfUmErp/5QY5GvJEQfmYsB0bS0K7jZEmDaR+prnnKTV8gD78GhsAHpqYh/4BGzPDeDGYqA5Dx+kyQyAQiCJAAw2BQOYN7ugY1W8Rgr/7P1/0t7ZRbyKhp76V9z8KKB8VtKHjGWi/L9Kpg7TsRxo2ku3yjGr4EG3bhHZtwzcmHNiHDR3GRv/Axi0wzhWMn447aWQEOmkIZI5AAw2BQOYN7ugo1W8RgtOWzxc0W3k/CAolRyuOWCRqYhWXJqfVPcjjjY+TX/5HBuFhgmZ0LBXt90K7dNC2I0jTNzQ5GzOrfj3SuAFt/gRt/Rxt/wrt2Ix1a6K9B7HB37FRU2zCH+MlY6IqDBmVUW0aAoFIARpoCAQyb3BGpBroB4Hz4Lr+qnCGRwojo2Ot7KLNbFLcvFtLSskRC05PQyP1JhLKC4kgRyvIUEdntLnNVIdhF42ehY+8oKBiSY05inlFuOhILNJ5EV8m2PAlUv8h2RkrrPVI/ftIwwfATyPNG9GWT9G2L9AOTbTrO6z/AjrijwlbwNmQTwMCgcgCGmgI5B8FFEH6W9uqMrNKk1Jzg8OL7iSUJqc1sYoH2h+KBPNTLxYYQarfIlQQfoscDZEw2tsbaWhOulzV93PIcTMx2tsHIu9fuZHs4gnMN1Cqu09hZFQzq3iO97Srtp56Ex/dytvkaEUA37dwXWNSn0FnL3ZW15JD/8LwSrGxUExYjzvp6YhH0B5rpHETtUTdvKkeP4pr3hZVviWu34OO583g4yEQiCyggYZA/vqM9vUzo2LDdY2oZohQsLZuips3Oyl18GEHubEi0BhoVvQdcrR0BBx8e7mhjk5w5IzQ7ijxJBELReCCdFTVNBYyCbWVloNnEPF81gUD3pd6uULO63FHx8ih02gvr0x196Y2nFLYRSMwQJr1Fn3AzlL7JMS4HUOOlpuhjq4IfVNqn0CxVvbk6GeDiaHh1pJSdkLKg6DQNA+fKWX4BoCBKHgefDEG2x+CASq5pVRQdCgQ7T6BcWIlC/umvyJAOQyk3wftOI00bUPq5j4DLVHtu0jN2+KK14TsNQLWSgHzZQF7k7DhnLg3DOV3whloCGQWQAMNgfyVEfL5wLkGnb1I9SvSFGtlV5acNjvbCqwGtUNCJQnJ5OjH4Y6OVt/Lvnf5GnU6NuS8PnCZwKmAkQC52XwDzDHwjoW3ou/YOFA/BSEw3gD+qe5BnpA31+pgNFcMXA1ytIThrm7w7tT4GZVg7zIxNETuQg4eVlRSeyPEiokjR8vHSHdPpKEZtcMpjQ8MkttIYaD9YW5QWIKDK/higPMBIzdyxJzhj0+Up94FF5B6njMq9ILBXe/LdbkFAi6X3BcZMdpri7RtRUccMaSL/CImxsQDKK8CHU1C+9zQh7/jTlrRHGjCNFe/Ja54VViyWsBQ5uct4+Wq8pkfCap+EbV5iPtTkIl6VMyB7hkCmR3QQEMgf1kG2x9K21hbpoBHzA0OH+sfIHdKC/Bq1K4IlSalkqMf0d/Slul3JUhLh9qKqpwbwU/CLQH4E7hhumVkQX1TaYrQMylPy5jLhDTNWr2sqzfJ0RhWl5sPhhPUYBrFWF7ijdFNZs9IW2k5tStCxXGJ5Gg5AIMfmdcWOGxys5loYhWTxoQR+qZz/PFkOgIOl3ErJuS8HvUM5RG4QQURUWBoRO53CvEI2nEW3zVw8CwmrJK6jA8VoqIejMdGR+PRPmek7QRST967e2bVviMq/7uAocrPXcLL+l9u5n9zc9by2YeFjfbi3gRkvBoVwbWDEMhcgQYaAvlr0lLMDr1gQP3rrpBCzukBg4ii8s5RTQxKNdBlyWnkaEnKx72A69RgekUamgPPTe5rDoAPWJuTG65HTsyVUwkOrqO9veRO5YPGQJO2nkERJC8kghomj/AagnLfRIKWohJqP4TYiSnkaFmMDwxGmVpRu5quSAMzebIguKOjM36x42wdFf2MM9LMKo4wmDnJRCGBk6zMuD/zKfFrcDfc9BHW/x0meAAcOzngMVC8DrSoC53IR/s9kOa9MupA17wlLFIHvpmT9u+c5H/hpL/AL94vengNHStFBYPklGsIBDJboIGGQP6CNBeVKJS2QS/gceWcZB0fHKQ2J1SWkk4KbmIVUxeTySlgdkd6ZulZSXBGRmfMQlZIEXoms/P0NBv+RZlaT4WJhcJM/2vUGPkFDPG0t5VNI4NF7YQQ9VbSMzE0PL3mhjSBMQy55UzUZudS2xIabH9IjlYE8CUvjIyidjsXgf871DR0dCwFbdmLNHyI12nmRkmqMssDgol60JE7aPsPSP1HZN/8aO5ZyFLjZvzXRPI/TyT9EydDSVB9DhkuxETjMFUDAplfoIGGQP5qtJdVzKN7JlQQEUV+m5kYH5BqoMtT706FoShaFJtAjVFISU5u8k+NS6OvuUVmXoGcCtMxnEUWwWhvL7UrQreMzIkYYOwy/K5QAxQSvkRPkcvVkF9I7YRQRXomOVo63NHRWMtL1E5Ikr/KISv6DrU5oVZ2GTlaboDNTff2p/Y5d2X6X33si4qK0X53pPELfMvAHk1swnOmNGjpIOPoWJoknWOG9YWisle49/970j3fXSKo0UPGazCU7OAhEMjcgQYaAvlLMdTZNeMP3HNUkJaOPAv4xvoHqG0JladlEDEogmRdvUkNmIVaitmPv79i9DY1h+oYUrudtaJMrXljiu0JQlM5O1zPGJMMNrJvBFNfnYU6axSoE1f3II/aA6GqzPvkaCmAq0GzFnNK6V7+cv7EAQBjOWoPhBSdZZ8CuOe7PpepHc6Xpg85UH4dvi6w7gOkfj3atRUbuYAJyxXzuMgEOhyBtOwml7qrfUdQsIKT+q/APU+k/Ae/7AdkrBzmbEAgTwhooCGQvw4CDjfGwpb693teVJebT34/CnQGWjIDDdxz9vUg6quzU5qHD/kM5GagrT3sotS6frPWvYDr5HeiRcjnUzshBAZCIKAkPon60uyk0AYoNVkPqD0Qqs6Sq0Y1f2Ii3s6J2pykBHsXhYqZ5IfdonZCaNa7seQGh1N7m0eBcdrkbovICDrggzRtJiwv2vENNvQdxg3DkAHFUixE3Xi56IbPpxtocdU6XvYLxPQzN/d9cV8SKlbgwkIgEIWABhoC+euQI2uqMtbKvrGQCZzNVJPxwcHu+sbq+zmZfleCtXWpTaYkj20a6+unNiRELCKc9TK4GRV09iJ//M/PIj+glcw1bbOWQokEKIoGSik/Aj4d6Eraq1MK1zMG/q82Jxfc2bKUdJpq37eNLchvL52qzPvUHgjV5uSRoykIuNxEB1dqW5KizW0ULZhIY3bbyyrI0XJAk1Q9XVFm1jk3Q0qT08ClBoNJ8IAVfQeMl8Dz1GCqKjMyMVEvOhSKtBxA6t6fNNCtn2H9e7DRcxg/BUOGFfHQKDaRjbR+N9XVZP5G5v+TTD//p7DeDOV3kxtBIJD5AxpoCOQvAm62KH+2p6soNp6+ygFvbJwZFSstf7qvuYXcgMKodANdmpRafS+b+vwcpZBbJQCe9a63Ar/XA4dKbPInbQcQkmIsbOmvMwmasnT0GSaRBmbAy4pFj/3639vYTFMQcEyOPByCivRManNC9XmF5OjHAe45ydmd2pAkYOgVrZMIoPkFYxZ7GY5094Scoy1Xp6UDxqX9re3kltMYHxisysy6Y21PbjtNKc42aJ8j0rL3sb1RGj7AJ6EH9mOjOhg3BBOWSmy0fF8e8RDSbYY0fPKngS5Zzb37n/j0c/Yb4v5UxdJCIBCIgkADDYH8FRBwuPRbVNRkPyC3kUJXbR21OEaquzc5biZGe/uob00oxc1bmjWfUrC2btbVm03Moql6wJzhEZqc10DJqODxU5CNnDOO4IQbChikXUgmBoeq7mXLnL0GDae3ood6teVRht8VafnW96/coMYTkj9rvDz1LrU5ocZCJjl6GrzxcXk2HwHuX86qzyTuXZZajaSnoYkcTQsYStEXYAFjIXnGjZOgaDOrWNqa1NDz58UNm5D6PyeMJ9X4Idq2Ce3cgvYeRgd10TF/jJeOiRoxlCdrQhrBM6Gbt091JSxS59z9D2CgBeU/IRP15HAIBDKvQAMNgfwVYNyKof7NnlLpTDWYaRjp6Y21+nM6Ld7OiTsq1+/soCH13eVRkJZOfliktF/z80IjqU0IZfgGkKNpAY5cZuozsE3ddQ3kltMQCQQ0iQSB+BVzJreRToSeCbUHehXeiqaZ5G4tKaU2IUSznQ0J8J2hNicEbCI5+hHgeyLPqkEwZphFxRKCNE9faoeEFC1jB8Y51E6mlOLqNT3ZSU7AUFZaNQ9eubTdBNcjDR8gTR+hLZ+ibZvRjm/RHl10+AYm6iT3/jgotxgvx/FoKaGQpcZJ//eJ5H8RtniiIoW3zoFAIAoBDTQE8twz1NlFM7l77/I1heqXESBicXtZRUV65sOKSvkrJIx091BPQKZum1jSzx3yxsal5WfHWF4iR9NCb3wDJTO7Qj6f3GwmCsKlrmYDkr8sNE3W8owqjIwmd/E44HJRWxF6cDOEHC0FdkIKtTmhZinFLsb6+uVZwwrcc3+rvBeHSpKTG7VPQvIUiplCLBTR7NOZ6OAq59eAhFgolPYdGy/+mGKdcYmr3xSVrRUWrxIWqQMTLGCtEpa+K27Txvh15N5JiAeQjvNT+6oImCqctH/j3F0i7o2DGw1CIE8aaKAhkOcemi02Ig3NJpf/LwizMNAJ9i7yTG9n+AZQ2wZK9kqUf3gATo9mpBEocc/yjxZAZLydM7UTQqzoO+QGUqDJgabqXsB1eapfRxrMnM+T6i5v3ZLiuERqc0IzGuiBtnb6JCJC4XrGIJLcWBFoUo0V2rG8NkdqJg+4erPbLn7wYUecrSO1w0D8N5YLwupPkPrHC88B91zxKr9gBff+/3Az/i83S4nP/FRQ9auozR0deYCJZf2/QMVIj+1UGrSgUImT+q/c3A+QYdmrPCEQyByBBhoCeb7pb2mjKdQw68q4s2O4q5t6DjSKt3MScLjkXmaiLDWd2pyQnD1gsqaf79g4KFRPDdBd30Dth1C0mQ05Wgo0a/5IirWyl3NaNEFKBQx8OxX5KLojdacbqoHurK6lX+9IKELPZEDBLAsqkYbm1J4JkdZT0oGiNKkms1iZKhYKS+KTpP1OAhRvY4b22CDNO6bXzRBXrePnLeWk/ttE+os8pqagwVbcm4hM1GHiCVkJ0JOgQzeQpi2S3t7l5y/npPwfPvsIMl5NjoNAIPMNNNAQyPNNpvQ96uSfbpwvFDLQt00suaPyThm2FLOpPRCSs7IEb3w85LzUegtBZy/OLq8g0VFqRoE8JSbEQhG14YwC5kz+HF9pE/aRBmbkUCmwYuKpzQmRcqBrc/Lo5/UJRRiYzjrveTrSimaEnNcnh0qnu07qyEfRrHpAW2m5zL3Ky1PTMWEbOngdad495aGFxas4d/+Tk7FcUHVWPPgAFQ4rmnqBjmcgrQfx3mrf4ectAwZaWGcMC9hBIAsANNAQyHPMaG+ftPlL8Py8+BWFGOrsop7JjAKWS4H6BpJdA6mdEJLzY1bfz6G2nVJhpFx7lVOpzpLaLX21CgL++AS14YxiJ6SQG0tH2l6PwIWTQ6VAs2P2lIFGEYRxm2716pRuG1vMruYGCZFAQO186i3I0dKRuhuLls5QhwIba/e3tqd5+JA7oQgMHgRc/McNVNSL9rmgjV9PzhkXrOCk/Qe/9Ht8y0BM3tyhxxDUIe0/4b3VvMV/sJiT9v+E7VdQMYccBoFA5htooCGQ5xia4hvZ14PI0U8eYD6oZzKj2IkK2EEM77mT2gkh+gWIU6S4elHbEgo5rydPHvaM0Gy+yLwdS46mMD4wSG1IVYyFrQL5CRiWczOE2gkhmvId02FGxVLbEmqSGGgBhyvn9tfg5MHHJL/BrKDZ+fyOjQM5WgrgCgBHS+0BKNP/KjlaCmA8IG2UQtW0nBAU41Ui7T/jk9C1b/NzF3Puq4u7IjFE3jQkMsgY2nkBqVsvrn6Tl/Mi9/4qUU88CitAQyBPHmigIZDnFUQslloBTUtnuOsp/IxLY3OnK87WUf61egQ0BfI6qmrI0RR44+PSpuoDFdzjmsptE0tqn4H4TuO+5FAKgw87qA2pUjQr90FQKLUTQiKBgBw9E8D9U9sSAgYa3Gh5Cm4ESu71rAcnVGhyhMAAiRwthb7mFmpzQl21sgpfSKxzzo1gebJWCBF7cP4JKkT7nJCGTeKat3g5L/CY25DREjkznmcCQXsdkYbPxFVv8LL/xivchAwXzKE3CAQiL9BAQyDPK+1lFdS/1oQy/a+RoxcEueyglk5vUzO5pSxonJM85pJ+m0aFkkmoSEtDl2cdYXd9I7UhSYkOruRmsqDZrk9OA02Tm3H/yo3QCwbU52dUe3klues5QON9wV0gR0tB2iaL0eY29BVdwNc76+pNmpEYWVo65WkZ5F6AvR1NRJp343PG2X8T1FxEeXLlIEkBxYbD0GZNceXr3Pv/wy/7AW6hAoEsDNBAQyDPKw8Cpc4ydtU+nT+i8hjo2U33DrQ/pHZFqIlRRI6mwJSe0RtlZk2OVhBpnQedvSiz5BzNKGhKIIbcTBY02/XJa6ClZwcppChTKz5n3lJyO6pqqG9BKPtGMDlaCtIGPMVxieTQR/Q2NklblylN4brGbaXl5I4koLxqtO2EuGodN0dZ2B4w101PJnKQ1sOiite49/9XUG+BCvrIARAI5AkADTQE8lwCnJm0sruxVnb0E2lPjkHpNpdQ2EUjhYr1TtHTIHWmtu6B7Kq36V4zbw4HVBAxy+WDU1Tfy6Z2S0hmiT36zfACicJzit/NdC8/aleE5DTQhZHR1LazE76VzzxBs8liftgtcrQUpO2fMmOB6o7K6hQ3qdnz0pR9PYiukjQygnacFVe+wWesF/enY3NLWUYFzUj7b6KyV3g5yqKH1zC4ghACWRCggYZAnkto5nrJOZcLCM08MaHKu/fIbeQD+Bhqb4SqMrPI0RSkpSkHPloSNxeamEXUbgnJXDxXmXGf2mq6arNzyW3kIMnZndoVITkNtNQ6FbNSTdYD8hvMCprxhpw71wh5vBnrpoPh6PSBChigthSzE+xdqJH0SnH1kiNDSYz22oor3hZUHEbGFP55gQwyinYZiMpe5Re8Le5NmqMdh0AgcgINNATyXCDCxMMYKpxaHlSXW0D9401opKf38bYLx0BbO/V8phRtZqNQKYnp0Ew9lqWkk6MfB0WQGT0TobmXV3tYUUntVs7OaTb8C5TUNhZwZcxhzwjNLiFioVy3gGYZ4iwUck5PzmqD9NTm5FE7J1QSn0SOnglpI8+cR5ucI2IxsOmxVnbUGHolOrqBYd7j7yYNFB0OF1VvFrW7oPw5/29FBWifu7D0LX6JBjLCnMXvFRAIZBZAAw2BLDSoeBy3wgr9nRM0ocOhmKB+anpJ2gQhvhDq6dHfSmegSRtwKEQTQ+osL03qKgF3dIzailDQ2YuK1gOh0lVTR+2ZkMxaKPlhkdRWU5pydYoSZTZzlgKQnJ9X/hptcgpYUpF82yjSUJWZRe2ZkMxxFIG0nzKANRcLhdX3c2h+rJCmZBdPua3zI/j1SH8oOlEhGRXPDRRBR6KFpR8Jak6jHLlKOkIgkLkDDTQEsrCgIlHPHXS8WpE/nCg6FIS0amLj4RgyTjwlbfuG3ODwx9suKPi+4pRTIhRlaq3YmOFxaH67Z9yOIUc/zkh3D7UVoVtG5uRoxaHZ1k7mDPT9Kzeorab0sGKWJSyk5ccDyVzXSKDomrl7Adfpd0oHyg0KI7+NgkgroAEEXiJHz0RDfiG1LdCDwNBIA6kXTZru+lzurm8kv4dcoJLBsFw1uWXDrxK1GIl7IzGR9MRrCAQyr0ADDYEsKKhwgMfUEDY5osIh8mvSQIVojwXS/AU2bI8hk9tWR5vNvHXwfCWbzo6+llbqKRGKs3UkRytCI4NF7ZPQg6BQcvTj0GzvMsezIqCZgZ4YknGXU929qa0IhV00knO2mEq4rjG1Q1xaOuRQKdDsO0NSsLYukYYuFgrB9aQGTJc8JVNoKE/LoPZJqDLjPjl6JmjmsOVXkJZO1tWb8u+s/sRB+SivERX0oegsvzAQCERRoIGGQBYUZLSUm/MGv3g/ypthyf/MIGNI+69I40ZsQBsTtWEoPmsVcl6f+nc9UL5dRZ4cNGV64+2cyNGK0FJUQu2TULqXPzn6caSlvQbOqsQylYdSsgIC5ajCQeM4s64FkqPlJlxPqoGWcwY6/pITue1MirG8NL14xXBXt7RvJqFQHcPR3tnXWStLTaf2Sagq8z45eiZoLLg8AqOFvJCI0d45Jy5DIJDnHGigIZAFRdwVwclQ4mb9HRkrk/cHXEEL0rwXafgA6zuGCSsxVAw8kLRVcQNPdVaM1kA7k6MVgWahnsxZZJoUjgR7F3K04kirwgGsJDmUAk3GbW3ObOpvENCkcIiFcuUOSav1Nl15oZHUtGaa5a2EwDWf9VpSGvsr5ww0OymV2lYehV4wYEbFTgwNk3uEQCD/kEADDYEsICgirDXkpL8wkfKf4r5kDJGroBg6fg9p0kDq38d6dmH8bAzliYUi6h94QjJXrT1RehubqKdEaI5WtadBas8RBqbk6MehWUSI18yeM9ISc2MtL5FDKdBs6ddaUkqOlpsoUytqh4R4Y5Np9PSEXTSitp1SpIEZzfYuWdcCqU2mi3k7ltxGPqRd6kC5c6DLUqTOYUtTuJ5xSUIyb1yu6waBQP5BgAYaAllAROP8or3APU8k/ZOwyR4VyjWbhQ5eQRq/ROrXY92aGCcUQ0YxFJW2n/CMm0EsGDTL6ZKc3MjRikCTxxyopUOfKwxelXa5wnQMydGKI23xnMzNpfH6epRWU+ppmN3qNByaMnYy1zVisgr/3Qu4Tr8bjoDLizafOUd/Ulo6s9viuypTatnsslS5qnBUSd/1hqpbRuaVd+8JeTxyLxAI5B8eaKAhkIUCRZGxct6DtyaS/gUYaH7RboTTjC/GlwGCdhsi9R8jde9h3RrYmDOxjjBUx5D69x5odr5kvuisrqWeEqFkF09ytCLQzCIH4mv1ZAxFaGZkuaOj5GgFkVYzWGZlYj6HQ201pbnkCic5Sd1IRZ6qEfzxCWpDQhF6JuTomehvaQvW1qU2/7MffVO6vfqkUJP1gNoVIXZSKjl6JmjKuUwXGADU5uTOOtUEAoH85YEGGgJ5wqAIKhpDuG3ISJGgRo+Tvgi4Z1zpi4StvsgoG+F1YAiXWBo4AygPbTuB1L2PG+iurdjIBUzUCoLvWNtT/+oDladlkHtYQGgylVPdfcjRioAiiLRZZKD+1jZyg8dJ8/CltiI0xyHHWF8/tU9CbaXl5OjHmRgaoraakpxbBs4ITRE6eepgjEr/UNFm8hYap0m3IJTi5g1uK7kZLXW5+dR+CMksB05Asyc8oThbxyZWsaInBoFA/tGABhoCeZIIB8VDD0TtAYKq07zcDyZS/u9E8j9PGmigtP/lFnwhqNYRdYYgw0xUPDFDpWRBI9K8B7hnILRzMzb8AyaqxjBxpt8V6t9+oHRvGSUpnijAMlJPafLEZNXKkEmkoTm1W0IyTTAr+g61FaHCyChytCKwE1OofQZKtmiRWYJjpKeX2pBQuK4ROVoRaPYRLE+9S46mAAYk1IaE4i/JXU0FRe96X6b2MF2KbjtPM38s51benJFRaltCSc7uNIndEAgEMh1ooCGQJ4h4hMFjaXIylk+k/MdE0jTr/Kf+eSLlPzmZKvyy7xFOE3UeGh1Lw1cQEgb64VfY4AGMn4WhvJL4JKoDCJT4Nu4oXX7qE6WlmE09JUKZ/tfI0QqS6OhG7ZZQXW4BOfpxWtll1FaEIgxM5dzdmoqIzwfNqX0CJTt7kKMp0NTXi7WyJ0crAismntonobyQCHI0hc4aqak4Ka5e5Gjp8MbGbhlJHfYESr6ufc0t5GbSaWYVUzshVHgrmhwthRm3aQRnMpekc3rAFwz8h42zdUywd6nKzILT2xDIXwBooCGQJwgqnhD33xXUmfKLdnGzX+Ok/fd0G81JX8zJeYtfvE/YaIcM56MiDrk96GHAF238ctJAt0sMNCcYQ0Y7qmqoJoBQ0Z0Eci8LBc2G29nXg8jRCkKzaV+prPxX3vg4cEjUhoRmXTAOXGpqb4Sq7mWToynQ7Dsjj/+mgWapXIqbbAdMMxDK8A0gR9PSVVNHk3sDFGNhS62FJw2agVB+WCQ5Wgq5QWHU5oGSJYNzT4inAuxyupf/9DcC15B+2SsEAnn2gQYaAlkAUJTfLe6N5xfvl3hoIn/jb4Lqc+KBe4hggDrx/AgE6dRF6j+aNNBtm7DB/di4PYb0iQQCaRXQQs7ryVNp4UlQnzfzPsmB87HHODMqltqt/J1L2/wcKNLQbBZFynoamqSZcvA8Z0S2FettbKa2JQTOlhytCK0lpdQ+CYEPS46mQHMfZzEQkvZryZQKwm+R20jhYUUVtTkhmRtSTtFeVkFtTijO1pE/PkFuMDeK4xKpb1SZcY8cB4FAniuggYZAFg5ktIib/dpEMl6Fg8fajnJbZFThEI8ibSeQ+g8mDXTLZ9jAPmxECxPjtepyboZQ/zBP+YC5197qqKzO8A2ItbLPC42cGJSxJTVBTbbUIgmzLv07RXVWDrVbQvKsUKRZfwaU4XdFoR/WwRBFWvJGoNwus7dJqoGeY8p4f4vUJGYgAVdGcjbNBLb8E71TgAub4ka7MbiWTldNHbnZTNDklsh5zTFJWcNIA6kbzcRfcpLz2y4PDfmFM07Az7GqIwQCeepAAw2BLByoaITH2slJJepAO2IiWWW8eJVoy36kbv2kgW7eKDHQRzFRFbAB9PUEkp09ZC5ikwYwdiTHAwyHPLPaNIUX2Akp5GgFodkx+7aJJTmagkggkLrBtUS5weFyeuiBtnaaFY1AwL+S28wETQ70HKv+8cbGqX1OSWbRkrLkNGorQrMbCE0MDdNf/GhzG3mqjnTXS/3O3wu4To6WDs0HDJSU2AOjR3IbBeFPTICRJ7VzQjK3z4RAIM840EBDIAsIiggmdyL8L3F/OipjJ0IUHb6NNG4m3DNuoJs+wvr3YMOHMV48huIJ0ylu3tS/zVOKsbCVaZVIDHd1Z/pfo3YFlOjgOkORkMcpSUimNiRUlZlFjlYQmh25A7V05MmjlZlLkO7lR1+cGDjsqnvZIef1qG2nJL+Toyljd8fGgRytINIyfALlqGRHk9vNiokjR8sHTfoyIXnq0NHsFZ8ha9ua6Qh5POCSqZ1M1/0rN0b78JrrijLa2wuuEv1WjvJ/SSAQyLMJNNAQyIIi7o7iZKhwH7yDjFdJT32WgHLRLgOkYeOUgUYaPsT6dmHDh7AJewzpARF9La0z/kA8paCzF/PDIsf6B8idUwBeITc4XFpSL6Ghjk5ys8cpjIyitiLUxJRh2mSCiMU0e3MMtD8kN6Ag4PJofrsnFKZjCJzcGMU5cUfHarIfxFpeojaZLnCGIz29pLbSEItE0jb8A+dJjlYQms0Iy1JkbNrHuB1DbUVIHpsrDWmr9wiBSyfTsPa3tlMbElK0gGMjg0XthCwtnUy/Ky3FbJkJUWKhqLu+gZ2QkmDvQu5kJs39vwMEAnm6QAMNgSwoyHg1N+ctftn3KI/ejKIoh4G07EPq8S1UJlX/PtazExs6hI3+hImKMFQI4hi3pHqdP6Wlk+bpW3Uve6CtnfRD+Uh3T11uAalKgDQ9rJBRbvne5Zlnr4HkTHKlR9r2MUCNhUxy9Ew05EtdHkfSbRPLNA8fcGXAMdqMdmPqaSpVsLCxtHlQMC6SM59EGtIqhQPlhcrIYy4Iv0VtRWguqTgCLhdcVWqfU5KZx0yT9JLm4UuOlsW9gOvUfmYUGFgmObmBEWZ5Wgb4pk0JDEXAk8A00wztqIq/5DTHmwuBQJ460EBDIAsKKhoRlJ0QPbyGiuiqNKDIGNpjgzZ89qd7JrI4ujWwoYN4FgfHG5+ERhGxUJTo4Er9I02jcF1j4AiB6OebqZK5uTTNjtky28oDTSU7+VML5LdNigp4LEXLkwEvRe2HEH0yiUwKb0VT+yQksxRdXkgEtRUhRUcIJGjKaODS0qFPtR/q6CI3eSR5FpKSEPH5ck4Yz6PCdY3k/40CAoE8s0ADDYEsMCgyzED5XRgq3WmhQnz/lJZdj00/Ewaa2EsFGOiRnzH+XQydANETQ8P0E3vzImBeyef5OGP9A9RWhIBTV9RZzkhZajq1c0Ly133jczixVnbUHuaoSEMzcCPIbyaLdC8/aleEZCbM0FOVeZ/aJyE8nZ2W/DCpq9/mvld89vUgardTYtyKITeYBk0evPxfgOlwRkZpcl3mXeBLIk+uEQQCefaBBhoCecZARRivHGn/CanfQHLPuIFu+QQb2IsbaKCxi5iQhWE80Gasr/+JeugEB1eZtc+66xuoDQnF2zmTo2cFzfYxYTqGqKw1jlMAr09fRkNRheoYKrSj3hRZV29SeyM0x43xaBbtRZvZkKMfhxUTR21FaO4FjIFnBTeL2vPkuZnTnRsY/EjLGs+5EUyOlg/+xESyiye1w3lXqrvPHH9VgEAgzw7QQEMgzw4ohnIl7vmPqc1TyKpf/2cWx/ARbNwA99CT89BDwKdS/2zPXdk3guWpcTExKLWmRFFsPDl6VgCvQ7NoUqEskZGe3vkacoReMOhtbCK/gXw8CAqldkiou66BHK0IA+0PqX0SkrmXSt2DPGorQvV5MnZNlweacofAW5OjH0da5ZlmVjE5VG4QsRjf/Fz6V2uOAhe8oYAhs4gNBAJ5joAGGgJ5FkBw6yzqREcTkdZvkfoPyb55+iR080a8FsfQoUfz0Ocwfgom7gA9iATc3OBw6t/vWSvGwrattJx8stLJmGnhWsg5PXnKgMgJTdJwfyu+v4z8TAwNJzm5UftRSNHmNnPJtZhxmzpCo71zypTFJ2spfRIK1zMmRz/OaF8/tRWhoc4ucrTiiIUiaenyMncaH3zYEUqZwE739pf/9wdp9DW3KLqcQKZuG1tUZWbJU+IaAoE8X0ADDYE8RQjf3I/xa9HRBLRLF238HKmf3DaFRmjrZ2jPDnxb76GDEid9DBu/hPHTMHEDhgw8LC+JkVVtTaaAda57kKdo4jJ/fIK8KktLB/RDjpsDRbEzlygO1taVmWRCRSwSFcXGK7qYckoPboYAn0ruVBGkFTaeex1owC0jC2rPeOfW9uRQCjOu15SZBy8/M242HqSl01ldSw6lMNzVDYZqROGLSENzMAgBjpwcNDtQFIwYk5zdqeemkMA36t7la+3llbDaBgTyVwUaaAhk4UEwhPPIN8ejPeZIywGk4WN5rPOfavwQbduEdW3FgJPu343vUDh4GBs+jY27YvwUhF9dm50Wa6W4jdbSSff2Bx5i1n/4geeuyX6Q4RsAnHTW1ZtdtfXkiLkx1j8Qcm6GfUwKI6PIoXIz1NEpbfsYaUpx8+qun1OKxRTUmnEh5/V7G5vJcYojbS1g0Z0EcigFMBpJ8/Sd3gq4Z3kyeeQHz5qY1j8wxHiegyLMfdZZGsCjl8Qn0fzcMaPCLhqB73x9XiF3lK7GDgQC+QsADTQE8oRAJaKAilF+AzoSg2+S0rwHz3VWyDeTtR6v1NG4AW3eiLZ9jnZ8g3VroH17sMFfsNFLKOdOV+X9gohIaT+X/yktnWQXz4r0zImhIfIJP3s0FjJJc8bAtYhFc52DHOnuAc4y1kpqqelAycQ8Myp2oE2xXBEZoCgYchAlrkPO62X6XRl82EGOmRXjg4PUDbTBG8k/VQ8+KVHwGBhK8mvzQVdNXUH47axrgSUJyfOY5zOP8MbGH1ZUgv8aucHhYERxx8aBKAFJKNXdG4wVWTFxwPoPtD+c9bATAoE8d0ADDYE8GcRDmLAFQ/9/e3ceY1dVB3BcCwgKiqIGJZIIkbIUShtbdpBNBAT+UVQkQTFo2DRGY4wkkhA1JsR/0ARcojFGQwSKKy0tbelCN6C0023aTl9hptuULjPtvP3dc67zptCUR7fTzkwhfj65f/Wd3EzSf745+d1zmkdktPx7WP/90HHp4XXzvp/+13aMCx3jQ+Hi8OqVcdO9eX1t/99Q6untXLxk2dTpC554uj8F+otz+u/+uOtiiK62pQdfVO8Q/T238F//7f/7Fzz59GDtBO9W3rFzw4qVq2bPWTxxcv/TNmlKf0H2/0tl587Wpe94zWmHR3+/a8++P6bn/31CrfQu+78GeAcS0DA0tv8lbr47ry1tHku3p6w3bHoorL0lrPncwMeCg5fRK8eG9jFZ++hsxXnZsvMaS0bXFo2rt38zlgutEc//n6GbdgD4PySgYSiE2P3TuO6GvDQhj2/7yCyUY2lh3PpY6LorFG4MHZcfeknviuYVo7Nl5zTaRtZfPq264LTqvLMq8y+pLv9eY8vk2OhVzwAwuAQ0DIFYCZ13xM6r8t6f52Hfk52hL5bm5lsfieu+HQo3DMx1tF49uI+nv5vPz5aNaiw+o/7SqdUXPlqZcVJp+inlOeOry+5rdP8zVrvjfm46BAAOg4CGIVDvDGtvbt4a2HNvXl/TPHZjf2KebYvFWaH7Z6Fw014vIHzLs3Jstuyc2vxPlqcdX3r2qOLEo0vTTqksvLWx4fFYfq11YgQAGGwCGgZf3DklFq4Lay7Kt30tr83PY711xV6Faiy+ENfdHTou2/dEx9hsycjK8ycUJ763+Mx7ihPfV5kzPtv4eKxvM6oBAMNDQMOgi3HLb0LHFaHjguYJzeUJeSi2LtmPelfc9OOBwei9NHS2/NzK8x98o54nHVNdcG3oOehABwAGg4CGwRZ2hM47w6rxoWNcvvnmvO9XediStj1cXxfW3988IvptAV1bcErp2aMH9p5HlOdcmPUsMLMBAMNMQMPgymLPU7Hw+Wbvrv5svumGvOeuvN6W52mZG0vzmtcTrh7/loBuH11+c/u5NPUT2aYJeXCmLwAMNwENgyfW8+qy2Hn77vBtXg247ct53yN5tulAnxK+VWzELb+Oa67aM6AbbWeWnjuuuf38zIjqsvtidUguhwMA9k9Aw2DoT+ewIxZnh6479zxGI669pDkG3XN7XvpDnnXlsXrwGR2r7fG12/Y82K6+8NOlyccMbD+fnG2bEYPRZwA4AgQ0HI6Yx1qe9cTi83HTA6FwbVjVepBzfO3y5iT09lvz3h/mpafyeiGPfQOf/R1wKjqL3Q82D4feHdAvvjEAXX3lq7HS1bocABgWAhoOVcxiozv2TmjuOjczdy+HZrzxrB4XChfHzivjhuvz12/Pd/wyr0zPs9cPvBu949+h8IXd79n9BWG987exsbN1MQAwLAQ0HKpGd1h3z8FdHzg2rBwT2s8P7aMHnrHZ6gvDhu/kjfWt72xRXdX8lPDNNK/NO7l5c8qkY8P2eXk8UHwDAENDQMOhitXY91zY8KNQ+OJARo/f+yb0yjGNtjOq806uzDyx+cw4qTL71OqLl2YbHs2zntZ3tgiV2PWt3WMh1TkfK00aUZ41KhTbW1cCAMNFQMNhCnnt1bz3ibj+u6FwTesM9MoxtRc/NfDl34jS5A9V5oyvrfxJtnVarPccxAx0U9j4QOi4ZNfbKrNOKk4aUV10WygbgAaAI0ZAwyCJ5dg3NXZ+Pay6YHdA1xd/pjTl2OLEo8qzxzTW/TnWug889/xWcdufwpqrd7V4ZeZHihNH1FY9GOtbW9cBAMNFQMMginl5UXjtK3sMXXy8OOmoytxLw45XDu3KwFicGQo3Nt/Wfn5lxon9Ld7Y+GQeKq3rAIDhIqBhcIXY83hYc83AnvH5lZkfLk05Idv0VMwO9crAxrr46pf635atOLc8/YTS1JNDz7w8Zq3LAIDhIqBhsIW+0HlHWDUuWzG6P3krcy+LxdUHOfG8FzEMXM4yLls+qjztA5U5F4W+5Yf+NgDgsAloGAJbHolrrmjuGU97f739B7G2pXVBghA3/yJ2XN5YenZp6nHVJXfG6obWJQDAMBLQMPjizqmhcF22fFRp6vGNDX+NWal1RZLtf4uFaxtLzipNObZeeDjWt7cuAACGkYCGIVDvCmtvaSw9uzLrjNAz/9A+H9wtlheEtTc12kaWnjuh0f20LwgB4MgS0DAEYi12faPRdmZ14fWx3Nn6a6rG5vDqrfVXTq/MHhm2zz3MHAcADpOAhqEQYvdDjUVn1QsP5Yc/cRFLYf39tYWnV166OhRX59EXhABwJAloGBKxd0Jjxc2xd04e662/pYpZ3Pxw7eWRteX3xOrG1l8BgOEloGGIhIFh5bR7B/cl9v6j9vJ52brH8saO1t8AgOEloOHdIGzPtv4nVrpcoQIAR5yAhncLo88A8I4goAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEggoAEAIIGABgCABAIaAAASCGgAAEjwP/CmlV0myb88AAAAAElFTkSuQmCC)\n",
-        "\n",
-        "This notebook is meant to show how you can quickly parse, chunk, and RAG on arxiv papers yourself!\n",
-        "\n",
-        "We use some awesome open-source repositories in this notebook. The stack that this notebook uses is the following:\n",
-        "\n",
-        "- Chonkie (of course)\n",
-        "- Docling (for PDF conversion)\n",
-        "- Model2Vec (for embeddings)\n",
-        "- Vicinity (for indexing)\n",
-        "- Together Client (for LLM calls)"
-      ],
-      "metadata": {
-        "id": "gcVXWGG6MopX"
-      }
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3IDX5QjwMzNp"
+   },
+   "source": [
+    "## Installs, Imports, Inits and Utils"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "hMS-5L6tj1du"
+   },
+   "source": [
+    "Installation takes a looooooong time, but only the first time you try to install. You may even be required to hit restart on your colab notebook. Don't worry, that's completely normal! Go ahead, grab a cup of coffee and await the CHONK!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
     },
+    "id": "9tN0VqzkNM9V",
+    "outputId": "5eb3b062-ba47-4873-a909-b46e822c153e"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "source": [
-        "## Installs, Imports, Inits and Utils"
-      ],
-      "metadata": {
-        "id": "3IDX5QjwMzNp"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Installation takes a looooooong time, but only the first time you try to install. You may even be required to hit restart on your colab notebook. Don't worry, that's completely normal! Go ahead, grab a cup of coffee and await the CHONK!"
-      ],
-      "metadata": {
-        "id": "hMS-5L6tj1du"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "!pip install -q chonkie docling model2vec vicinity together rich[jupyter]"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "9tN0VqzkNM9V",
-        "outputId": "5eb3b062-ba47-4873-a909-b46e822c153e"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m48.2/48.2 kB\u001b[0m \u001b[31m3.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m51.2/51.2 kB\u001b[0m \u001b[31m3.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m121.9/121.9 kB\u001b[0m \u001b[31m10.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m73.8/73.8 kB\u001b[0m \u001b[31m6.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.8/7.8 MB\u001b[0m \u001b[31m60.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m93.2/93.2 kB\u001b[0m \u001b[31m6.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m78.8/78.8 kB\u001b[0m \u001b[31m6.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m22.4/22.4 MB\u001b[0m \u001b[31m15.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.9/2.9 MB\u001b[0m \u001b[31m46.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m42.1/42.1 kB\u001b[0m \u001b[31m2.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.5/4.5 MB\u001b[0m \u001b[31m48.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m431.7/431.7 kB\u001b[0m \u001b[31m23.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.0/2.0 MB\u001b[0m \u001b[31m38.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.9/2.9 MB\u001b[0m \u001b[31m60.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m244.3/244.3 kB\u001b[0m \u001b[31m15.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m472.8/472.8 kB\u001b[0m \u001b[31m31.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m543.2/543.2 kB\u001b[0m \u001b[31m29.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m47.3/47.3 kB\u001b[0m \u001b[31m3.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.2/1.2 MB\u001b[0m \u001b[31m49.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m165.1/165.1 kB\u001b[0m \u001b[31m12.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m422.9/422.9 kB\u001b[0m \u001b[31m26.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m912.2/912.2 kB\u001b[0m \u001b[31m32.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m286.8/286.8 kB\u001b[0m \u001b[31m19.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.6/1.6 MB\u001b[0m \u001b[31m41.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m272.8/272.8 kB\u001b[0m \u001b[31m19.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m134.8/134.8 kB\u001b[0m \u001b[31m11.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m119.4/119.4 kB\u001b[0m \u001b[31m10.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25h"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Get all the required imports here\n",
-        "from chonkie import RecursiveChunker, RecursiveRules, RecursiveLevel\n",
-        "from docling.document_converter import DocumentConverter\n",
-        "from google.colab import userdata\n",
-        "from model2vec import StaticModel\n",
-        "import numpy as np\n",
-        "import os\n",
-        "from pprint import pprint\n",
-        "from rich.console import Console\n",
-        "from rich.text import Text\n",
-        "from together import Together\n",
-        "from transformers import AutoTokenizer\n",
-        "from typing import List\n",
-        "from vicinity import Vicinity, Backend, Metric"
-      ],
-      "metadata": {
-        "id": "2Alnp3TMNpcr"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Initialize the rich text console for better printing\n",
-        "console = Console()\n",
-        "\n",
-        "# Set your Together API key to use Deepseek R1 with it~\n",
-        "os.environ['TOGETHER_API_KEY'] = userdata.get('TOGETHER_API_KEY')\n",
-        "\n",
-        "# Initialise a Document Converter\n",
-        "converter = DocumentConverter()\n",
-        "\n",
-        "# This chunker would recursively split the text to get 256 tokens or less per chunk\n",
-        "rules = RecursiveRules(\n",
-        "    levels=[\n",
-        "        RecursiveLevel(delimiters=['######', '#####', '####', '###', '##', '#']),\n",
-        "        RecursiveLevel(delimiters=['\\n\\n', '\\n', '\\r\\n', '\\r']),\n",
-        "        RecursiveLevel(delimiters='.?!;:'),\n",
-        "        RecursiveLevel()\n",
-        "    ]\n",
-        ")\n",
-        "chunker = RecursiveChunker(rules=rules, chunk_size=384)\n",
-        "\n",
-        "# Initialise a model2vec model for encoding sentences for retrieval\n",
-        "model = StaticModel.from_pretrained(\"minishlab/potion-retrieval-32M\")\n",
-        "\n",
-        "# Initialise the Together client to call upon Deepseek R1\n",
-        "client = Together()\n",
-        "\n",
-        "# (Optional) Initialise the tokenizer for Deepseek R1\n",
-        "tokenizer = AutoTokenizer.from_pretrained(\"deepseek-ai/DeepSeek-R1\")"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 333,
-          "referenced_widgets": [
-            "f3f468050cb5486589c68d273fa859a6",
-            "a54f3fbe457c4eb180aaeebb3d849ba0",
-            "ebbfe03efc654c08a13ad2d14b7b5c31",
-            "5a912a0e334d4ccfb9df57b27a22f38a",
-            "e3203d311565460d894ee217af5b5f42",
-            "d36682aa48f04f3dbc1c9c67ec6b12f9",
-            "adcd55623850471eb401625e37094039",
-            "97c14d92f1314350a869fa597b5de66c",
-            "12b10bf1df0542899733ea423889ddce",
-            "5727087483534a61a3a68ce3a8763cd6",
-            "509b942cf9e64a0c9f4ae2579a986639",
-            "8b00bb6eca4b4b68b61fae4dcaafe949",
-            "d2badcdaf80e4c759aa829f450c1807b",
-            "6be572d089be4626ab684e4721416488",
-            "66a7d89614e94d8491302a797a4c12e5",
-            "13e1bdf79aff423c9624874cb9c9a870",
-            "5a3fd46acb0c447790c980a98f62e361",
-            "97112c2b170148e5b937afc4da6ab1c4",
-            "87a26b89a5cb4d518cd9bf2b330bd498",
-            "9fc9f9eaec244b0eb4c92c20301c6e63",
-            "b1a1836c316342109ee8718629380efe",
-            "f67a93d013984b40b3055eb5c546fec4",
-            "9aec040202fb4a58973ede6f4d760707",
-            "a8bc59e034fe4daeaa00bfeadd2635f6",
-            "8d15667d78bc400080d7b4c6bdb396b2",
-            "0e10ceb014ed428891a8cf05c2a2251e",
-            "6be64614024c438daaea95a47b144c04",
-            "708454183e4b460f90f7fa3f430bc332",
-            "cbcec8f8093c4a92b211ea0fb8885a3a",
-            "20d7b3de1705424c9e61db230c43fd95",
-            "8698fbf252024bea85051703f9aacbf7",
-            "34e293cc15484477b940eb870743dcdc",
-            "f39f8a5a039a4b4e8b9ca06cc874a465",
-            "a3eacad2d39449d0be3ba3e606dc5cf7",
-            "ac5ee023c9c943a0a5ed531fea511b1a",
-            "e44835492ff645f8a588a7d7ec1f04b5",
-            "d2610ed202794ec2918482e18ca457fc",
-            "6c1da5303cad44098dafd87763b609f7",
-            "4b6bd295aba748bd9670cd06a69682a9",
-            "dec5a689253f41acaf392d1ef20f494b",
-            "7d0bf8146d2747f2b518ddb43f203c88",
-            "de9b6916a9ec4d788ba0c07b4d397480",
-            "8d0b2d93f67c4ff2a633660782125131",
-            "b568a2f59a154ddeafb78710e1518604",
-            "d3f68b3fb7b4494294922e06de7dbe53",
-            "c49defa1fcea4d30bdec9435d651e2b1",
-            "90d2e938d0c1476588c088acf1b86685",
-            "30c134be926948b3959ce7a723c0ae8a",
-            "9cbcc6b7d1354e5ea98eebf487d2a94f",
-            "ebed0e46009745ae9818d16a9dade7ef",
-            "755799f1e6b14b2f91f19edf06964436",
-            "0937dafccc1547069a553c0421028172",
-            "4003e08660c64d10a18d74bd47f19275",
-            "5de1ff0789f547e7a6147888e08aca64",
-            "985458e3563244c9b94525d831fd90dc",
-            "ca28c121e84e425185a4d801c3930b69",
-            "dc7fdda7a5354621978c17ec22ed0330",
-            "7ae08b4d31924479809eb7d3f2fb38fb",
-            "ce4b6e104d7b433da4eb1ee3a7278182",
-            "2d74a3e80b9646be88ed4bc5158ff8a2",
-            "3e30645b7a384ed48129e7afa471a982",
-            "9324441028b1496e87c7059bcd1b371b",
-            "8a3bb9d63ba640c6a0c63c7bd08d50cf",
-            "a0f4ea3ee6f04fd4ba0e5cb37f24b343",
-            "853eb421b8364fe0a7e3a2e91be79aaf",
-            "51be8798d9b8426081c9cb8955624b9c"
-          ]
-        },
-        "id": "SSgotkx6dvt3",
-        "outputId": "7fd5fa58-4754-4c8e-efec-1c04133bf81e"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.10/dist-packages/huggingface_hub/utils/_auth.py:94: UserWarning: \n",
-            "The secret `HF_TOKEN` does not exist in your Colab secrets.\n",
-            "To authenticate with the Hugging Face Hub, create a token in your settings tab (https://huggingface.co/settings/tokens), set it as secret in your Google Colab and restart your session.\n",
-            "You will be able to reuse this secret in all of your notebooks.\n",
-            "Please note that authentication is recommended but still optional to access public models or datasets.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "model.safetensors:   0%|          | 0.00/129M [00:00<?, ?B/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "f3f468050cb5486589c68d273fa859a6"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "README.md:   0%|          | 0.00/16.7k [00:00<?, ?B/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "8b00bb6eca4b4b68b61fae4dcaafe949"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "config.json:   0%|          | 0.00/202 [00:00<?, ?B/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "9aec040202fb4a58973ede6f4d760707"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "tokenizer.json:   0%|          | 0.00/1.49M [00:00<?, ?B/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "a3eacad2d39449d0be3ba3e606dc5cf7"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "tokenizer_config.json:   0%|          | 0.00/3.58k [00:00<?, ?B/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "d3f68b3fb7b4494294922e06de7dbe53"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "tokenizer.json:   0%|          | 0.00/7.85M [00:00<?, ?B/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "ca28c121e84e425185a4d801c3930b69"
-            }
-          },
-          "metadata": {}
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# A wrapped up print function\n",
-        "def rprint(text: str, console: Console=console, width: int = 80) -> None:\n",
-        "  richtext = Text(text)\n",
-        "  console.print(richtext.wrap(console, width=width))"
-      ],
-      "metadata": {
-        "id": "9rxDtTGhlUnE"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# A simple utility function to make the prompts from the given chunks\n",
-        "def create_prompt(chunks: List[str], query: str) -> str:\n",
-        "  prompt_template = \"\"\"<instructions>\n",
-        "  Based on the provided contexts, answer the given question to the best of your ability. Remember to also add citations at appropriate points in the format of square brackets like [1][2][3], especially at sentence or paragraph endings.\n",
-        "  You will be given 4 passages in the context, marked with a label 'Doc [1]:' to denote the passage number. Use that number for citations. Answer only from the given context, and if there's no appropriate context, reply \"No relevant context found!\".\n",
-        "  </instructions>\n",
-        "\n",
-        "  <context>\n",
-        "  {context}\n",
-        "  </context>\n",
-        "\n",
-        "  <query>\n",
-        "  {query}\n",
-        "  </query>\n",
-        "  \"\"\"\n",
-        "  context = \"\\n\\n\".join([f\"Doc {i+1}: {chunk}\" for i, chunk in enumerate(chunks)])\n",
-        "  prompt = prompt_template.format(context=context, query=query)\n",
-        "  return prompt"
-      ],
-      "metadata": {
-        "id": "aV3bBbjXfU4F"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Step 1: Use docling to convert PDF -> Markdown!"
-      ],
-      "metadata": {
-        "id": "_OQuHrrJNswJ"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "This step takes about 20-30 seconds depending on your PDF."
-      ],
-      "metadata": {
-        "id": "XFAq-C0phEnO"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Given a source PDF link, we can convert it to Markdown which is easier to use!\n",
-        "source = \"https://arxiv.org/pdf/1706.03762\"\n",
-        "result = converter.convert(source)\n",
-        "text = result.document.export_to_markdown()"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "HLWqslfsNzOI",
-        "outputId": "a8a95747-9054-4197-9524-37b3455436a6"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "WARNING:easyocr.easyocr:Downloading detection model, please wait. This may take several minutes depending upon your network connection.\n",
-            "WARNING:easyocr.easyocr:Downloading recognition model, please wait. This may take several minutes depending upon your network connection.\n",
-            "/usr/local/lib/python3.10/dist-packages/torch/utils/cpp_extension.py:1964: UserWarning: TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. \n",
-            "If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'].\n",
-            "  warnings.warn(\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Lets have a quick look at the text we'll be working with~\n",
-        "rprint(text[:2000])"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 833
-        },
-        "id": "JOW-yKPFWOow",
-        "outputId": "6886bbcb-176f-4695-bb87-3e39aeb18a70"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "Provided proper attribution is provided, Google hereby grants permission to \n",
-              "reproduce the tables and figures in this paper solely for use in journalistic or\n",
-              "scholarly works.\n",
-              "\n",
-              "## Attention Is All You Need\n",
-              "\n",
-              "Ashish Vaswani ∗ Google Brain avaswani@google.com\n",
-              "\n",
-              "Noam Shazeer ∗ Google Brain noam@google.com\n",
-              "\n",
-              "Niki Parmar ∗ Google Research nikip@google.com\n",
-              "\n",
-              "Jakob Uszkoreit ∗ Google Research usz@google.com\n",
-              "\n",
-              "Llion Jones ∗ Google Research llion@google.com\n",
-              "\n",
-              "Aidan N. Gomez ∗ † University of Toronto\n",
-              "\n",
-              "aidan@cs.toronto.edu\n",
-              "\n",
-              "Łukasz Kaiser Google Brain lukaszkaiser@google.com\n",
-              "\n",
-              "∗\n",
-              "\n",
-              "Illia Polosukhin ∗ ‡\n",
-              "\n",
-              "illia.polosukhin@gmail.com\n",
-              "\n",
-              "## Abstract\n",
-              "\n",
-              "The dominant sequence transduction models are based on complex recurrent or \n",
-              "convolutional neural networks that include an encoder and a decoder. The best \n",
-              "performing models also connect the encoder and decoder through an attention \n",
-              "mechanism. We propose a new simple network architecture, the Transformer, based \n",
-              "solely on attention mechanisms, dispensing with recurrence and convolutions \n",
-              "entirely. Experiments on two machine translation tasks show these models to be \n",
-              "superior in quality while being more parallelizable and requiring significantly \n",
-              "less time to train. Our model achieves 28.4 BLEU on the WMT 2014 \n",
-              "Englishto-German translation task, improving over the existing best results, \n",
-              "including ensembles, by over 2 BLEU. On the WMT 2014 English-to-French \n",
-              "translation task, our model establishes a new single-model state-of-the-art BLEU\n",
-              "score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the\n",
-              "training costs of the best models from the literature. We show that the \n",
-              "Transformer generalizes well to other tasks by applying it successfully to \n",
-              "English constituency parsing both with large and limited training data.\n",
-              "\n",
-              "## 1 Introduction\n",
-              "\n",
-              "Recurrent neural networks, long short-term memory [13] and gated recurrent [7] \n",
-              "neural networks in particular, have been firmly established as state of the art \n",
-              "approaches in sequence modeling and transduction prob\n"
-            ],
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Provided proper attribution is provided, Google hereby grants permission to \n",
-              "reproduce the tables and figures in this paper solely for use in journalistic or\n",
-              "scholarly works.\n",
-              "\n",
-              "## Attention Is All You Need\n",
-              "\n",
-              "Ashish Vaswani ∗ Google Brain avaswani@google.com\n",
-              "\n",
-              "Noam Shazeer ∗ Google Brain noam@google.com\n",
-              "\n",
-              "Niki Parmar ∗ Google Research nikip@google.com\n",
-              "\n",
-              "Jakob Uszkoreit ∗ Google Research usz@google.com\n",
-              "\n",
-              "Llion Jones ∗ Google Research llion@google.com\n",
-              "\n",
-              "Aidan N. Gomez ∗ † University of Toronto\n",
-              "\n",
-              "aidan@cs.toronto.edu\n",
-              "\n",
-              "Łukasz Kaiser Google Brain lukaszkaiser@google.com\n",
-              "\n",
-              "∗\n",
-              "\n",
-              "Illia Polosukhin ∗ ‡\n",
-              "\n",
-              "illia.polosukhin@gmail.com\n",
-              "\n",
-              "## Abstract\n",
-              "\n",
-              "The dominant sequence transduction models are based on complex recurrent or \n",
-              "convolutional neural networks that include an encoder and a decoder. The best \n",
-              "performing models also connect the encoder and decoder through an attention \n",
-              "mechanism. We propose a new simple network architecture, the Transformer, based \n",
-              "solely on attention mechanisms, dispensing with recurrence and convolutions \n",
-              "entirely. Experiments on two machine translation tasks show these models to be \n",
-              "superior in quality while being more parallelizable and requiring significantly \n",
-              "less time to train. Our model achieves 28.4 BLEU on the WMT 2014 \n",
-              "Englishto-German translation task, improving over the existing best results, \n",
-              "including ensembles, by over 2 BLEU. On the WMT 2014 English-to-French \n",
-              "translation task, our model establishes a new single-model state-of-the-art BLEU\n",
-              "score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the\n",
-              "training costs of the best models from the literature. We show that the \n",
-              "Transformer generalizes well to other tasks by applying it successfully to \n",
-              "English constituency parsing both with large and limited training data.\n",
-              "\n",
-              "## 1 Introduction\n",
-              "\n",
-              "Recurrent neural networks, long short-term memory [13] and gated recurrent [7] \n",
-              "neural networks in particular, have been firmly established as state of the art \n",
-              "approaches in sequence modeling and transduction prob\n",
-              "</pre>\n"
-            ]
-          },
-          "metadata": {}
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Get the total deepseek tokens for the entire PDF\n",
-        "total_text_tokens = len(tokenizer.encode(text))\n",
-        "rprint(f\"This PDF contains: {total_text_tokens} tokens\")"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 33
-        },
-        "id": "Gul7zYCSnOXE",
-        "outputId": "ab7e9b6a-d396-490a-9875-400d52ac0940"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "This PDF contains: 9928 tokens\n"
-            ],
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">This PDF contains: 9928 tokens\n",
-              "</pre>\n"
-            ]
-          },
-          "metadata": {}
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Step 2: Chunk your texts w/ Chonkie!"
-      ],
-      "metadata": {
-        "id": "u76kuds3YYqA"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# This is all it takes to chunk!\n",
-        "chunks = chunker(text)\n",
-        "print(f\"Total number of chunks: {len(chunks)}\")"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "O6M4GdxkOBMI",
-        "outputId": "5ab5a9e8-78b1-45a3-823a-96d6e72fbdef"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Total number of chunks: 58\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Let's have a quick look at our chunks\n",
-        "for chunk in chunks[:4]:\n",
-        "  rprint(chunk.text)\n",
-        "  print('-'*80, '\\n\\n')"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
-        "id": "TSCJbBIhYdfD",
-        "outputId": "3b3d9168-c8ec-40c4-b6af-f7402337fe2a"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "Provided proper attribution is provided, Google hereby grants permission to \n",
-              "reproduce the tables and figures in this paper solely for use in journalistic or\n",
-              "scholarly works.\n",
-              "\n",
-              "## Attention Is All You Need\n",
-              "\n",
-              "Ashish Vaswani ∗ Google Brain avaswani@google.com\n",
-              "\n",
-              "Noam Shazeer ∗ Google Brain noam@google.com\n",
-              "\n",
-              "Niki Parmar ∗ Google Research nikip@google.com\n",
-              "\n",
-              "Jakob Uszkoreit ∗ Google Research usz@google.com\n",
-              "\n",
-              "Llion Jones ∗ Google Research llion@google.com\n",
-              "\n",
-              "Aidan N. Gomez ∗ † University of Toronto\n",
-              "\n",
-              "aidan@cs.toronto.edu\n",
-              "\n",
-              "Łukasz Kaiser Google Brain lukaszkaiser@google.com\n",
-              "\n",
-              "∗\n",
-              "\n",
-              "Illia Polosukhin ∗ ‡\n",
-              "\n",
-              "illia.polosukhin@gmail.com\n",
-              "\n",
-              "##\n"
-            ],
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Provided proper attribution is provided, Google hereby grants permission to \n",
-              "reproduce the tables and figures in this paper solely for use in journalistic or\n",
-              "scholarly works.\n",
-              "\n",
-              "## Attention Is All You Need\n",
-              "\n",
-              "Ashish Vaswani ∗ Google Brain avaswani@google.com\n",
-              "\n",
-              "Noam Shazeer ∗ Google Brain noam@google.com\n",
-              "\n",
-              "Niki Parmar ∗ Google Research nikip@google.com\n",
-              "\n",
-              "Jakob Uszkoreit ∗ Google Research usz@google.com\n",
-              "\n",
-              "Llion Jones ∗ Google Research llion@google.com\n",
-              "\n",
-              "Aidan N. Gomez ∗ † University of Toronto\n",
-              "\n",
-              "aidan@cs.toronto.edu\n",
-              "\n",
-              "Łukasz Kaiser Google Brain lukaszkaiser@google.com\n",
-              "\n",
-              "∗\n",
-              "\n",
-              "Illia Polosukhin ∗ ‡\n",
-              "\n",
-              "illia.polosukhin@gmail.com\n",
-              "\n",
-              "##\n",
-              "</pre>\n"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "-------------------------------------------------------------------------------- \n",
-            "\n",
-            "\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              " Abstract\n",
-              "\n",
-              "The dominant sequence transduction models are based on complex recurrent or \n",
-              "convolutional neural networks that include an encoder and a decoder. The best \n",
-              "performing models also connect the encoder and decoder through an attention \n",
-              "mechanism. We propose a new simple network architecture, the Transformer, based \n",
-              "solely on attention mechanisms, dispensing with recurrence and convolutions \n",
-              "entirely. Experiments on two machine translation tasks show these models to be \n",
-              "superior in quality while being more parallelizable and requiring significantly \n",
-              "less time to train. Our model achieves 28.4 BLEU on the WMT 2014 \n",
-              "Englishto-German translation task, improving over the existing best results, \n",
-              "including ensembles, by over 2 BLEU. On the WMT 2014 English-to-French \n",
-              "translation task, our model establishes a new single-model state-of-the-art BLEU\n",
-              "score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the\n",
-              "training costs of the best models from the literature. We show that the \n",
-              "Transformer generalizes well to other tasks by applying it successfully to \n",
-              "English constituency parsing both with large and limited training data.\n",
-              "\n",
-              "##\n"
-            ],
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> Abstract\n",
-              "\n",
-              "The dominant sequence transduction models are based on complex recurrent or \n",
-              "convolutional neural networks that include an encoder and a decoder. The best \n",
-              "performing models also connect the encoder and decoder through an attention \n",
-              "mechanism. We propose a new simple network architecture, the Transformer, based \n",
-              "solely on attention mechanisms, dispensing with recurrence and convolutions \n",
-              "entirely. Experiments on two machine translation tasks show these models to be \n",
-              "superior in quality while being more parallelizable and requiring significantly \n",
-              "less time to train. Our model achieves 28.4 BLEU on the WMT 2014 \n",
-              "Englishto-German translation task, improving over the existing best results, \n",
-              "including ensembles, by over 2 BLEU. On the WMT 2014 English-to-French \n",
-              "translation task, our model establishes a new single-model state-of-the-art BLEU\n",
-              "score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the\n",
-              "training costs of the best models from the literature. We show that the \n",
-              "Transformer generalizes well to other tasks by applying it successfully to \n",
-              "English constituency parsing both with large and limited training data.\n",
-              "\n",
-              "##\n",
-              "</pre>\n"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "-------------------------------------------------------------------------------- \n",
-            "\n",
-            "\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              " 1 Introduction\n",
-              "\n",
-              "Recurrent neural networks, long short-term memory [13] and gated recurrent [7] \n",
-              "neural networks in particular, have been firmly established as state of the art \n",
-              "approaches in sequence modeling and transduction problems such as language \n",
-              "modeling and machine translation [35, 2, 5]. Numerous efforts have since \n",
-              "continued to push the boundaries of recurrent language models and \n",
-              "encoder-decoder architectures [38, 24, 15].\n",
-              "\n",
-              "Recurrent models typically factor computation along the symbol positions of the \n",
-              "input and output sequences. Aligning the positions to steps in computation time,\n",
-              "they generate a sequence of hidden states h t , as a function of the previous \n",
-              "hidden state h t -1 and the input for position t . This inherently sequential \n",
-              "nature precludes parallelization within training examples, which becomes \n",
-              "critical at longer sequence lengths, as memory constraints limit batching across\n",
-              "examples. Recent work has achieved significant improvements in computational \n",
-              "efficiency through factorization tricks [21] and conditional computation [32], \n",
-              "while also improving model performance in case of the latter. The fundamental \n",
-              "constraint of sequential computation, however, remains.\n",
-              "\n",
-              "Attention mechanisms have become an integral part of compelling sequence \n",
-              "modeling and transduction models in various tasks, allowing modeling of \n",
-              "dependencies without regard to their distance in the input or output sequences \n",
-              "[2, 19]. In all but a few cases [27], however, such attention mechanisms are \n",
-              "used in conjunction with a recurrent network.\n",
-              "\n",
-              "In this work we propose the Transformer, a model architecture eschewing \n",
-              "recurrence and instead relying entirely on an attention mechanism to draw global\n",
-              "dependencies between input and output. The Transformer allows for significantly \n",
-              "more parallelization and can reach a new state of the art in translation quality\n",
-              "after being trained for as little as twelve hours on eight P100 GPUs.\n",
-              "\n",
-              "##\n"
-            ],
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> 1 Introduction\n",
-              "\n",
-              "Recurrent neural networks, long short-term memory [13] and gated recurrent [7] \n",
-              "neural networks in particular, have been firmly established as state of the art \n",
-              "approaches in sequence modeling and transduction problems such as language \n",
-              "modeling and machine translation [35, 2, 5]. Numerous efforts have since \n",
-              "continued to push the boundaries of recurrent language models and \n",
-              "encoder-decoder architectures [38, 24, 15].\n",
-              "\n",
-              "Recurrent models typically factor computation along the symbol positions of the \n",
-              "input and output sequences. Aligning the positions to steps in computation time,\n",
-              "they generate a sequence of hidden states h t , as a function of the previous \n",
-              "hidden state h t -1 and the input for position t . This inherently sequential \n",
-              "nature precludes parallelization within training examples, which becomes \n",
-              "critical at longer sequence lengths, as memory constraints limit batching across\n",
-              "examples. Recent work has achieved significant improvements in computational \n",
-              "efficiency through factorization tricks [21] and conditional computation [32], \n",
-              "while also improving model performance in case of the latter. The fundamental \n",
-              "constraint of sequential computation, however, remains.\n",
-              "\n",
-              "Attention mechanisms have become an integral part of compelling sequence \n",
-              "modeling and transduction models in various tasks, allowing modeling of \n",
-              "dependencies without regard to their distance in the input or output sequences \n",
-              "[2, 19]. In all but a few cases [27], however, such attention mechanisms are \n",
-              "used in conjunction with a recurrent network.\n",
-              "\n",
-              "In this work we propose the Transformer, a model architecture eschewing \n",
-              "recurrence and instead relying entirely on an attention mechanism to draw global\n",
-              "dependencies between input and output. The Transformer allows for significantly \n",
-              "more parallelization and can reach a new state of the art in translation quality\n",
-              "after being trained for as little as twelve hours on eight P100 GPUs.\n",
-              "\n",
-              "##\n",
-              "</pre>\n"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "-------------------------------------------------------------------------------- \n",
-            "\n",
-            "\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              " 2 Background\n",
-              "\n",
-              "The goal of reducing sequential computation also forms the foundation of the \n",
-              "Extended Neural GPU [16], ByteNet [18] and ConvS2S [9], all of which use \n",
-              "convolutional neural networks as basic building block, computing hidden \n",
-              "representations in parallel for all input and output positions. In these models,\n",
-              "the number of operations required to relate signals from two arbitrary input or \n",
-              "output positions grows in the distance between positions, linearly for ConvS2S \n",
-              "and logarithmically for ByteNet. This makes it more difficult to learn \n",
-              "dependencies between distant positions [12]. In the Transformer this is reduced \n",
-              "to a constant number of operations, albeit at the cost of reduced effective \n",
-              "resolution due to averaging attention-weighted positions, an effect we \n",
-              "counteract with Multi-Head Attention as described in section 3.2.\n",
-              "\n",
-              "Self-attention, sometimes called intra-attention is an attention mechanism \n",
-              "relating different positions of a single sequence in order to compute a \n",
-              "representation of the sequence. Self-attention has been used successfully in a \n",
-              "variety of tasks including reading comprehension, abstractive summarization, \n",
-              "textual entailment and learning task-independent sentence representations [4, \n",
-              "27, 28, 22].\n",
-              "\n",
-              "End-to-end memory networks are based on a recurrent attention mechanism instead \n",
-              "of sequencealigned recurrence and have been shown to perform well on \n",
-              "simple-language question answering and language modeling tasks [34].\n",
-              "\n",
-              "To the best of our knowledge, however, the Transformer is the first transduction\n",
-              "model relying entirely on self-attention to compute representations of its input\n",
-              "and output without using sequencealigned RNNs or convolution. In the following \n",
-              "sections, we will describe the Transformer, motivate self-attention and discuss \n",
-              "its advantages over models such as [17, 18] and [9].\n",
-              "\n",
-              "##\n"
-            ],
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> 2 Background\n",
-              "\n",
-              "The goal of reducing sequential computation also forms the foundation of the \n",
-              "Extended Neural GPU [16], ByteNet [18] and ConvS2S [9], all of which use \n",
-              "convolutional neural networks as basic building block, computing hidden \n",
-              "representations in parallel for all input and output positions. In these models,\n",
-              "the number of operations required to relate signals from two arbitrary input or \n",
-              "output positions grows in the distance between positions, linearly for ConvS2S \n",
-              "and logarithmically for ByteNet. This makes it more difficult to learn \n",
-              "dependencies between distant positions [12]. In the Transformer this is reduced \n",
-              "to a constant number of operations, albeit at the cost of reduced effective \n",
-              "resolution due to averaging attention-weighted positions, an effect we \n",
-              "counteract with Multi-Head Attention as described in section 3.2.\n",
-              "\n",
-              "Self-attention, sometimes called intra-attention is an attention mechanism \n",
-              "relating different positions of a single sequence in order to compute a \n",
-              "representation of the sequence. Self-attention has been used successfully in a \n",
-              "variety of tasks including reading comprehension, abstractive summarization, \n",
-              "textual entailment and learning task-independent sentence representations [4, \n",
-              "27, 28, 22].\n",
-              "\n",
-              "End-to-end memory networks are based on a recurrent attention mechanism instead \n",
-              "of sequencealigned recurrence and have been shown to perform well on \n",
-              "simple-language question answering and language modeling tasks [34].\n",
-              "\n",
-              "To the best of our knowledge, however, the Transformer is the first transduction\n",
-              "model relying entirely on self-attention to compute representations of its input\n",
-              "and output without using sequencealigned RNNs or convolution. In the following \n",
-              "sections, we will describe the Transformer, motivate self-attention and discuss \n",
-              "its advantages over models such as [17, 18] and [9].\n",
-              "\n",
-              "##\n",
-              "</pre>\n"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "-------------------------------------------------------------------------------- \n",
-            "\n",
-            "\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Step 3: Retrieval"
-      ],
-      "metadata": {
-        "id": "ptvqLz8ccVXs"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Step 3.1: Get the embeddings for each of the chunks!"
-      ],
-      "metadata": {
-        "id": "FZdHJXpecCxN"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Create some dummy data as strings or other serializable objects\n",
-        "items = [chunk.text for chunk in chunks]\n",
-        "vectors = model.encode(items)\n",
-        "print(vectors.shape)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "uBsn0wr_RrqF",
-        "outputId": "61ab7db6-c4e7-450e-b2e6-0982faf74a78"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "(58, 512)\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Step 3.2: Create an index with the chunks and embeddings for retrieval"
-      ],
-      "metadata": {
-        "id": "Vtdz0L0Rch23"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Initialize the Vicinity instance (using the basic backend and cosine metric)\n",
-        "vicinity = Vicinity.from_vectors_and_items(\n",
-        "    vectors=vectors,\n",
-        "    items=items,\n",
-        "    backend_type=Backend.BASIC,\n",
-        "    metric=Metric.COSINE\n",
-        ")"
-      ],
-      "metadata": {
-        "id": "m1mA-weURs1C"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Step 3.3: Get results for a given query from the index~"
-      ],
-      "metadata": {
-        "id": "E59tnX8LcrJV"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Set a query that you wish to answer, and get it's embeddings\n",
-        "query = \"What is a Multi-Head Self Attention?\""
-      ],
-      "metadata": {
-        "id": "jzfUfZEYRbhQ"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Encode the query and get the top 4 chunks\n",
-        "query_vector = model.encode(query)\n",
-        "\n",
-        "# Query for nearest neighbors with a top-k search\n",
-        "results = vicinity.query(query_vector, k=4)"
-      ],
-      "metadata": {
-        "id": "VGLZVELlP_CJ"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Let's have a look at the retrieved chunks\n",
-        "retrieved_chunks = [x[0] for x in results[0]]\n",
-        "\n",
-        "for chunk in retrieved_chunks:\n",
-        "  rprint(chunk)\n",
-        "  print('-'*80, '\\n\\n')"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
-        "id": "Hk9mhU4-Ry6p",
-        "outputId": "d10b5c28-624d-4923-b2ee-70807082aa31"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              " Attention Visualizations Input-Input Layer5\n",
-              "\n",
-              "Figure 3: An example of the attention mechanism following long-distance \n",
-              "dependencies in the encoder self-attention in layer 5 of 6. Many of the \n",
-              "attention heads attend to a distant dependency of the verb 'making', completing \n",
-              "the phrase 'making...more difficult'. Attentions here shown only for the word \n",
-              "'making'. Different colors represent different heads. Best viewed in color.\n",
-              "\n",
-              "<!-- image -->\n",
-              "\n",
-              "Input-Input Layer5\n",
-              "\n",
-              "Figure 4: Two attention heads, also in layer 5 of 6, apparently involved in \n",
-              "anaphora resolution. Top: Full attentions for head 5. Bottom: Isolated \n",
-              "attentions from just the word 'its' for attention heads 5 and 6. Note that the \n",
-              "attentions are very sharp for this word.\n",
-              "\n",
-              "<!-- image -->\n",
-              "\n",
-              "Input-Input Layer5\n",
-              "\n",
-              "Figure 5: Many of the attention heads exhibit behaviour that seems related to \n",
-              "the structure of the sentence. We give two such examples above, from two \n",
-              "different heads from the encoder self-attention at layer 5 of 6. The heads \n",
-              "clearly learned to perform different tasks.\n",
-              "\n",
-              "<!-- image -->\n"
-            ],
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> Attention Visualizations Input-Input Layer5\n",
-              "\n",
-              "Figure 3: An example of the attention mechanism following long-distance \n",
-              "dependencies in the encoder self-attention in layer 5 of 6. Many of the \n",
-              "attention heads attend to a distant dependency of the verb 'making', completing \n",
-              "the phrase 'making...more difficult'. Attentions here shown only for the word \n",
-              "'making'. Different colors represent different heads. Best viewed in color.\n",
-              "\n",
-              "&lt;!-- image --&gt;\n",
-              "\n",
-              "Input-Input Layer5\n",
-              "\n",
-              "Figure 4: Two attention heads, also in layer 5 of 6, apparently involved in \n",
-              "anaphora resolution. Top: Full attentions for head 5. Bottom: Isolated \n",
-              "attentions from just the word 'its' for attention heads 5 and 6. Note that the \n",
-              "attentions are very sharp for this word.\n",
-              "\n",
-              "&lt;!-- image --&gt;\n",
-              "\n",
-              "Input-Input Layer5\n",
-              "\n",
-              "Figure 5: Many of the attention heads exhibit behaviour that seems related to \n",
-              "the structure of the sentence. We give two such examples above, from two \n",
-              "different heads from the encoder self-attention at layer 5 of 6. The heads \n",
-              "clearly learned to perform different tasks.\n",
-              "\n",
-              "&lt;!-- image --&gt;\n",
-              "</pre>\n"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "-------------------------------------------------------------------------------- \n",
-            "\n",
-            "\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              " 2 Background\n",
-              "\n",
-              "The goal of reducing sequential computation also forms the foundation of the \n",
-              "Extended Neural GPU [16], ByteNet [18] and ConvS2S [9], all of which use \n",
-              "convolutional neural networks as basic building block, computing hidden \n",
-              "representations in parallel for all input and output positions. In these models,\n",
-              "the number of operations required to relate signals from two arbitrary input or \n",
-              "output positions grows in the distance between positions, linearly for ConvS2S \n",
-              "and logarithmically for ByteNet. This makes it more difficult to learn \n",
-              "dependencies between distant positions [12]. In the Transformer this is reduced \n",
-              "to a constant number of operations, albeit at the cost of reduced effective \n",
-              "resolution due to averaging attention-weighted positions, an effect we \n",
-              "counteract with Multi-Head Attention as described in section 3.2.\n",
-              "\n",
-              "Self-attention, sometimes called intra-attention is an attention mechanism \n",
-              "relating different positions of a single sequence in order to compute a \n",
-              "representation of the sequence. Self-attention has been used successfully in a \n",
-              "variety of tasks including reading comprehension, abstractive summarization, \n",
-              "textual entailment and learning task-independent sentence representations [4, \n",
-              "27, 28, 22].\n",
-              "\n",
-              "End-to-end memory networks are based on a recurrent attention mechanism instead \n",
-              "of sequencealigned recurrence and have been shown to perform well on \n",
-              "simple-language question answering and language modeling tasks [34].\n",
-              "\n",
-              "To the best of our knowledge, however, the Transformer is the first transduction\n",
-              "model relying entirely on self-attention to compute representations of its input\n",
-              "and output without using sequencealigned RNNs or convolution. In the following \n",
-              "sections, we will describe the Transformer, motivate self-attention and discuss \n",
-              "its advantages over models such as [17, 18] and [9].\n",
-              "\n",
-              "##\n"
-            ],
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> 2 Background\n",
-              "\n",
-              "The goal of reducing sequential computation also forms the foundation of the \n",
-              "Extended Neural GPU [16], ByteNet [18] and ConvS2S [9], all of which use \n",
-              "convolutional neural networks as basic building block, computing hidden \n",
-              "representations in parallel for all input and output positions. In these models,\n",
-              "the number of operations required to relate signals from two arbitrary input or \n",
-              "output positions grows in the distance between positions, linearly for ConvS2S \n",
-              "and logarithmically for ByteNet. This makes it more difficult to learn \n",
-              "dependencies between distant positions [12]. In the Transformer this is reduced \n",
-              "to a constant number of operations, albeit at the cost of reduced effective \n",
-              "resolution due to averaging attention-weighted positions, an effect we \n",
-              "counteract with Multi-Head Attention as described in section 3.2.\n",
-              "\n",
-              "Self-attention, sometimes called intra-attention is an attention mechanism \n",
-              "relating different positions of a single sequence in order to compute a \n",
-              "representation of the sequence. Self-attention has been used successfully in a \n",
-              "variety of tasks including reading comprehension, abstractive summarization, \n",
-              "textual entailment and learning task-independent sentence representations [4, \n",
-              "27, 28, 22].\n",
-              "\n",
-              "End-to-end memory networks are based on a recurrent attention mechanism instead \n",
-              "of sequencealigned recurrence and have been shown to perform well on \n",
-              "simple-language question answering and language modeling tasks [34].\n",
-              "\n",
-              "To the best of our knowledge, however, the Transformer is the first transduction\n",
-              "model relying entirely on self-attention to compute representations of its input\n",
-              "and output without using sequencealigned RNNs or convolution. In the following \n",
-              "sections, we will describe the Transformer, motivate self-attention and discuss \n",
-              "its advantages over models such as [17, 18] and [9].\n",
-              "\n",
-              "##\n",
-              "</pre>\n"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "-------------------------------------------------------------------------------- \n",
-            "\n",
-            "\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              " Scaled Dot-Product Attention\n",
-              "\n",
-              "<!-- image -->\n",
-              "\n",
-              "Figure 2: (left) Scaled Dot-Product Attention. (right) Multi-Head Attention \n",
-              "consists of several attention layers running in parallel.\n",
-              "\n",
-              "<!-- image -->\n",
-              "\n",
-              "of the values, where the weight assigned to each value is computed by a \n",
-              "compatibility function of the query with the corresponding key.\n",
-              "\n",
-              "##\n"
-            ],
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> Scaled Dot-Product Attention\n",
-              "\n",
-              "&lt;!-- image --&gt;\n",
-              "\n",
-              "Figure 2: (left) Scaled Dot-Product Attention. (right) Multi-Head Attention \n",
-              "consists of several attention layers running in parallel.\n",
-              "\n",
-              "&lt;!-- image --&gt;\n",
-              "\n",
-              "of the values, where the weight assigned to each value is computed by a \n",
-              "compatibility function of the query with the corresponding key.\n",
-              "\n",
-              "##\n",
-              "</pre>\n"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "-------------------------------------------------------------------------------- \n",
-            "\n",
-            "\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              " 3.2.2 Multi-Head Attention\n",
-              "\n",
-              "Instead of performing a single attention function with d model-dimensional keys,\n",
-              "values and queries, we found it beneficial to linearly project the queries, keys\n",
-              "and values h times with different, learned linear projections to d k , d k and d\n",
-              "v dimensions, respectively. On each of these projected versions of queries, keys\n",
-              "and values we then perform the attention function in parallel, yielding d v \n",
-              "-dimensional\n",
-              "\n",
-              "output values. These are concatenated and once again projected, resulting in the\n",
-              "final values, as depicted in Figure 2.\n",
-              "\n",
-              "Multi-head attention allows the model to jointly attend to information from \n",
-              "different representation subspaces at different positions. With a single \n",
-              "attention head, averaging inhibits this.\n",
-              "\n",
-              "$$MultiHead( Q,K,V ) = Concat(head 1 , ..., head h ) W O where head = Attention(\n",
-              "QW Q , KW K , V W V )$$\n",
-              "\n",
-              "$$i i i i$$\n",
-              "\n",
-              "Where the projections are parameter matrices W Q i ∈ R d model × d k , W K i ∈ R\n",
-              "d model × d k , W V i ∈ R d model × d v and W O ∈ R hd v × d model .\n",
-              "\n",
-              "In this work we employ h = 8 parallel attention layers, or heads. For each of \n",
-              "these we use d k = d v = d model /h = 64 . Due to the reduced dimension of each \n",
-              "head, the total computational cost is similar to that of single-head attention \n",
-              "with full dimensionality.\n",
-              "\n",
-              "##\n"
-            ],
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> 3.2.2 Multi-Head Attention\n",
-              "\n",
-              "Instead of performing a single attention function with d model-dimensional keys,\n",
-              "values and queries, we found it beneficial to linearly project the queries, keys\n",
-              "and values h times with different, learned linear projections to d k , d k and d\n",
-              "v dimensions, respectively. On each of these projected versions of queries, keys\n",
-              "and values we then perform the attention function in parallel, yielding d v \n",
-              "-dimensional\n",
-              "\n",
-              "output values. These are concatenated and once again projected, resulting in the\n",
-              "final values, as depicted in Figure 2.\n",
-              "\n",
-              "Multi-head attention allows the model to jointly attend to information from \n",
-              "different representation subspaces at different positions. With a single \n",
-              "attention head, averaging inhibits this.\n",
-              "\n",
-              "$$MultiHead( Q,K,V ) = Concat(head 1 , ..., head h ) W O where head = Attention(\n",
-              "QW Q , KW K , V W V )$$\n",
-              "\n",
-              "$$i i i i$$\n",
-              "\n",
-              "Where the projections are parameter matrices W Q i ∈ R d model × d k , W K i ∈ R\n",
-              "d model × d k , W V i ∈ R d model × d v and W O ∈ R hd v × d model .\n",
-              "\n",
-              "In this work we employ h = 8 parallel attention layers, or heads. For each of \n",
-              "these we use d k = d v = d model /h = 64 . Due to the reduced dimension of each \n",
-              "head, the total computational cost is similar to that of single-head attention \n",
-              "with full dimensionality.\n",
-              "\n",
-              "##\n",
-              "</pre>\n"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "-------------------------------------------------------------------------------- \n",
-            "\n",
-            "\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Step 4: Generate an answer with the LLM"
-      ],
-      "metadata": {
-        "id": "SVTkv6mPR0Cy"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Let's generate the prompt to use~\n",
-        "prompt = create_prompt(retrieved_chunks, query)\n",
-        "prompt_tokens = len(tokenizer.encode(prompt))\n",
-        "rprint(f\"This prompt contains: {prompt_tokens} tokens\")"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 33
-        },
-        "id": "aImQYMvhUW2e",
-        "outputId": "383a4c80-2aa9-43b7-b7cc-e3c6ee0d26fe"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "This prompt contains: 1102 tokens\n"
-            ],
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">This prompt contains: 1102 tokens\n",
-              "</pre>\n"
-            ]
-          },
-          "metadata": {}
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# And finally the respose~\n",
-        "response = client.chat.completions.create(\n",
-        "    model=\"deepseek-ai/DeepSeek-R1\",\n",
-        "    messages=[{\"role\": \"user\", \"content\": prompt}],\n",
-        ")"
-      ],
-      "metadata": {
-        "id": "5VYQXFGPSdeo"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Print the final response without the thinking tokens\n",
-        "answer = response.choices[0].message.content.split(\"</think>\")[-1]\n",
-        "rprint(answer)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 305
-        },
-        "id": "0l4xB1FEbYky",
-        "outputId": "ce36555f-5b55-4baa-c1d4-285c9ba88ff5"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "\n",
-              "\n",
-              "Multi-Head Self Attention is a mechanism in the Transformer architecture that \n",
-              "enables the model to jointly process information from different representation \n",
-              "subspaces at different positions within a sequence. Instead of performing a \n",
-              "single attention function, it linearly projects the input's queries, keys, and \n",
-              "values multiple times into lower-dimensional subspaces using distinct learned \n",
-              "projections. Each projection (or \"head\") independently performs scaled \n",
-              "dot-product self-attention, which involves relating different positions of the \n",
-              "input sequence to compute a contextual representation [2][4]. \n",
-              "\n",
-              "The outputs from all heads are concatenated and linearly transformed to produce \n",
-              "the final result. This design allows the model to capture diverse dependencies, \n",
-              "such as long-range relationships or syntactic patterns, more effectively than \n",
-              "single-head attention. For example, different heads may specialize in tasks like\n",
-              "resolving anaphora or tracking verb phrases [1]. The computational efficiency is\n",
-              "maintained by reducing the dimensionality of each head (e.g., using 8 heads with\n",
-              "64 dimensions each in the original Transformer) while preserving the total \n",
-              "parameter count [4].\n"
-            ],
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-              "\n",
-              "Multi-Head Self Attention is a mechanism in the Transformer architecture that \n",
-              "enables the model to jointly process information from different representation \n",
-              "subspaces at different positions within a sequence. Instead of performing a \n",
-              "single attention function, it linearly projects the input's queries, keys, and \n",
-              "values multiple times into lower-dimensional subspaces using distinct learned \n",
-              "projections. Each projection (or \"head\") independently performs scaled \n",
-              "dot-product self-attention, which involves relating different positions of the \n",
-              "input sequence to compute a contextual representation [2][4]. \n",
-              "\n",
-              "The outputs from all heads are concatenated and linearly transformed to produce \n",
-              "the final result. This design allows the model to capture diverse dependencies, \n",
-              "such as long-range relationships or syntactic patterns, more effectively than \n",
-              "single-head attention. For example, different heads may specialize in tasks like\n",
-              "resolving anaphora or tracking verb phrases [1]. The computational efficiency is\n",
-              "maintained by reducing the dimensionality of each head (e.g., using 8 heads with\n",
-              "64 dimensions each in the original Transformer) while preserving the total \n",
-              "parameter count [4].\n",
-              "</pre>\n"
-            ]
-          },
-          "metadata": {}
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Conclusions\n",
-        "\n",
-        "We got a great answer back from Deepseek R1, while saving about **~8,800 input tokens** to Deepseek!\n",
-        "\n",
-        "Hope you liked the notebook~ If you find chonkie useful for your applications and need some support with it, reach out at `support@chonkie.ai` or over the Discord server."
-      ],
-      "metadata": {
-        "id": "rVB0wXjGvC41"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Fin."
-      ],
-      "metadata": {
-        "id": "-mgUVHRnUjiK"
-      }
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m48.2/48.2 kB\u001b[0m \u001b[31m3.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m51.2/51.2 kB\u001b[0m \u001b[31m3.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m121.9/121.9 kB\u001b[0m \u001b[31m10.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m73.8/73.8 kB\u001b[0m \u001b[31m6.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.8/7.8 MB\u001b[0m \u001b[31m60.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m93.2/93.2 kB\u001b[0m \u001b[31m6.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m78.8/78.8 kB\u001b[0m \u001b[31m6.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m22.4/22.4 MB\u001b[0m \u001b[31m15.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.9/2.9 MB\u001b[0m \u001b[31m46.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m42.1/42.1 kB\u001b[0m \u001b[31m2.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.5/4.5 MB\u001b[0m \u001b[31m48.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m431.7/431.7 kB\u001b[0m \u001b[31m23.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.0/2.0 MB\u001b[0m \u001b[31m38.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.9/2.9 MB\u001b[0m \u001b[31m60.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m244.3/244.3 kB\u001b[0m \u001b[31m15.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m472.8/472.8 kB\u001b[0m \u001b[31m31.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m543.2/543.2 kB\u001b[0m \u001b[31m29.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m47.3/47.3 kB\u001b[0m \u001b[31m3.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.2/1.2 MB\u001b[0m \u001b[31m49.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m165.1/165.1 kB\u001b[0m \u001b[31m12.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m422.9/422.9 kB\u001b[0m \u001b[31m26.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m912.2/912.2 kB\u001b[0m \u001b[31m32.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m286.8/286.8 kB\u001b[0m \u001b[31m19.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.6/1.6 MB\u001b[0m \u001b[31m41.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m272.8/272.8 kB\u001b[0m \u001b[31m19.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m134.8/134.8 kB\u001b[0m \u001b[31m11.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m119.4/119.4 kB\u001b[0m \u001b[31m10.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "!pip install -q chonkie docling model2vec vicinity together rich[jupyter]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2Alnp3TMNpcr"
+   },
+   "outputs": [],
+   "source": [
+    "# Get all the required imports here\n",
+    "import os\n",
+    "from typing import List\n",
+    "\n",
+    "from docling.document_converter import DocumentConverter\n",
+    "from google.colab import userdata\n",
+    "from model2vec import StaticModel\n",
+    "from rich.console import Console\n",
+    "from rich.text import Text\n",
+    "from together import Together\n",
+    "from transformers import AutoTokenizer\n",
+    "from vicinity import Backend, Metric, Vicinity\n",
+    "\n",
+    "from chonkie import RecursiveChunker, RecursiveLevel, RecursiveRules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 333,
+     "referenced_widgets": [
+      "f3f468050cb5486589c68d273fa859a6",
+      "a54f3fbe457c4eb180aaeebb3d849ba0",
+      "ebbfe03efc654c08a13ad2d14b7b5c31",
+      "5a912a0e334d4ccfb9df57b27a22f38a",
+      "e3203d311565460d894ee217af5b5f42",
+      "d36682aa48f04f3dbc1c9c67ec6b12f9",
+      "adcd55623850471eb401625e37094039",
+      "97c14d92f1314350a869fa597b5de66c",
+      "12b10bf1df0542899733ea423889ddce",
+      "5727087483534a61a3a68ce3a8763cd6",
+      "509b942cf9e64a0c9f4ae2579a986639",
+      "8b00bb6eca4b4b68b61fae4dcaafe949",
+      "d2badcdaf80e4c759aa829f450c1807b",
+      "6be572d089be4626ab684e4721416488",
+      "66a7d89614e94d8491302a797a4c12e5",
+      "13e1bdf79aff423c9624874cb9c9a870",
+      "5a3fd46acb0c447790c980a98f62e361",
+      "97112c2b170148e5b937afc4da6ab1c4",
+      "87a26b89a5cb4d518cd9bf2b330bd498",
+      "9fc9f9eaec244b0eb4c92c20301c6e63",
+      "b1a1836c316342109ee8718629380efe",
+      "f67a93d013984b40b3055eb5c546fec4",
+      "9aec040202fb4a58973ede6f4d760707",
+      "a8bc59e034fe4daeaa00bfeadd2635f6",
+      "8d15667d78bc400080d7b4c6bdb396b2",
+      "0e10ceb014ed428891a8cf05c2a2251e",
+      "6be64614024c438daaea95a47b144c04",
+      "708454183e4b460f90f7fa3f430bc332",
+      "cbcec8f8093c4a92b211ea0fb8885a3a",
+      "20d7b3de1705424c9e61db230c43fd95",
+      "8698fbf252024bea85051703f9aacbf7",
+      "34e293cc15484477b940eb870743dcdc",
+      "f39f8a5a039a4b4e8b9ca06cc874a465",
+      "a3eacad2d39449d0be3ba3e606dc5cf7",
+      "ac5ee023c9c943a0a5ed531fea511b1a",
+      "e44835492ff645f8a588a7d7ec1f04b5",
+      "d2610ed202794ec2918482e18ca457fc",
+      "6c1da5303cad44098dafd87763b609f7",
+      "4b6bd295aba748bd9670cd06a69682a9",
+      "dec5a689253f41acaf392d1ef20f494b",
+      "7d0bf8146d2747f2b518ddb43f203c88",
+      "de9b6916a9ec4d788ba0c07b4d397480",
+      "8d0b2d93f67c4ff2a633660782125131",
+      "b568a2f59a154ddeafb78710e1518604",
+      "d3f68b3fb7b4494294922e06de7dbe53",
+      "c49defa1fcea4d30bdec9435d651e2b1",
+      "90d2e938d0c1476588c088acf1b86685",
+      "30c134be926948b3959ce7a723c0ae8a",
+      "9cbcc6b7d1354e5ea98eebf487d2a94f",
+      "ebed0e46009745ae9818d16a9dade7ef",
+      "755799f1e6b14b2f91f19edf06964436",
+      "0937dafccc1547069a553c0421028172",
+      "4003e08660c64d10a18d74bd47f19275",
+      "5de1ff0789f547e7a6147888e08aca64",
+      "985458e3563244c9b94525d831fd90dc",
+      "ca28c121e84e425185a4d801c3930b69",
+      "dc7fdda7a5354621978c17ec22ed0330",
+      "7ae08b4d31924479809eb7d3f2fb38fb",
+      "ce4b6e104d7b433da4eb1ee3a7278182",
+      "2d74a3e80b9646be88ed4bc5158ff8a2",
+      "3e30645b7a384ed48129e7afa471a982",
+      "9324441028b1496e87c7059bcd1b371b",
+      "8a3bb9d63ba640c6a0c63c7bd08d50cf",
+      "a0f4ea3ee6f04fd4ba0e5cb37f24b343",
+      "853eb421b8364fe0a7e3a2e91be79aaf",
+      "51be8798d9b8426081c9cb8955624b9c"
+     ]
+    },
+    "id": "SSgotkx6dvt3",
+    "outputId": "7fd5fa58-4754-4c8e-efec-1c04133bf81e"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.10/dist-packages/huggingface_hub/utils/_auth.py:94: UserWarning: \n",
+      "The secret `HF_TOKEN` does not exist in your Colab secrets.\n",
+      "To authenticate with the Hugging Face Hub, create a token in your settings tab (https://huggingface.co/settings/tokens), set it as secret in your Google Colab and restart your session.\n",
+      "You will be able to reuse this secret in all of your notebooks.\n",
+      "Please note that authentication is recommended but still optional to access public models or datasets.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f3f468050cb5486589c68d273fa859a6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model.safetensors:   0%|          | 0.00/129M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8b00bb6eca4b4b68b61fae4dcaafe949",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "README.md:   0%|          | 0.00/16.7k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9aec040202fb4a58973ede6f4d760707",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "config.json:   0%|          | 0.00/202 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a3eacad2d39449d0be3ba3e606dc5cf7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "tokenizer.json:   0%|          | 0.00/1.49M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d3f68b3fb7b4494294922e06de7dbe53",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "tokenizer_config.json:   0%|          | 0.00/3.58k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ca28c121e84e425185a4d801c3930b69",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "tokenizer.json:   0%|          | 0.00/7.85M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Initialize the rich text console for better printing\n",
+    "console = Console()\n",
+    "\n",
+    "# Set your Together API key to use Deepseek R1 with it~\n",
+    "os.environ['TOGETHER_API_KEY'] = userdata.get('TOGETHER_API_KEY')\n",
+    "\n",
+    "# Initialise a Document Converter\n",
+    "converter = DocumentConverter()\n",
+    "\n",
+    "# This chunker would recursively split the text to get 256 tokens or less per chunk\n",
+    "rules = RecursiveRules(\n",
+    "    levels=[\n",
+    "        RecursiveLevel(delimiters=['######', '#####', '####', '###', '##', '#']),\n",
+    "        RecursiveLevel(delimiters=['\\n\\n', '\\n', '\\r\\n', '\\r']),\n",
+    "        RecursiveLevel(delimiters='.?!;:'),\n",
+    "        RecursiveLevel()\n",
+    "    ]\n",
+    ")\n",
+    "chunker = RecursiveChunker(rules=rules, chunk_size=384)\n",
+    "\n",
+    "# Initialise a model2vec model for encoding sentences for retrieval\n",
+    "model = StaticModel.from_pretrained(\"minishlab/potion-retrieval-32M\")\n",
+    "\n",
+    "# Initialise the Together client to call upon Deepseek R1\n",
+    "client = Together()\n",
+    "\n",
+    "# (Optional) Initialise the tokenizer for Deepseek R1\n",
+    "tokenizer = AutoTokenizer.from_pretrained(\"deepseek-ai/DeepSeek-R1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "9rxDtTGhlUnE"
+   },
+   "outputs": [],
+   "source": [
+    "# A wrapped up print function\n",
+    "def rprint(text: str, console: Console=console, width: int = 80) -> None:\n",
+    "  richtext = Text(text)\n",
+    "  console.print(richtext.wrap(console, width=width))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "aV3bBbjXfU4F"
+   },
+   "outputs": [],
+   "source": [
+    "# A simple utility function to make the prompts from the given chunks\n",
+    "def create_prompt(chunks: List[str], query: str) -> str:\n",
+    "  prompt_template = \"\"\"<instructions>\n",
+    "  Based on the provided contexts, answer the given question to the best of your ability. Remember to also add citations at appropriate points in the format of square brackets like [1][2][3], especially at sentence or paragraph endings.\n",
+    "  You will be given 4 passages in the context, marked with a label 'Doc [1]:' to denote the passage number. Use that number for citations. Answer only from the given context, and if there's no appropriate context, reply \"No relevant context found!\".\n",
+    "  </instructions>\n",
+    "\n",
+    "  <context>\n",
+    "  {context}\n",
+    "  </context>\n",
+    "\n",
+    "  <query>\n",
+    "  {query}\n",
+    "  </query>\n",
+    "  \"\"\"\n",
+    "  context = \"\\n\\n\".join([f\"Doc {i+1}: {chunk}\" for i, chunk in enumerate(chunks)])\n",
+    "  prompt = prompt_template.format(context=context, query=query)\n",
+    "  return prompt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_OQuHrrJNswJ"
+   },
+   "source": [
+    "## Step 1: Use docling to convert PDF -> Markdown!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XFAq-C0phEnO"
+   },
+   "source": [
+    "This step takes about 20-30 seconds depending on your PDF."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "HLWqslfsNzOI",
+    "outputId": "a8a95747-9054-4197-9524-37b3455436a6"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:easyocr.easyocr:Downloading detection model, please wait. This may take several minutes depending upon your network connection.\n",
+      "WARNING:easyocr.easyocr:Downloading recognition model, please wait. This may take several minutes depending upon your network connection.\n",
+      "/usr/local/lib/python3.10/dist-packages/torch/utils/cpp_extension.py:1964: UserWarning: TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. \n",
+      "If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'].\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Given a source PDF link, we can convert it to Markdown which is easier to use!\n",
+    "source = \"https://arxiv.org/pdf/1706.03762\"\n",
+    "result = converter.convert(source)\n",
+    "text = result.document.export_to_markdown()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 833
+    },
+    "id": "JOW-yKPFWOow",
+    "outputId": "6886bbcb-176f-4695-bb87-3e39aeb18a70"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Provided proper attribution is provided, Google hereby grants permission to \n",
+       "reproduce the tables and figures in this paper solely for use in journalistic or\n",
+       "scholarly works.\n",
+       "\n",
+       "## Attention Is All You Need\n",
+       "\n",
+       "Ashish Vaswani ∗ Google Brain avaswani@google.com\n",
+       "\n",
+       "Noam Shazeer ∗ Google Brain noam@google.com\n",
+       "\n",
+       "Niki Parmar ∗ Google Research nikip@google.com\n",
+       "\n",
+       "Jakob Uszkoreit ∗ Google Research usz@google.com\n",
+       "\n",
+       "Llion Jones ∗ Google Research llion@google.com\n",
+       "\n",
+       "Aidan N. Gomez ∗ † University of Toronto\n",
+       "\n",
+       "aidan@cs.toronto.edu\n",
+       "\n",
+       "Łukasz Kaiser Google Brain lukaszkaiser@google.com\n",
+       "\n",
+       "∗\n",
+       "\n",
+       "Illia Polosukhin ∗ ‡\n",
+       "\n",
+       "illia.polosukhin@gmail.com\n",
+       "\n",
+       "## Abstract\n",
+       "\n",
+       "The dominant sequence transduction models are based on complex recurrent or \n",
+       "convolutional neural networks that include an encoder and a decoder. The best \n",
+       "performing models also connect the encoder and decoder through an attention \n",
+       "mechanism. We propose a new simple network architecture, the Transformer, based \n",
+       "solely on attention mechanisms, dispensing with recurrence and convolutions \n",
+       "entirely. Experiments on two machine translation tasks show these models to be \n",
+       "superior in quality while being more parallelizable and requiring significantly \n",
+       "less time to train. Our model achieves 28.4 BLEU on the WMT 2014 \n",
+       "Englishto-German translation task, improving over the existing best results, \n",
+       "including ensembles, by over 2 BLEU. On the WMT 2014 English-to-French \n",
+       "translation task, our model establishes a new single-model state-of-the-art BLEU\n",
+       "score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the\n",
+       "training costs of the best models from the literature. We show that the \n",
+       "Transformer generalizes well to other tasks by applying it successfully to \n",
+       "English constituency parsing both with large and limited training data.\n",
+       "\n",
+       "## 1 Introduction\n",
+       "\n",
+       "Recurrent neural networks, long short-term memory [13] and gated recurrent [7] \n",
+       "neural networks in particular, have been firmly established as state of the art \n",
+       "approaches in sequence modeling and transduction prob\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Provided proper attribution is provided, Google hereby grants permission to \n",
+       "reproduce the tables and figures in this paper solely for use in journalistic or\n",
+       "scholarly works.\n",
+       "\n",
+       "## Attention Is All You Need\n",
+       "\n",
+       "Ashish Vaswani ∗ Google Brain avaswani@google.com\n",
+       "\n",
+       "Noam Shazeer ∗ Google Brain noam@google.com\n",
+       "\n",
+       "Niki Parmar ∗ Google Research nikip@google.com\n",
+       "\n",
+       "Jakob Uszkoreit ∗ Google Research usz@google.com\n",
+       "\n",
+       "Llion Jones ∗ Google Research llion@google.com\n",
+       "\n",
+       "Aidan N. Gomez ∗ † University of Toronto\n",
+       "\n",
+       "aidan@cs.toronto.edu\n",
+       "\n",
+       "Łukasz Kaiser Google Brain lukaszkaiser@google.com\n",
+       "\n",
+       "∗\n",
+       "\n",
+       "Illia Polosukhin ∗ ‡\n",
+       "\n",
+       "illia.polosukhin@gmail.com\n",
+       "\n",
+       "## Abstract\n",
+       "\n",
+       "The dominant sequence transduction models are based on complex recurrent or \n",
+       "convolutional neural networks that include an encoder and a decoder. The best \n",
+       "performing models also connect the encoder and decoder through an attention \n",
+       "mechanism. We propose a new simple network architecture, the Transformer, based \n",
+       "solely on attention mechanisms, dispensing with recurrence and convolutions \n",
+       "entirely. Experiments on two machine translation tasks show these models to be \n",
+       "superior in quality while being more parallelizable and requiring significantly \n",
+       "less time to train. Our model achieves 28.4 BLEU on the WMT 2014 \n",
+       "Englishto-German translation task, improving over the existing best results, \n",
+       "including ensembles, by over 2 BLEU. On the WMT 2014 English-to-French \n",
+       "translation task, our model establishes a new single-model state-of-the-art BLEU\n",
+       "score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the\n",
+       "training costs of the best models from the literature. We show that the \n",
+       "Transformer generalizes well to other tasks by applying it successfully to \n",
+       "English constituency parsing both with large and limited training data.\n",
+       "\n",
+       "## 1 Introduction\n",
+       "\n",
+       "Recurrent neural networks, long short-term memory [13] and gated recurrent [7] \n",
+       "neural networks in particular, have been firmly established as state of the art \n",
+       "approaches in sequence modeling and transduction prob\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Lets have a quick look at the text we'll be working with~\n",
+    "rprint(text[:2000])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 33
+    },
+    "id": "Gul7zYCSnOXE",
+    "outputId": "ab7e9b6a-d396-490a-9875-400d52ac0940"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">This PDF contains: 9928 tokens\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "This PDF contains: 9928 tokens\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Get the total deepseek tokens for the entire PDF\n",
+    "total_text_tokens = len(tokenizer.encode(text))\n",
+    "rprint(f\"This PDF contains: {total_text_tokens} tokens\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "u76kuds3YYqA"
+   },
+   "source": [
+    "## Step 2: Chunk your texts w/ Chonkie!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "O6M4GdxkOBMI",
+    "outputId": "5ab5a9e8-78b1-45a3-823a-96d6e72fbdef"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total number of chunks: 58\n"
+     ]
+    }
+   ],
+   "source": [
+    "# This is all it takes to chunk!\n",
+    "chunks = chunker(text)\n",
+    "print(f\"Total number of chunks: {len(chunks)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 1000
+    },
+    "id": "TSCJbBIhYdfD",
+    "outputId": "3b3d9168-c8ec-40c4-b6af-f7402337fe2a"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Provided proper attribution is provided, Google hereby grants permission to \n",
+       "reproduce the tables and figures in this paper solely for use in journalistic or\n",
+       "scholarly works.\n",
+       "\n",
+       "## Attention Is All You Need\n",
+       "\n",
+       "Ashish Vaswani ∗ Google Brain avaswani@google.com\n",
+       "\n",
+       "Noam Shazeer ∗ Google Brain noam@google.com\n",
+       "\n",
+       "Niki Parmar ∗ Google Research nikip@google.com\n",
+       "\n",
+       "Jakob Uszkoreit ∗ Google Research usz@google.com\n",
+       "\n",
+       "Llion Jones ∗ Google Research llion@google.com\n",
+       "\n",
+       "Aidan N. Gomez ∗ † University of Toronto\n",
+       "\n",
+       "aidan@cs.toronto.edu\n",
+       "\n",
+       "Łukasz Kaiser Google Brain lukaszkaiser@google.com\n",
+       "\n",
+       "∗\n",
+       "\n",
+       "Illia Polosukhin ∗ ‡\n",
+       "\n",
+       "illia.polosukhin@gmail.com\n",
+       "\n",
+       "##\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Provided proper attribution is provided, Google hereby grants permission to \n",
+       "reproduce the tables and figures in this paper solely for use in journalistic or\n",
+       "scholarly works.\n",
+       "\n",
+       "## Attention Is All You Need\n",
+       "\n",
+       "Ashish Vaswani ∗ Google Brain avaswani@google.com\n",
+       "\n",
+       "Noam Shazeer ∗ Google Brain noam@google.com\n",
+       "\n",
+       "Niki Parmar ∗ Google Research nikip@google.com\n",
+       "\n",
+       "Jakob Uszkoreit ∗ Google Research usz@google.com\n",
+       "\n",
+       "Llion Jones ∗ Google Research llion@google.com\n",
+       "\n",
+       "Aidan N. Gomez ∗ † University of Toronto\n",
+       "\n",
+       "aidan@cs.toronto.edu\n",
+       "\n",
+       "Łukasz Kaiser Google Brain lukaszkaiser@google.com\n",
+       "\n",
+       "∗\n",
+       "\n",
+       "Illia Polosukhin ∗ ‡\n",
+       "\n",
+       "illia.polosukhin@gmail.com\n",
+       "\n",
+       "##\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------------------------------------------------------------- \n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> Abstract\n",
+       "\n",
+       "The dominant sequence transduction models are based on complex recurrent or \n",
+       "convolutional neural networks that include an encoder and a decoder. The best \n",
+       "performing models also connect the encoder and decoder through an attention \n",
+       "mechanism. We propose a new simple network architecture, the Transformer, based \n",
+       "solely on attention mechanisms, dispensing with recurrence and convolutions \n",
+       "entirely. Experiments on two machine translation tasks show these models to be \n",
+       "superior in quality while being more parallelizable and requiring significantly \n",
+       "less time to train. Our model achieves 28.4 BLEU on the WMT 2014 \n",
+       "Englishto-German translation task, improving over the existing best results, \n",
+       "including ensembles, by over 2 BLEU. On the WMT 2014 English-to-French \n",
+       "translation task, our model establishes a new single-model state-of-the-art BLEU\n",
+       "score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the\n",
+       "training costs of the best models from the literature. We show that the \n",
+       "Transformer generalizes well to other tasks by applying it successfully to \n",
+       "English constituency parsing both with large and limited training data.\n",
+       "\n",
+       "##\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       " Abstract\n",
+       "\n",
+       "The dominant sequence transduction models are based on complex recurrent or \n",
+       "convolutional neural networks that include an encoder and a decoder. The best \n",
+       "performing models also connect the encoder and decoder through an attention \n",
+       "mechanism. We propose a new simple network architecture, the Transformer, based \n",
+       "solely on attention mechanisms, dispensing with recurrence and convolutions \n",
+       "entirely. Experiments on two machine translation tasks show these models to be \n",
+       "superior in quality while being more parallelizable and requiring significantly \n",
+       "less time to train. Our model achieves 28.4 BLEU on the WMT 2014 \n",
+       "Englishto-German translation task, improving over the existing best results, \n",
+       "including ensembles, by over 2 BLEU. On the WMT 2014 English-to-French \n",
+       "translation task, our model establishes a new single-model state-of-the-art BLEU\n",
+       "score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the\n",
+       "training costs of the best models from the literature. We show that the \n",
+       "Transformer generalizes well to other tasks by applying it successfully to \n",
+       "English constituency parsing both with large and limited training data.\n",
+       "\n",
+       "##\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------------------------------------------------------------- \n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> 1 Introduction\n",
+       "\n",
+       "Recurrent neural networks, long short-term memory [13] and gated recurrent [7] \n",
+       "neural networks in particular, have been firmly established as state of the art \n",
+       "approaches in sequence modeling and transduction problems such as language \n",
+       "modeling and machine translation [35, 2, 5]. Numerous efforts have since \n",
+       "continued to push the boundaries of recurrent language models and \n",
+       "encoder-decoder architectures [38, 24, 15].\n",
+       "\n",
+       "Recurrent models typically factor computation along the symbol positions of the \n",
+       "input and output sequences. Aligning the positions to steps in computation time,\n",
+       "they generate a sequence of hidden states h t , as a function of the previous \n",
+       "hidden state h t -1 and the input for position t . This inherently sequential \n",
+       "nature precludes parallelization within training examples, which becomes \n",
+       "critical at longer sequence lengths, as memory constraints limit batching across\n",
+       "examples. Recent work has achieved significant improvements in computational \n",
+       "efficiency through factorization tricks [21] and conditional computation [32], \n",
+       "while also improving model performance in case of the latter. The fundamental \n",
+       "constraint of sequential computation, however, remains.\n",
+       "\n",
+       "Attention mechanisms have become an integral part of compelling sequence \n",
+       "modeling and transduction models in various tasks, allowing modeling of \n",
+       "dependencies without regard to their distance in the input or output sequences \n",
+       "[2, 19]. In all but a few cases [27], however, such attention mechanisms are \n",
+       "used in conjunction with a recurrent network.\n",
+       "\n",
+       "In this work we propose the Transformer, a model architecture eschewing \n",
+       "recurrence and instead relying entirely on an attention mechanism to draw global\n",
+       "dependencies between input and output. The Transformer allows for significantly \n",
+       "more parallelization and can reach a new state of the art in translation quality\n",
+       "after being trained for as little as twelve hours on eight P100 GPUs.\n",
+       "\n",
+       "##\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       " 1 Introduction\n",
+       "\n",
+       "Recurrent neural networks, long short-term memory [13] and gated recurrent [7] \n",
+       "neural networks in particular, have been firmly established as state of the art \n",
+       "approaches in sequence modeling and transduction problems such as language \n",
+       "modeling and machine translation [35, 2, 5]. Numerous efforts have since \n",
+       "continued to push the boundaries of recurrent language models and \n",
+       "encoder-decoder architectures [38, 24, 15].\n",
+       "\n",
+       "Recurrent models typically factor computation along the symbol positions of the \n",
+       "input and output sequences. Aligning the positions to steps in computation time,\n",
+       "they generate a sequence of hidden states h t , as a function of the previous \n",
+       "hidden state h t -1 and the input for position t . This inherently sequential \n",
+       "nature precludes parallelization within training examples, which becomes \n",
+       "critical at longer sequence lengths, as memory constraints limit batching across\n",
+       "examples. Recent work has achieved significant improvements in computational \n",
+       "efficiency through factorization tricks [21] and conditional computation [32], \n",
+       "while also improving model performance in case of the latter. The fundamental \n",
+       "constraint of sequential computation, however, remains.\n",
+       "\n",
+       "Attention mechanisms have become an integral part of compelling sequence \n",
+       "modeling and transduction models in various tasks, allowing modeling of \n",
+       "dependencies without regard to their distance in the input or output sequences \n",
+       "[2, 19]. In all but a few cases [27], however, such attention mechanisms are \n",
+       "used in conjunction with a recurrent network.\n",
+       "\n",
+       "In this work we propose the Transformer, a model architecture eschewing \n",
+       "recurrence and instead relying entirely on an attention mechanism to draw global\n",
+       "dependencies between input and output. The Transformer allows for significantly \n",
+       "more parallelization and can reach a new state of the art in translation quality\n",
+       "after being trained for as little as twelve hours on eight P100 GPUs.\n",
+       "\n",
+       "##\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------------------------------------------------------------- \n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> 2 Background\n",
+       "\n",
+       "The goal of reducing sequential computation also forms the foundation of the \n",
+       "Extended Neural GPU [16], ByteNet [18] and ConvS2S [9], all of which use \n",
+       "convolutional neural networks as basic building block, computing hidden \n",
+       "representations in parallel for all input and output positions. In these models,\n",
+       "the number of operations required to relate signals from two arbitrary input or \n",
+       "output positions grows in the distance between positions, linearly for ConvS2S \n",
+       "and logarithmically for ByteNet. This makes it more difficult to learn \n",
+       "dependencies between distant positions [12]. In the Transformer this is reduced \n",
+       "to a constant number of operations, albeit at the cost of reduced effective \n",
+       "resolution due to averaging attention-weighted positions, an effect we \n",
+       "counteract with Multi-Head Attention as described in section 3.2.\n",
+       "\n",
+       "Self-attention, sometimes called intra-attention is an attention mechanism \n",
+       "relating different positions of a single sequence in order to compute a \n",
+       "representation of the sequence. Self-attention has been used successfully in a \n",
+       "variety of tasks including reading comprehension, abstractive summarization, \n",
+       "textual entailment and learning task-independent sentence representations [4, \n",
+       "27, 28, 22].\n",
+       "\n",
+       "End-to-end memory networks are based on a recurrent attention mechanism instead \n",
+       "of sequencealigned recurrence and have been shown to perform well on \n",
+       "simple-language question answering and language modeling tasks [34].\n",
+       "\n",
+       "To the best of our knowledge, however, the Transformer is the first transduction\n",
+       "model relying entirely on self-attention to compute representations of its input\n",
+       "and output without using sequencealigned RNNs or convolution. In the following \n",
+       "sections, we will describe the Transformer, motivate self-attention and discuss \n",
+       "its advantages over models such as [17, 18] and [9].\n",
+       "\n",
+       "##\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       " 2 Background\n",
+       "\n",
+       "The goal of reducing sequential computation also forms the foundation of the \n",
+       "Extended Neural GPU [16], ByteNet [18] and ConvS2S [9], all of which use \n",
+       "convolutional neural networks as basic building block, computing hidden \n",
+       "representations in parallel for all input and output positions. In these models,\n",
+       "the number of operations required to relate signals from two arbitrary input or \n",
+       "output positions grows in the distance between positions, linearly for ConvS2S \n",
+       "and logarithmically for ByteNet. This makes it more difficult to learn \n",
+       "dependencies between distant positions [12]. In the Transformer this is reduced \n",
+       "to a constant number of operations, albeit at the cost of reduced effective \n",
+       "resolution due to averaging attention-weighted positions, an effect we \n",
+       "counteract with Multi-Head Attention as described in section 3.2.\n",
+       "\n",
+       "Self-attention, sometimes called intra-attention is an attention mechanism \n",
+       "relating different positions of a single sequence in order to compute a \n",
+       "representation of the sequence. Self-attention has been used successfully in a \n",
+       "variety of tasks including reading comprehension, abstractive summarization, \n",
+       "textual entailment and learning task-independent sentence representations [4, \n",
+       "27, 28, 22].\n",
+       "\n",
+       "End-to-end memory networks are based on a recurrent attention mechanism instead \n",
+       "of sequencealigned recurrence and have been shown to perform well on \n",
+       "simple-language question answering and language modeling tasks [34].\n",
+       "\n",
+       "To the best of our knowledge, however, the Transformer is the first transduction\n",
+       "model relying entirely on self-attention to compute representations of its input\n",
+       "and output without using sequencealigned RNNs or convolution. In the following \n",
+       "sections, we will describe the Transformer, motivate self-attention and discuss \n",
+       "its advantages over models such as [17, 18] and [9].\n",
+       "\n",
+       "##\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------------------------------------------------------------- \n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Let's have a quick look at our chunks\n",
+    "for chunk in chunks[:4]:\n",
+    "  rprint(chunk.text)\n",
+    "  print('-'*80, '\\n\\n')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ptvqLz8ccVXs"
+   },
+   "source": [
+    "## Step 3: Retrieval"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FZdHJXpecCxN"
+   },
+   "source": [
+    "### Step 3.1: Get the embeddings for each of the chunks!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "uBsn0wr_RrqF",
+    "outputId": "61ab7db6-c4e7-450e-b2e6-0982faf74a78"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(58, 512)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create some dummy data as strings or other serializable objects\n",
+    "items = [chunk.text for chunk in chunks]\n",
+    "vectors = model.encode(items)\n",
+    "print(vectors.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Vtdz0L0Rch23"
+   },
+   "source": [
+    "### Step 3.2: Create an index with the chunks and embeddings for retrieval"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "m1mA-weURs1C"
+   },
+   "outputs": [],
+   "source": [
+    "# Initialize the Vicinity instance (using the basic backend and cosine metric)\n",
+    "vicinity = Vicinity.from_vectors_and_items(\n",
+    "    vectors=vectors,\n",
+    "    items=items,\n",
+    "    backend_type=Backend.BASIC,\n",
+    "    metric=Metric.COSINE\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "E59tnX8LcrJV"
+   },
+   "source": [
+    "### Step 3.3: Get results for a given query from the index~"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "jzfUfZEYRbhQ"
+   },
+   "outputs": [],
+   "source": [
+    "# Set a query that you wish to answer, and get it's embeddings\n",
+    "query = \"What is a Multi-Head Self Attention?\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "VGLZVELlP_CJ"
+   },
+   "outputs": [],
+   "source": [
+    "# Encode the query and get the top 4 chunks\n",
+    "query_vector = model.encode(query)\n",
+    "\n",
+    "# Query for nearest neighbors with a top-k search\n",
+    "results = vicinity.query(query_vector, k=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 1000
+    },
+    "id": "Hk9mhU4-Ry6p",
+    "outputId": "d10b5c28-624d-4923-b2ee-70807082aa31"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> Attention Visualizations Input-Input Layer5\n",
+       "\n",
+       "Figure 3: An example of the attention mechanism following long-distance \n",
+       "dependencies in the encoder self-attention in layer 5 of 6. Many of the \n",
+       "attention heads attend to a distant dependency of the verb 'making', completing \n",
+       "the phrase 'making...more difficult'. Attentions here shown only for the word \n",
+       "'making'. Different colors represent different heads. Best viewed in color.\n",
+       "\n",
+       "&lt;!-- image --&gt;\n",
+       "\n",
+       "Input-Input Layer5\n",
+       "\n",
+       "Figure 4: Two attention heads, also in layer 5 of 6, apparently involved in \n",
+       "anaphora resolution. Top: Full attentions for head 5. Bottom: Isolated \n",
+       "attentions from just the word 'its' for attention heads 5 and 6. Note that the \n",
+       "attentions are very sharp for this word.\n",
+       "\n",
+       "&lt;!-- image --&gt;\n",
+       "\n",
+       "Input-Input Layer5\n",
+       "\n",
+       "Figure 5: Many of the attention heads exhibit behaviour that seems related to \n",
+       "the structure of the sentence. We give two such examples above, from two \n",
+       "different heads from the encoder self-attention at layer 5 of 6. The heads \n",
+       "clearly learned to perform different tasks.\n",
+       "\n",
+       "&lt;!-- image --&gt;\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       " Attention Visualizations Input-Input Layer5\n",
+       "\n",
+       "Figure 3: An example of the attention mechanism following long-distance \n",
+       "dependencies in the encoder self-attention in layer 5 of 6. Many of the \n",
+       "attention heads attend to a distant dependency of the verb 'making', completing \n",
+       "the phrase 'making...more difficult'. Attentions here shown only for the word \n",
+       "'making'. Different colors represent different heads. Best viewed in color.\n",
+       "\n",
+       "<!-- image -->\n",
+       "\n",
+       "Input-Input Layer5\n",
+       "\n",
+       "Figure 4: Two attention heads, also in layer 5 of 6, apparently involved in \n",
+       "anaphora resolution. Top: Full attentions for head 5. Bottom: Isolated \n",
+       "attentions from just the word 'its' for attention heads 5 and 6. Note that the \n",
+       "attentions are very sharp for this word.\n",
+       "\n",
+       "<!-- image -->\n",
+       "\n",
+       "Input-Input Layer5\n",
+       "\n",
+       "Figure 5: Many of the attention heads exhibit behaviour that seems related to \n",
+       "the structure of the sentence. We give two such examples above, from two \n",
+       "different heads from the encoder self-attention at layer 5 of 6. The heads \n",
+       "clearly learned to perform different tasks.\n",
+       "\n",
+       "<!-- image -->\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------------------------------------------------------------- \n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> 2 Background\n",
+       "\n",
+       "The goal of reducing sequential computation also forms the foundation of the \n",
+       "Extended Neural GPU [16], ByteNet [18] and ConvS2S [9], all of which use \n",
+       "convolutional neural networks as basic building block, computing hidden \n",
+       "representations in parallel for all input and output positions. In these models,\n",
+       "the number of operations required to relate signals from two arbitrary input or \n",
+       "output positions grows in the distance between positions, linearly for ConvS2S \n",
+       "and logarithmically for ByteNet. This makes it more difficult to learn \n",
+       "dependencies between distant positions [12]. In the Transformer this is reduced \n",
+       "to a constant number of operations, albeit at the cost of reduced effective \n",
+       "resolution due to averaging attention-weighted positions, an effect we \n",
+       "counteract with Multi-Head Attention as described in section 3.2.\n",
+       "\n",
+       "Self-attention, sometimes called intra-attention is an attention mechanism \n",
+       "relating different positions of a single sequence in order to compute a \n",
+       "representation of the sequence. Self-attention has been used successfully in a \n",
+       "variety of tasks including reading comprehension, abstractive summarization, \n",
+       "textual entailment and learning task-independent sentence representations [4, \n",
+       "27, 28, 22].\n",
+       "\n",
+       "End-to-end memory networks are based on a recurrent attention mechanism instead \n",
+       "of sequencealigned recurrence and have been shown to perform well on \n",
+       "simple-language question answering and language modeling tasks [34].\n",
+       "\n",
+       "To the best of our knowledge, however, the Transformer is the first transduction\n",
+       "model relying entirely on self-attention to compute representations of its input\n",
+       "and output without using sequencealigned RNNs or convolution. In the following \n",
+       "sections, we will describe the Transformer, motivate self-attention and discuss \n",
+       "its advantages over models such as [17, 18] and [9].\n",
+       "\n",
+       "##\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       " 2 Background\n",
+       "\n",
+       "The goal of reducing sequential computation also forms the foundation of the \n",
+       "Extended Neural GPU [16], ByteNet [18] and ConvS2S [9], all of which use \n",
+       "convolutional neural networks as basic building block, computing hidden \n",
+       "representations in parallel for all input and output positions. In these models,\n",
+       "the number of operations required to relate signals from two arbitrary input or \n",
+       "output positions grows in the distance between positions, linearly for ConvS2S \n",
+       "and logarithmically for ByteNet. This makes it more difficult to learn \n",
+       "dependencies between distant positions [12]. In the Transformer this is reduced \n",
+       "to a constant number of operations, albeit at the cost of reduced effective \n",
+       "resolution due to averaging attention-weighted positions, an effect we \n",
+       "counteract with Multi-Head Attention as described in section 3.2.\n",
+       "\n",
+       "Self-attention, sometimes called intra-attention is an attention mechanism \n",
+       "relating different positions of a single sequence in order to compute a \n",
+       "representation of the sequence. Self-attention has been used successfully in a \n",
+       "variety of tasks including reading comprehension, abstractive summarization, \n",
+       "textual entailment and learning task-independent sentence representations [4, \n",
+       "27, 28, 22].\n",
+       "\n",
+       "End-to-end memory networks are based on a recurrent attention mechanism instead \n",
+       "of sequencealigned recurrence and have been shown to perform well on \n",
+       "simple-language question answering and language modeling tasks [34].\n",
+       "\n",
+       "To the best of our knowledge, however, the Transformer is the first transduction\n",
+       "model relying entirely on self-attention to compute representations of its input\n",
+       "and output without using sequencealigned RNNs or convolution. In the following \n",
+       "sections, we will describe the Transformer, motivate self-attention and discuss \n",
+       "its advantages over models such as [17, 18] and [9].\n",
+       "\n",
+       "##\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------------------------------------------------------------- \n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> Scaled Dot-Product Attention\n",
+       "\n",
+       "&lt;!-- image --&gt;\n",
+       "\n",
+       "Figure 2: (left) Scaled Dot-Product Attention. (right) Multi-Head Attention \n",
+       "consists of several attention layers running in parallel.\n",
+       "\n",
+       "&lt;!-- image --&gt;\n",
+       "\n",
+       "of the values, where the weight assigned to each value is computed by a \n",
+       "compatibility function of the query with the corresponding key.\n",
+       "\n",
+       "##\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       " Scaled Dot-Product Attention\n",
+       "\n",
+       "<!-- image -->\n",
+       "\n",
+       "Figure 2: (left) Scaled Dot-Product Attention. (right) Multi-Head Attention \n",
+       "consists of several attention layers running in parallel.\n",
+       "\n",
+       "<!-- image -->\n",
+       "\n",
+       "of the values, where the weight assigned to each value is computed by a \n",
+       "compatibility function of the query with the corresponding key.\n",
+       "\n",
+       "##\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------------------------------------------------------------- \n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"> 3.2.2 Multi-Head Attention\n",
+       "\n",
+       "Instead of performing a single attention function with d model-dimensional keys,\n",
+       "values and queries, we found it beneficial to linearly project the queries, keys\n",
+       "and values h times with different, learned linear projections to d k , d k and d\n",
+       "v dimensions, respectively. On each of these projected versions of queries, keys\n",
+       "and values we then perform the attention function in parallel, yielding d v \n",
+       "-dimensional\n",
+       "\n",
+       "output values. These are concatenated and once again projected, resulting in the\n",
+       "final values, as depicted in Figure 2.\n",
+       "\n",
+       "Multi-head attention allows the model to jointly attend to information from \n",
+       "different representation subspaces at different positions. With a single \n",
+       "attention head, averaging inhibits this.\n",
+       "\n",
+       "$$MultiHead( Q,K,V ) = Concat(head 1 , ..., head h ) W O where head = Attention(\n",
+       "QW Q , KW K , V W V )$$\n",
+       "\n",
+       "$$i i i i$$\n",
+       "\n",
+       "Where the projections are parameter matrices W Q i ∈ R d model × d k , W K i ∈ R\n",
+       "d model × d k , W V i ∈ R d model × d v and W O ∈ R hd v × d model .\n",
+       "\n",
+       "In this work we employ h = 8 parallel attention layers, or heads. For each of \n",
+       "these we use d k = d v = d model /h = 64 . Due to the reduced dimension of each \n",
+       "head, the total computational cost is similar to that of single-head attention \n",
+       "with full dimensionality.\n",
+       "\n",
+       "##\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       " 3.2.2 Multi-Head Attention\n",
+       "\n",
+       "Instead of performing a single attention function with d model-dimensional keys,\n",
+       "values and queries, we found it beneficial to linearly project the queries, keys\n",
+       "and values h times with different, learned linear projections to d k , d k and d\n",
+       "v dimensions, respectively. On each of these projected versions of queries, keys\n",
+       "and values we then perform the attention function in parallel, yielding d v \n",
+       "-dimensional\n",
+       "\n",
+       "output values. These are concatenated and once again projected, resulting in the\n",
+       "final values, as depicted in Figure 2.\n",
+       "\n",
+       "Multi-head attention allows the model to jointly attend to information from \n",
+       "different representation subspaces at different positions. With a single \n",
+       "attention head, averaging inhibits this.\n",
+       "\n",
+       "$$MultiHead( Q,K,V ) = Concat(head 1 , ..., head h ) W O where head = Attention(\n",
+       "QW Q , KW K , V W V )$$\n",
+       "\n",
+       "$$i i i i$$\n",
+       "\n",
+       "Where the projections are parameter matrices W Q i ∈ R d model × d k , W K i ∈ R\n",
+       "d model × d k , W V i ∈ R d model × d v and W O ∈ R hd v × d model .\n",
+       "\n",
+       "In this work we employ h = 8 parallel attention layers, or heads. For each of \n",
+       "these we use d k = d v = d model /h = 64 . Due to the reduced dimension of each \n",
+       "head, the total computational cost is similar to that of single-head attention \n",
+       "with full dimensionality.\n",
+       "\n",
+       "##\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------------------------------------------------------------- \n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Let's have a look at the retrieved chunks\n",
+    "retrieved_chunks = [x[0] for x in results[0]]\n",
+    "\n",
+    "for chunk in retrieved_chunks:\n",
+    "  rprint(chunk)\n",
+    "  print('-'*80, '\\n\\n')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "SVTkv6mPR0Cy"
+   },
+   "source": [
+    "## Step 4: Generate an answer with the LLM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 33
+    },
+    "id": "aImQYMvhUW2e",
+    "outputId": "383a4c80-2aa9-43b7-b7cc-e3c6ee0d26fe"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">This prompt contains: 1102 tokens\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "This prompt contains: 1102 tokens\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Let's generate the prompt to use~\n",
+    "prompt = create_prompt(retrieved_chunks, query)\n",
+    "prompt_tokens = len(tokenizer.encode(prompt))\n",
+    "rprint(f\"This prompt contains: {prompt_tokens} tokens\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "5VYQXFGPSdeo"
+   },
+   "outputs": [],
+   "source": [
+    "# And finally the respose~\n",
+    "response = client.chat.completions.create(\n",
+    "    model=\"deepseek-ai/DeepSeek-R1\",\n",
+    "    messages=[{\"role\": \"user\", \"content\": prompt}],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 305
+    },
+    "id": "0l4xB1FEbYky",
+    "outputId": "ce36555f-5b55-4baa-c1d4-285c9ba88ff5"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "\n",
+       "Multi-Head Self Attention is a mechanism in the Transformer architecture that \n",
+       "enables the model to jointly process information from different representation \n",
+       "subspaces at different positions within a sequence. Instead of performing a \n",
+       "single attention function, it linearly projects the input's queries, keys, and \n",
+       "values multiple times into lower-dimensional subspaces using distinct learned \n",
+       "projections. Each projection (or \"head\") independently performs scaled \n",
+       "dot-product self-attention, which involves relating different positions of the \n",
+       "input sequence to compute a contextual representation [2][4]. \n",
+       "\n",
+       "The outputs from all heads are concatenated and linearly transformed to produce \n",
+       "the final result. This design allows the model to capture diverse dependencies, \n",
+       "such as long-range relationships or syntactic patterns, more effectively than \n",
+       "single-head attention. For example, different heads may specialize in tasks like\n",
+       "resolving anaphora or tracking verb phrases [1]. The computational efficiency is\n",
+       "maintained by reducing the dimensionality of each head (e.g., using 8 heads with\n",
+       "64 dimensions each in the original Transformer) while preserving the total \n",
+       "parameter count [4].\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n",
+       "\n",
+       "Multi-Head Self Attention is a mechanism in the Transformer architecture that \n",
+       "enables the model to jointly process information from different representation \n",
+       "subspaces at different positions within a sequence. Instead of performing a \n",
+       "single attention function, it linearly projects the input's queries, keys, and \n",
+       "values multiple times into lower-dimensional subspaces using distinct learned \n",
+       "projections. Each projection (or \"head\") independently performs scaled \n",
+       "dot-product self-attention, which involves relating different positions of the \n",
+       "input sequence to compute a contextual representation [2][4]. \n",
+       "\n",
+       "The outputs from all heads are concatenated and linearly transformed to produce \n",
+       "the final result. This design allows the model to capture diverse dependencies, \n",
+       "such as long-range relationships or syntactic patterns, more effectively than \n",
+       "single-head attention. For example, different heads may specialize in tasks like\n",
+       "resolving anaphora or tracking verb phrases [1]. The computational efficiency is\n",
+       "maintained by reducing the dimensionality of each head (e.g., using 8 heads with\n",
+       "64 dimensions each in the original Transformer) while preserving the total \n",
+       "parameter count [4].\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Print the final response without the thinking tokens\n",
+    "answer = response.choices[0].message.content.split(\"</think>\")[-1]\n",
+    "rprint(answer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rVB0wXjGvC41"
+   },
+   "source": [
+    "## Conclusions\n",
+    "\n",
+    "We got a great answer back from Deepseek R1, while saving about **~8,800 input tokens** to Deepseek!\n",
+    "\n",
+    "Hope you liked the notebook~ If you find chonkie useful for your applications and need some support with it, reach out at `support@chonkie.ai` or over the Discord server."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-mgUVHRnUjiK"
+   },
+   "source": [
+    "# Fin."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "0937dafccc1547069a553c0421028172": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "0e10ceb014ed428891a8cf05c2a2251e": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_34e293cc15484477b940eb870743dcdc",
+      "placeholder": "​",
+      "style": "IPY_MODEL_f39f8a5a039a4b4e8b9ca06cc874a465",
+      "value": " 202/202 [00:00&lt;00:00, 4.22kB/s]"
+     }
+    },
+    "12b10bf1df0542899733ea423889ddce": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "13e1bdf79aff423c9624874cb9c9a870": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "20d7b3de1705424c9e61db230c43fd95": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "2d74a3e80b9646be88ed4bc5158ff8a2": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "30c134be926948b3959ce7a723c0ae8a": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_5de1ff0789f547e7a6147888e08aca64",
+      "placeholder": "​",
+      "style": "IPY_MODEL_985458e3563244c9b94525d831fd90dc",
+      "value": " 3.58k/3.58k [00:00&lt;00:00, 52.6kB/s]"
+     }
+    },
+    "34e293cc15484477b940eb870743dcdc": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "3e30645b7a384ed48129e7afa471a982": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "4003e08660c64d10a18d74bd47f19275": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "4b6bd295aba748bd9670cd06a69682a9": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "509b942cf9e64a0c9f4ae2579a986639": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "51be8798d9b8426081c9cb8955624b9c": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "5727087483534a61a3a68ce3a8763cd6": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "5a3fd46acb0c447790c980a98f62e361": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "5a912a0e334d4ccfb9df57b27a22f38a": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_5727087483534a61a3a68ce3a8763cd6",
+      "placeholder": "​",
+      "style": "IPY_MODEL_509b942cf9e64a0c9f4ae2579a986639",
+      "value": " 129M/129M [00:03&lt;00:00, 43.2MB/s]"
+     }
+    },
+    "5de1ff0789f547e7a6147888e08aca64": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "66a7d89614e94d8491302a797a4c12e5": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_b1a1836c316342109ee8718629380efe",
+      "placeholder": "​",
+      "style": "IPY_MODEL_f67a93d013984b40b3055eb5c546fec4",
+      "value": " 16.7k/16.7k [00:00&lt;00:00, 588kB/s]"
+     }
+    },
+    "6be572d089be4626ab684e4721416488": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_87a26b89a5cb4d518cd9bf2b330bd498",
+      "max": 16673,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_9fc9f9eaec244b0eb4c92c20301c6e63",
+      "value": 16673
+     }
+    },
+    "6be64614024c438daaea95a47b144c04": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "6c1da5303cad44098dafd87763b609f7": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "708454183e4b460f90f7fa3f430bc332": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "755799f1e6b14b2f91f19edf06964436": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "7ae08b4d31924479809eb7d3f2fb38fb": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_8a3bb9d63ba640c6a0c63c7bd08d50cf",
+      "max": 7847602,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_a0f4ea3ee6f04fd4ba0e5cb37f24b343",
+      "value": 7847602
+     }
+    },
+    "7d0bf8146d2747f2b518ddb43f203c88": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "853eb421b8364fe0a7e3a2e91be79aaf": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "8698fbf252024bea85051703f9aacbf7": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "87a26b89a5cb4d518cd9bf2b330bd498": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "8a3bb9d63ba640c6a0c63c7bd08d50cf": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "8b00bb6eca4b4b68b61fae4dcaafe949": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_d2badcdaf80e4c759aa829f450c1807b",
+       "IPY_MODEL_6be572d089be4626ab684e4721416488",
+       "IPY_MODEL_66a7d89614e94d8491302a797a4c12e5"
+      ],
+      "layout": "IPY_MODEL_13e1bdf79aff423c9624874cb9c9a870"
+     }
+    },
+    "8d0b2d93f67c4ff2a633660782125131": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "8d15667d78bc400080d7b4c6bdb396b2": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_20d7b3de1705424c9e61db230c43fd95",
+      "max": 202,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_8698fbf252024bea85051703f9aacbf7",
+      "value": 202
+     }
+    },
+    "90d2e938d0c1476588c088acf1b86685": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_0937dafccc1547069a553c0421028172",
+      "max": 3584,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_4003e08660c64d10a18d74bd47f19275",
+      "value": 3584
+     }
+    },
+    "9324441028b1496e87c7059bcd1b371b": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "97112c2b170148e5b937afc4da6ab1c4": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "97c14d92f1314350a869fa597b5de66c": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "985458e3563244c9b94525d831fd90dc": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "9aec040202fb4a58973ede6f4d760707": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_a8bc59e034fe4daeaa00bfeadd2635f6",
+       "IPY_MODEL_8d15667d78bc400080d7b4c6bdb396b2",
+       "IPY_MODEL_0e10ceb014ed428891a8cf05c2a2251e"
+      ],
+      "layout": "IPY_MODEL_6be64614024c438daaea95a47b144c04"
+     }
+    },
+    "9cbcc6b7d1354e5ea98eebf487d2a94f": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "9fc9f9eaec244b0eb4c92c20301c6e63": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "a0f4ea3ee6f04fd4ba0e5cb37f24b343": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "a3eacad2d39449d0be3ba3e606dc5cf7": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_ac5ee023c9c943a0a5ed531fea511b1a",
+       "IPY_MODEL_e44835492ff645f8a588a7d7ec1f04b5",
+       "IPY_MODEL_d2610ed202794ec2918482e18ca457fc"
+      ],
+      "layout": "IPY_MODEL_6c1da5303cad44098dafd87763b609f7"
+     }
+    },
+    "a54f3fbe457c4eb180aaeebb3d849ba0": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_d36682aa48f04f3dbc1c9c67ec6b12f9",
+      "placeholder": "​",
+      "style": "IPY_MODEL_adcd55623850471eb401625e37094039",
+      "value": "model.safetensors: 100%"
+     }
+    },
+    "a8bc59e034fe4daeaa00bfeadd2635f6": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_708454183e4b460f90f7fa3f430bc332",
+      "placeholder": "​",
+      "style": "IPY_MODEL_cbcec8f8093c4a92b211ea0fb8885a3a",
+      "value": "config.json: 100%"
+     }
+    },
+    "ac5ee023c9c943a0a5ed531fea511b1a": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_4b6bd295aba748bd9670cd06a69682a9",
+      "placeholder": "​",
+      "style": "IPY_MODEL_dec5a689253f41acaf392d1ef20f494b",
+      "value": "tokenizer.json: 100%"
+     }
+    },
+    "adcd55623850471eb401625e37094039": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "b1a1836c316342109ee8718629380efe": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "b568a2f59a154ddeafb78710e1518604": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "c49defa1fcea4d30bdec9435d651e2b1": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_ebed0e46009745ae9818d16a9dade7ef",
+      "placeholder": "​",
+      "style": "IPY_MODEL_755799f1e6b14b2f91f19edf06964436",
+      "value": "tokenizer_config.json: 100%"
+     }
+    },
+    "ca28c121e84e425185a4d801c3930b69": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_dc7fdda7a5354621978c17ec22ed0330",
+       "IPY_MODEL_7ae08b4d31924479809eb7d3f2fb38fb",
+       "IPY_MODEL_ce4b6e104d7b433da4eb1ee3a7278182"
+      ],
+      "layout": "IPY_MODEL_2d74a3e80b9646be88ed4bc5158ff8a2"
+     }
+    },
+    "cbcec8f8093c4a92b211ea0fb8885a3a": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "ce4b6e104d7b433da4eb1ee3a7278182": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_853eb421b8364fe0a7e3a2e91be79aaf",
+      "placeholder": "​",
+      "style": "IPY_MODEL_51be8798d9b8426081c9cb8955624b9c",
+      "value": " 7.85M/7.85M [00:01&lt;00:00, 5.71MB/s]"
+     }
+    },
+    "d2610ed202794ec2918482e18ca457fc": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_8d0b2d93f67c4ff2a633660782125131",
+      "placeholder": "​",
+      "style": "IPY_MODEL_b568a2f59a154ddeafb78710e1518604",
+      "value": " 1.49M/1.49M [00:00&lt;00:00, 1.79MB/s]"
+     }
+    },
+    "d2badcdaf80e4c759aa829f450c1807b": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_5a3fd46acb0c447790c980a98f62e361",
+      "placeholder": "​",
+      "style": "IPY_MODEL_97112c2b170148e5b937afc4da6ab1c4",
+      "value": "README.md: 100%"
+     }
+    },
+    "d36682aa48f04f3dbc1c9c67ec6b12f9": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "d3f68b3fb7b4494294922e06de7dbe53": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_c49defa1fcea4d30bdec9435d651e2b1",
+       "IPY_MODEL_90d2e938d0c1476588c088acf1b86685",
+       "IPY_MODEL_30c134be926948b3959ce7a723c0ae8a"
+      ],
+      "layout": "IPY_MODEL_9cbcc6b7d1354e5ea98eebf487d2a94f"
+     }
+    },
+    "dc7fdda7a5354621978c17ec22ed0330": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_3e30645b7a384ed48129e7afa471a982",
+      "placeholder": "​",
+      "style": "IPY_MODEL_9324441028b1496e87c7059bcd1b371b",
+      "value": "tokenizer.json: 100%"
+     }
+    },
+    "de9b6916a9ec4d788ba0c07b4d397480": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "dec5a689253f41acaf392d1ef20f494b": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "e3203d311565460d894ee217af5b5f42": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "e44835492ff645f8a588a7d7ec1f04b5": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_7d0bf8146d2747f2b518ddb43f203c88",
+      "max": 1493150,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_de9b6916a9ec4d788ba0c07b4d397480",
+      "value": 1493150
+     }
+    },
+    "ebbfe03efc654c08a13ad2d14b7b5c31": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_97c14d92f1314350a869fa597b5de66c",
+      "max": 129210456,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_12b10bf1df0542899733ea423889ddce",
+      "value": 129210456
+     }
+    },
+    "ebed0e46009745ae9818d16a9dade7ef": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "f39f8a5a039a4b4e8b9ca06cc874a465": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "f3f468050cb5486589c68d273fa859a6": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_a54f3fbe457c4eb180aaeebb3d849ba0",
+       "IPY_MODEL_ebbfe03efc654c08a13ad2d14b7b5c31",
+       "IPY_MODEL_5a912a0e334d4ccfb9df57b27a22f38a"
+      ],
+      "layout": "IPY_MODEL_e3203d311565460d894ee217af5b5f42"
+     }
+    },
+    "f67a93d013984b40b3055eb5c546fec4": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -13,10 +13,10 @@ from .chunker import (
 from .embeddings import (
     AutoEmbeddings,
     BaseEmbeddings,
+    CohereEmbeddings,
     Model2VecEmbeddings,
     OpenAIEmbeddings,
     SentenceTransformerEmbeddings,
-    CohereEmbeddings,
 )
 from .refinery import (
     BaseRefinery,

--- a/src/chonkie/embeddings/__init__.py
+++ b/src/chonkie/embeddings/__init__.py
@@ -1,9 +1,9 @@
 from .auto import AutoEmbeddings
 from .base import BaseEmbeddings
+from .cohere import CohereEmbeddings
 from .model2vec import Model2VecEmbeddings
 from .openai import OpenAIEmbeddings
 from .sentence_transformer import SentenceTransformerEmbeddings
-from .cohere import CohereEmbeddings
 
 # Add all embeddings classes to __all__
 __all__ = [

--- a/src/chonkie/embeddings/cohere.py
+++ b/src/chonkie/embeddings/cohere.py
@@ -7,8 +7,9 @@ import numpy as np
 
 from .base import BaseEmbeddings
 
+
 class CohereEmbeddings(BaseEmbeddings):
-    """Cohere embeddings implementation using their API"""
+    """Cohere embeddings implementation using their API."""
 
     AVAILABLE_MODELS = {
         # cohere v3.0 models
@@ -45,8 +46,8 @@ class CohereEmbeddings(BaseEmbeddings):
             timeout: timeout in seconds for API requests
             batch_size: maximum number of texts to embed in one API call (maximum allowed by Cohere is 96)
             show_warnings: whether to show warnings about token usage and truncation
-        """
 
+        """
         super().__init__()
         if not self.is_available():
             raise ImportError(
@@ -54,9 +55,9 @@ class CohereEmbeddings(BaseEmbeddings):
             )
         else:
             global cohere
-            import tokenizers
             import requests
-            from cohere import ClientV2 # using v2
+            import tokenizers
+            from cohere import ClientV2  # using v2
 
         if model not in self.AVAILABLE_MODELS:
             raise ValueError(
@@ -87,7 +88,7 @@ class CohereEmbeddings(BaseEmbeddings):
 
 
     def embed(self, text: str) -> np.ndarray:
-        """Generate embeddings for a single text"""
+        """Generate embeddings for a single text."""
         token_count = self.count_tokens(text)
         if token_count > 512 and self._show_warnings:   # Cohere models max_context_length
             warnings.warn(
@@ -175,7 +176,7 @@ class CohereEmbeddings(BaseEmbeddings):
         return len(self._tokenizer.encode(text, add_special_tokens=False))
     
     def count_tokens_batch(self, texts: List[str]) -> List[int]:
-        """Count tokens in multiple texts"""
+        """Count tokens in multiple texts."""
         tokens = self._tokenizer.encode_batch(texts, add_special_tokens=False)
         return [len(t) for t in tokens]
     
@@ -187,11 +188,11 @@ class CohereEmbeddings(BaseEmbeddings):
 
     @property
     def dimension(self) -> int:
-        """Return the embedding dimension"""
+        """Return the embedding dimension."""
         return self._dimension
     
     def get_tokenizer_or_token_counter(self):
-        """Return a tokenizers tokenizer object of the current model"""
+        """Return a tokenizers tokenizer object of the current model."""
         return self._tokenizer
     
     @classmethod

--- a/src/chonkie/embeddings/registry.py
+++ b/src/chonkie/embeddings/registry.py
@@ -3,10 +3,10 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Pattern, Type, Union
 
 from .base import BaseEmbeddings
+from .cohere import CohereEmbeddings
 from .model2vec import Model2VecEmbeddings
 from .openai import OpenAIEmbeddings
 from .sentence_transformer import SentenceTransformerEmbeddings
-from .cohere import CohereEmbeddings
 
 
 @dataclass

--- a/src/chonkie/refinery/overlap.py
+++ b/src/chonkie/refinery/overlap.py
@@ -1,17 +1,17 @@
 """Refinery class which adds overlap as context to chunks."""
 
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 from chonkie.refinery.base import BaseRefinery
-from chonkie.types import Chunk, Context, SemanticChunk, SentenceChunk
-
+from chonkie.types import Chunk, Context, SemanticChunk, SentenceChunk, RecursiveRules
 
 class OverlapRefinery(BaseRefinery):
     """Refinery class which adds overlap as context to chunks.
 
-    This refinery provides two methods for calculating overlap:
+    This refinery provides three methods for calculating overlap:
     1. Exact: Uses a tokenizer to precisely determine token boundaries
     2. Approximate: Estimates tokens based on text length ratios
+    3. Recursive: Uses hierarchical rules to find natural boundaries in text
 
     It can handle different types of chunks (basic Chunks, SentenceChunks,
     and SemanticChunks) and can optionally update the chunk text to include
@@ -21,38 +21,60 @@ class OverlapRefinery(BaseRefinery):
     def __init__(
         self,
         context_size: int = 128,
+        min_tokens: Optional[int] = None,
         tokenizer: Any = None,
+        rules: Optional[RecursiveRules] = None,
+        method: str = "static",
         mode: str = "suffix",
         merge_context: bool = True,
         inplace: bool = True,
         approximate: bool = True,
     ) -> None:
         """Initialize the OverlapRefinery class.
-
+        
         Args:
-            context_size: Number of tokens to include in context
+            context_size: Maximum number of tokens to include in context
+            min_tokens: Minimum number of tokens required for recursive method
             tokenizer: Optional tokenizer for exact token counting
-            merge_context: Whether to merge context with chunk text
-            inplace: Whether to update chunks in place
+            rules: Optional rules for recursive boundary finding
+            method: Either 'static' or 'recursive'
+            mode: Either 'suffix' or 'prefix'
+            merge_context: Whether to merge context into chunk text
+            inplace: Whether to modify chunks in place
             approximate: Whether to use approximate token counting
-            mode: Whether to add context to the prefix or suffix
-
         """
         super().__init__(context_size)
+        
+        # Validate method
+        if method not in ["static", "recursive"]:
+            raise ValueError("method must be either 'static' or 'recursive'")
+            
+        # Validate mode
+        if mode not in ["suffix", "prefix"]:
+            raise ValueError("mode must be either 'suffix' or 'prefix'")
+            
+        # Validate recursive-specific parameters
+        if method == "recursive":
+            if min_tokens is None:
+                raise ValueError("min_tokens must be specified when using recursive method")
+            if min_tokens > context_size:
+                raise ValueError("min_tokens cannot be greater than context_size")
+                
+        self.method = method
+        self.min_tokens = min_tokens
+        self.rules = rules if rules else RecursiveRules()
         self.merge_context = merge_context
         self.inplace = inplace
         self.mode = mode
 
-        # If tokenizer provided, we can do exact token counting
+        # Set up tokenizer and counting method
         if tokenizer is not None:
             self.tokenizer = tokenizer
             self._tokenizer_backend = self._get_tokenizer_backend()
             self.approximate = approximate
         else:
-            # Without tokenizer, must use approximate method
             self.approximate = True
-        
-        # Average number of characters per token
+            
         self._AVG_CHAR_PER_TOKEN = 7
     
     def _get_tokenizer_backend(self) -> str:
@@ -110,85 +132,250 @@ class OverlapRefinery(BaseRefinery):
         else:
             raise ValueError(f"Unsupported tokenizer backend: {self._tokenizer_backend}")     
 
-    def _get_refined_chunks(
-        self, chunks: List[Chunk], inplace: bool = True
-    ) -> List[Chunk]:
-        """Convert regular chunks to refined chunks with progressive memory cleanup.
+    def _count_tokens(self, text: str) -> int:
+        """Unified token counting method."""
+        if not text:
+            return 0
+        if hasattr(self, "tokenizer") and not self.approximate:
+            return len(self.tokenizer.encode(text))
+        return len(text) // self._AVG_CHAR_PER_TOKEN
 
-        This method takes regular chunks and converts them to RefinedChunks one at a
-        time. When inplace is True, it progressively removes chunks from the input
-        list to minimize memory usage.
-
-        The conversion preserves all relevant information from the original chunks,
-        including sentences and embeddings if they exist. This allows us to maintain
-        the full capabilities of semantic chunks while adding refinement features.
-
-        Args:
-            chunks: List of original chunks to convert
-            inplace: Whether to modify the input list during conversion
-
-        Returns:
-            List of RefinedChunks without any context (context is added later)
-
-        Example:
-            For memory efficiency with large datasets:
-            ```
-            chunks = load_large_dataset()  # Many chunks
-            refined = refinery._get_refined_chunks(chunks, inplace=True)
-            # chunks is now empty, memory is freed
-            ```
-
-        """
+    def _validate_chunks(self, chunks: List[Chunk]) -> None:
+        """Validate chunk inputs."""
         if not chunks:
-            return []
+            return
+            
+        if len(set(type(chunk) for chunk in chunks)) > 1:
+            raise ValueError("All chunks must be of the same type")
 
-        refined_chunks = []
-
-        # Use enumerate to track position without modifying list during iteration
-        for i in range(len(chunks)):
-            if inplace:
-                # Get and remove the first chunk
-                chunk = chunks.pop(0)
+    def _find_boundary_with_rules(self, text: str, rule: RecursiveRules, 
+                                direction: str = "backward") -> Optional[Tuple[str, int]]:
+        """Generic boundary finding logic that works in both directions."""
+        if not rule.delimiters:
+            return None
+            
+        for delimiter in rule.delimiters:
+            parts = text.split(delimiter)
+            if len(parts) <= 1:
+                continue
+                
+            if direction == "backward":
+                # Build context from the end
+                current_text = ""
+                accumulated_parts = []
+                
+                for part in reversed(parts):
+                    if not part:
+                        continue
+                        
+                    test_text = part + delimiter + current_text
+                    token_count = self._count_tokens(test_text)
+                    
+                    if token_count >= self.min_tokens:
+                        if accumulated_parts:
+                            final_text = part + delimiter + delimiter.join(accumulated_parts)
+                        else:
+                            final_text = test_text
+                            
+                        try:
+                            start_pos = text.rindex(final_text)
+                            return final_text, start_pos
+                        except ValueError:
+                            continue
+                            
+                    accumulated_parts.insert(0, part)
+                    current_text = test_text
             else:
-                # Just get a reference if not modifying in place
-                chunk = chunks[i]
+                # Build context from start
+                current_text = ""
+                accumulated_parts = []
+                
+                for part in parts:
+                    if not part:
+                        continue
+                        
+                    test_text = current_text + delimiter + part if current_text else part
+                    token_count = self._count_tokens(test_text)
+                    
+                    if token_count >= self.min_tokens:
+                        if accumulated_parts:
+                            final_text = delimiter.join(accumulated_parts) + delimiter + part
+                        else:
+                            final_text = test_text
+                            
+                        try:
+                            start_pos = text.index(final_text)
+                            return final_text, start_pos + len(final_text)
+                        except ValueError:
+                            continue
+                            
+                    accumulated_parts.append(part)
+                    current_text = test_text
+                    
+        return None
 
-            # Create refined version preserving appropriate attributes
-            refined_chunk = SemanticChunk(
-                text=chunk.text,
-                start_index=chunk.start_index,
-                end_index=chunk.end_index,
-                token_count=chunk.token_count,
-                # Preserve sentences and embeddings if they exist
-                sentences=chunk.sentences
-                if isinstance(chunk, (SentenceChunk, SemanticChunk))
-                else None,
-                embedding=chunk.embedding if isinstance(chunk, SemanticChunk) else None,
-                context=None,  # Context is added later in the refinement process
+    def _find_primary_boundary_context(self, text: str) -> Optional[Tuple[str, int]]:
+        """Find primary boundary context working backward."""
+        if not self.rules or len(self.rules) == 0:
+            return None
+            
+        return self._find_boundary_with_rules(text, self.rules[0], "backward")
+
+    def _find_forward_boundary_context(self, text: str) -> Optional[Tuple[str, int]]:
+        """Find primary boundary context working forward."""
+        if not self.rules or len(self.rules) == 0:
+            return None
+            
+        return self._find_boundary_with_rules(text, self.rules[0], "forward")
+
+    def _get_hierarchical_context(self, chunk: Chunk) -> Optional[Context]:
+        """Get context using hierarchical rules.
+        
+        First tries to find appropriate boundaries using primary rule,
+        then falls back to secondary rules if needed.
+        """
+        if not chunk.text:
+            return None
+            
+        # First try primary boundaries
+        primary_result = self._find_primary_boundary_context(chunk.text)
+        
+        if primary_result:
+            context_text, start_pos = primary_result
+            return Context(
+                text=context_text,
+                token_count=self._count_tokens(context_text),
+                start_index=chunk.start_index + start_pos,
+                end_index=chunk.end_index
             )
-
-            refined_chunks.append(refined_chunk)
-
-        if inplace:
-            # Clear the input list to free memory
-            chunks.clear()
-            chunks += refined_chunks
-
-        return refined_chunks
+            
+        # Fallback to trying other rules if primary boundary didn't work
+        for level_index in range(1, len(self.rules)):
+            rule = self.rules[level_index]
+            if not rule.delimiters and not rule.whitespace:
+                continue
+                
+            if rule.delimiters:
+                for delimiter in rule.delimiters:
+                    pos = chunk.text.rfind(delimiter)
+                    while pos >= 0:
+                        candidate_text = chunk.text[pos + len(delimiter):]
+                        token_count = self._count_tokens(candidate_text)
+                        
+                        if self.min_tokens <= token_count <= self.context_size:
+                            return Context(
+                                text=candidate_text,
+                                token_count=token_count,
+                                start_index=chunk.start_index + pos + len(delimiter),
+                                end_index=chunk.end_index
+                            )
+                        pos = chunk.text.rfind(delimiter, 0, pos)
+                        
+            elif rule.whitespace:
+                words = chunk.text.split()
+                current_text = ""
+                for word in reversed(words):
+                    if current_text:
+                        test_text = word + " " + current_text
+                    else:
+                        test_text = word
+                    token_count = self._count_tokens(test_text)
+                    
+                    if token_count >= self.min_tokens:
+                        try:
+                            start_pos = chunk.text.rindex(test_text)
+                            return Context(
+                                text=test_text,
+                                token_count=token_count,
+                                start_index=chunk.start_index + start_pos,
+                                end_index=chunk.end_index
+                            )
+                        except ValueError:
+                            continue
+                            
+                    current_text = test_text
+        
+        # Last resort: use the whole chunk
+        return Context(
+            text=chunk.text,
+            token_count=self._count_tokens(chunk.text),
+            start_index=chunk.start_index,
+            end_index=chunk.end_index
+        )
+    
+    def _get_forward_hierarchical_context(self, chunk: Chunk) -> Optional[Context]:
+        """Get context using hierarchical rules, working forwards."""
+        if not chunk.text:
+            return None
+            
+        # First try primary boundaries
+        primary_result = self._find_forward_boundary_context(chunk.text)
+        
+        if primary_result:
+            context_text, end_pos = primary_result
+            return Context(
+                text=context_text,
+                token_count=self._count_tokens(context_text),
+                start_index=chunk.start_index,
+                end_index=chunk.start_index + end_pos
+            )
+            
+        # Fallback to trying other rules if primary boundary didn't work
+        for level_index in range(1, len(self.rules)):
+            rule = self.rules[level_index]
+            if not rule.delimiters and not rule.whitespace:
+                continue
+                
+            if rule.delimiters:
+                for delimiter in rule.delimiters:
+                    pos = chunk.text.find(delimiter)
+                    while pos >= 0:
+                        candidate_text = chunk.text[:pos]
+                        token_count = self._count_tokens(candidate_text)
+                        
+                        if self.min_tokens <= token_count <= self.context_size:
+                            return Context(
+                                text=candidate_text,
+                                token_count=token_count,
+                                start_index=chunk.start_index,
+                                end_index=chunk.start_index + pos
+                            )
+                        pos = chunk.text.find(delimiter, pos + 1)
+                        
+            elif rule.whitespace:
+                words = chunk.text.split()
+                current_text = ""
+                for word in words:
+                    if current_text:
+                        test_text = current_text + " " + word
+                    else:
+                        test_text = word
+                    token_count = self._count_tokens(test_text)
+                    
+                    if token_count >= self.min_tokens:
+                        try:
+                            end_pos = chunk.text.index(test_text) + len(test_text)
+                            return Context(
+                                text=test_text,
+                                token_count=token_count,
+                                start_index=chunk.start_index,
+                                end_index=chunk.start_index + end_pos
+                            )
+                        except ValueError:
+                            continue
+                            
+                    current_text = test_text
+        
+        # Last resort: use the whole chunk
+        return Context(
+            text=chunk.text,
+            token_count=self._count_tokens(chunk.text),
+            start_index=chunk.start_index,
+            end_index=chunk.end_index
+        )
 
     def _prefix_overlap_token_exact(self, chunk: Chunk) -> Optional[Context]:
-        """Calculate precise token-based overlap context using tokenizer.
-
-        Takes a larger window of text from the chunk end, tokenizes it,
-        and selects exactly context_size tokens worth of text.
-
-        Args:
-            chunk: Chunk to extract context from
-
-        Returns:
-            Context object with precise token boundaries, or None if no tokenizer
-
-        """
+        """Calculate precise token-based overlap context using tokenizer."""
         if not hasattr(self, "tokenizer"):
             return None
 
@@ -197,6 +384,7 @@ class OverlapRefinery(BaseRefinery):
         text_portion = chunk.text[-char_window:]
 
         # Get exact token boundaries
+
         tokens = self._encode(text_portion) #TODO: should be self._encode; need a unified tokenizer interface
         context_tokens = min(self.context_size, len(tokens))
         context_tokens_ids = tokens[-context_tokens:]
@@ -217,12 +405,70 @@ class OverlapRefinery(BaseRefinery):
             # If context text can't be found (e.g., due to special tokens), fall back to approximate
             return self._prefix_overlap_token_approximate(chunk)
 
-    def _suffix_overlap_token_exact(self, chunk: Chunk) -> Optional[Context]:
-        """Calculate precise token-based overlap context using tokenizer.
+    def _prefix_overlap_token_approximate(self, chunk: Chunk) -> Optional[Context]:
+        """Calculate approximate token-based overlap context."""
+        # Calculate desired context size
+        context_tokens = min(self.context_size, chunk.token_count)
 
-        Takes a larger window of text from the chunk start, tokenizes it,
-        and selects exactly context_size tokens worth of text.
-        """
+        # Estimate text length based on token ratio
+        context_ratio = context_tokens / chunk.token_count
+        char_length = int(len(chunk.text) * context_ratio)
+
+        # Extract context text from end
+        context_text = chunk.text[-char_length:]
+
+        return Context(
+            text=context_text,
+            token_count=context_tokens,
+            start_index=chunk.end_index - char_length,
+            end_index=chunk.end_index,
+        )
+
+    def _get_prefix_overlap_context(self, chunk: Chunk) -> Optional[Context]:
+        """Get appropriate overlap context based on chunk type."""
+        if isinstance(chunk, SemanticChunk) or isinstance(chunk, SentenceChunk):
+            return self._prefix_overlap_sentence(chunk)
+        elif isinstance(chunk, Chunk):
+            return self._prefix_overlap_token(chunk)
+        else:
+            raise ValueError(f"Unsupported chunk type: {type(chunk)}")
+
+    def _prefix_overlap_token(self, chunk: Chunk) -> Optional[Context]:
+        """Choose between exact or approximate token overlap calculation."""
+        if self.approximate:
+            return self._prefix_overlap_token_approximate(chunk)
+        return self._prefix_overlap_token_exact(chunk)
+
+    def _prefix_overlap_sentence(self, chunk: SentenceChunk) -> Optional[Context]:
+            """Calculate overlap context based on sentences."""
+            if not chunk.sentences:
+                return None
+
+            context_sentences = []
+            total_tokens = 0
+
+            # Add sentences from the end until we hit context_size
+            for sentence in reversed(chunk.sentences):
+                if total_tokens + sentence.token_count <= self.context_size:
+                    context_sentences.insert(0, sentence)
+                    total_tokens += sentence.token_count
+                else:
+                    break
+                    
+            # If no sentences were added, add the last sentence
+            if not context_sentences:
+                context_sentences.append(chunk.sentences[-1])
+                total_tokens = chunk.sentences[-1].token_count
+
+            return Context(
+                text="".join(s.text for s in context_sentences),
+                token_count=total_tokens,
+                start_index=context_sentences[0].start_index,
+                end_index=context_sentences[-1].end_index,
+            )
+        
+    def _suffix_overlap_token_exact(self, chunk: Chunk) -> Optional[Context]:
+        """Calculate precise token-based overlap context using tokenizer."""
         if not hasattr(self, "tokenizer"):
             return None
 
@@ -248,40 +494,8 @@ class OverlapRefinery(BaseRefinery):
             # If context text can't be found (e.g., due to special tokens), fall back to approximate
             return self._suffix_overlap_token_approximate(chunk)
 
-    def _prefix_overlap_token_approximate(self, chunk: Chunk) -> Optional[Context]:
-        """Calculate approximate token-based overlap context.
-
-        Estimates token positions based on character length ratios.
-
-        Args:
-            chunk: Chunk to extract context from
-
-        Returns:
-            Context object with estimated token boundaries
-
-        """
-        # Calculate desired context size
-        context_tokens = min(self.context_size, chunk.token_count)
-
-        # Estimate text length based on token ratio
-        context_ratio = context_tokens / chunk.token_count
-        char_length = int(len(chunk.text) * context_ratio)
-
-        # Extract context text from end
-        context_text = chunk.text[-char_length:]
-
-        return Context(
-            text=context_text,
-            token_count=context_tokens,
-            start_index=chunk.end_index - char_length,
-            end_index=chunk.end_index,
-        )
-
     def _suffix_overlap_token_approximate(self, chunk: Chunk) -> Optional[Context]:
-        """Calculate approximate token-based overlap context.
-
-        Estimates token positions based on character length ratios.
-        """
+        """Calculate approximate token-based overlap context."""
         # Calculate desired context size
         context_tokens = min(self.context_size, chunk.token_count)
 
@@ -289,7 +503,7 @@ class OverlapRefinery(BaseRefinery):
         context_ratio = context_tokens / chunk.token_count
         char_length = int(len(chunk.text) * context_ratio)
 
-        # Extract context text from end
+        # Extract context text from start
         context_text = chunk.text[:char_length]
 
         return Context(
@@ -299,96 +513,37 @@ class OverlapRefinery(BaseRefinery):
             end_index=chunk.start_index + char_length,
         )
 
-    def _prefix_overlap_token(self, chunk: Chunk) -> Optional[Context]:
-        """Choose between exact or approximate token overlap calculation.
-
-        Args:
-            chunk: Chunk to process
-
-        Returns:
-            Context object from either exact or approximate calculation
-
-        """
-        if self.approximate:
-            return self._prefix_overlap_token_approximate(chunk)
-        return self._prefix_overlap_token_exact(chunk)
-
     def _suffix_overlap_token(self, chunk: Chunk) -> Optional[Context]:
-        """Choose between exact or approximate token overlap calculation.
-
-        Args:
-            chunk: Chunk to process
-
-        Returns:
-            Context object from either exact or approximate calculation
-
-        """
+        """Choose between exact or approximate token overlap calculation."""
         if self.approximate:
             return self._suffix_overlap_token_approximate(chunk)
         return self._suffix_overlap_token_exact(chunk)
 
-    def _prefix_overlap_sentence(self, chunk: SentenceChunk) -> Optional[Context]:
-        """Calculate overlap context based on sentences.
-
-        Takes sentences from the end of the chunk up to context_size tokens.
-
-        Args:
-            chunk: SentenceChunk to process
-
-        Returns:
-            Context object containing complete sentences
-
-        """
-        if not chunk.sentences:
-            return None
-
-        context_sentences = []
-        total_tokens = 0
-
-        # Add sentences from the end until we hit context_size
-        for sentence in reversed(chunk.sentences):
-            if total_tokens + sentence.token_count <= self.context_size:
-                context_sentences.insert(0, sentence)
-                total_tokens += sentence.token_count
-            else:
-                break
-        # If no sentences were added, add the last sentence
-        if not context_sentences:
-            context_sentences.append(chunk.sentences[-1])
-            total_tokens = chunk.sentences[-1].token_count
-
-        return Context(
-            text="".join(s.text for s in context_sentences),
-            token_count=total_tokens,
-            start_index=context_sentences[0].start_index,
-            end_index=context_sentences[-1].end_index,
-        )
+    def _get_suffix_overlap_context(self, chunk: Chunk) -> Optional[Context]:
+        """Get appropriate overlap context based on chunk type."""
+        if isinstance(chunk, SemanticChunk) or isinstance(chunk, SentenceChunk):
+            return self._suffix_overlap_sentence(chunk)
+        elif isinstance(chunk, Chunk):
+            return self._suffix_overlap_token(chunk)
+        else:
+            raise ValueError(f"Unsupported chunk type: {type(chunk)}")
 
     def _suffix_overlap_sentence(self, chunk: SentenceChunk) -> Optional[Context]:
-        """Calculate overlap context based on sentences from the start.
-
-        Takes sentences from the start of the chunk up to context_size tokens.
-
-        Args:
-            chunk: SentenceChunk to process
-
-        Returns:
-            Context object containing complete sentences
-
-        """
+        """Calculate overlap context based on sentences from the start."""
         if not chunk.sentences:
             return None
 
         context_sentences = []
         total_tokens = 0
 
-        # Add sentences from the end until we hit context_size
+        # Add sentences from the start until we hit context_size
         for sentence in chunk.sentences:
             if total_tokens + sentence.token_count <= self.context_size:
                 context_sentences.append(sentence)
                 total_tokens += sentence.token_count
             else:
                 break
+                
         # If no sentences were added, add the first sentence
         if not context_sentences:
             context_sentences.append(chunk.sentences[0])
@@ -401,44 +556,12 @@ class OverlapRefinery(BaseRefinery):
             end_index=context_sentences[-1].end_index,
         )
 
-    def _get_prefix_overlap_context(self, chunk: Chunk) -> Optional[Context]:
-        """Get appropriate overlap context based on chunk type."""
-        if isinstance(chunk, SemanticChunk) or isinstance(chunk, SentenceChunk):
-            return self._prefix_overlap_sentence(chunk)
-        elif isinstance(chunk, Chunk):
-            return self._prefix_overlap_token(chunk)
-        else:
-            raise ValueError(f"Unsupported chunk type: {type(chunk)}")
-
-    def _get_suffix_overlap_context(self, chunk: Chunk) -> Optional[Context]:
-        """Get appropriate overlap context based on chunk type."""
-        if isinstance(chunk, SemanticChunk) or isinstance(chunk, SentenceChunk):
-            return self._suffix_overlap_sentence(chunk)
-        elif isinstance(chunk, Chunk):
-            return self._suffix_overlap_token(chunk)
-        else:
-            raise ValueError(f"Unsupported chunk type: {type(chunk)}")
-
-    def _refine_prefix(self, chunks: List[Chunk]) -> List[Chunk]:
-        """Refine chunks by adding overlap context to the prefix.
-
-        For each chunk after the first, adds context from the previous chunk.
-        Can optionally update the chunk text to include the context.
-
-        Args:
-            chunks: List of chunks to refine
-
-        Returns:
-            List of refined chunks with added context
-
-        """
+    def _refine_prefix_static(self, chunks: List[Chunk]) -> List[Chunk]:
+        """Refine chunks using static prefix overlap."""
         if not chunks:
             return chunks
 
-        # Validate chunk types
-        if len(set(type(chunk) for chunk in chunks)) > 1:
-            raise ValueError("All chunks must be of the same type")
-
+        # Create new chunks if not modifying in place
         if not self.inplace:
             refined_chunks = [chunk.copy() for chunk in chunks]
         else:
@@ -454,6 +577,7 @@ class OverlapRefinery(BaseRefinery):
             if self.merge_context and context:
                 refined_chunks[i].text = context.text + refined_chunks[i].text
                 refined_chunks[i].start_index = context.start_index
+
                 # Update token count to include context and space
                 # Calculate new token count
                 if hasattr(self, "tokenizer") and not self.approximate:
@@ -469,26 +593,12 @@ class OverlapRefinery(BaseRefinery):
 
         return refined_chunks
 
-    def _refine_suffix(self, chunks: List[Chunk]) -> List[Chunk]:
-        """Refine chunks by adding overlap context to the suffix.
-
-        For each chunk before the last, adds context from the next chunk.
-        Can optionally update the chunk text to include the context.
-
-        Args:
-            chunks: List of chunks to refine
-
-        Returns:
-            List of refined chunks with added context
-
-        """
+    def _refine_suffix_static(self, chunks: List[Chunk]) -> List[Chunk]:
+        """Refine chunks using static suffix overlap."""
         if not chunks:
             return chunks
 
-        # Validate chunk types
-        if len(set(type(chunk) for chunk in chunks)) > 1:
-            raise ValueError("All chunks must be of the same type")
-
+        # Create new chunks if not modifying in place
         if not self.inplace:
             refined_chunks = [chunk.copy() for chunk in chunks]
         else:
@@ -504,6 +614,57 @@ class OverlapRefinery(BaseRefinery):
             if self.merge_context and context:
                 refined_chunks[i].text = refined_chunks[i].text + context.text
                 refined_chunks[i].end_index = context.end_index
+                refined_chunks[i].token_count = self._count_tokens(refined_chunks[i].text)
+
+        return refined_chunks
+
+    def _refine_prefix_hierarchical(self, chunks: List[Chunk]) -> List[Chunk]:
+        """Refine chunks using hierarchical prefix overlap."""
+        if not chunks:
+            return chunks
+
+        # Create new chunks if not modifying in place
+        if not self.inplace:
+            refined_chunks = [chunk.copy() for chunk in chunks]
+        else:
+            refined_chunks = chunks
+
+        # Process chunks after first
+        for i in range(1, len(refined_chunks)):
+            # Get hierarchical context from previous chunk
+            context = self._get_hierarchical_context(chunks[i - 1])
+            setattr(refined_chunks[i], "context", context)
+
+            # Optionally update chunk text to include context
+            if self.merge_context and context:
+                refined_chunks[i].text = context.text + refined_chunks[i].text
+                refined_chunks[i].start_index = context.start_index
+                refined_chunks[i].token_count = self._count_tokens(refined_chunks[i].text)
+
+        return refined_chunks
+
+    def _refine_suffix_hierarchical(self, chunks: List[Chunk]) -> List[Chunk]:
+        """Refine chunks using hierarchical suffix overlap."""
+        if not chunks:
+            return chunks
+
+        # Create new chunks if not modifying in place
+        if not self.inplace:
+            refined_chunks = [chunk.copy() for chunk in chunks]
+        else:
+            refined_chunks = chunks
+
+        # Process chunks before last
+        for i in range(len(refined_chunks) - 1):
+            # Get hierarchical context from next chunk
+            context = self._get_forward_hierarchical_context(chunks[i + 1])
+            setattr(refined_chunks[i], "context", context)
+
+            # Optionally update chunk text to include context
+            if self.merge_context and context:
+                refined_chunks[i].text = refined_chunks[i].text + context.text
+                refined_chunks[i].end_index = context.end_index
+
                 # Update token count to include context
                 # Calculate new token count
                 if hasattr(self, "tokenizer") and not self.approximate:
@@ -520,18 +681,30 @@ class OverlapRefinery(BaseRefinery):
         return refined_chunks
 
     def refine(self, chunks: List[Chunk]) -> List[Chunk]:
-        """Refine chunks by adding overlap context."""
-        if self.mode == "prefix":
-            return self._refine_prefix(chunks)
-        elif self.mode == "suffix":
-            return self._refine_suffix(chunks)
+        """Refine chunks by adding appropriate context."""
+        # Validate inputs first
+        if not chunks:
+            return chunks
+        self._validate_chunks(chunks)
+        
+        # Choose appropriate refinement method
+        if self.method == "recursive":
+            if self.mode == "prefix":
+                return self._refine_prefix_hierarchical(chunks)
+            elif self.mode == "suffix":
+                return self._refine_suffix_hierarchical(chunks)
+            else:
+                raise ValueError(f"Unsupported mode: {self.mode}")
         else:
-            raise ValueError(f"Unsupported mode: {self.mode}")
+            # Original static overlap logic
+            if self.mode == "prefix":
+                return self._refine_prefix_static(chunks)
+            elif self.mode == "suffix":
+                return self._refine_suffix_static(chunks)
+            else:
+                raise ValueError(f"Unsupported mode: {self.mode}")
 
     @classmethod
     def is_available(cls) -> bool:
-        """Check if the OverlapRefinery is available.
-
-        Always returns True as this refinery has no external dependencies.
-        """
+        """Check if the OverlapRefinery is available."""
         return True

--- a/src/chonkie/tokenizer.py
+++ b/src/chonkie/tokenizer.py
@@ -1,7 +1,7 @@
 """A utility module for handling tokenization across different backends."""
-from collections import defaultdict
 import importlib
 import inspect
+from collections import defaultdict
 from typing import Any, Callable, Dict, List, Union
 
 

--- a/src/chonkie/types.py
+++ b/src/chonkie/types.py
@@ -40,8 +40,6 @@ class Context:
         """Validate the Context attributes after initialization."""
         if not isinstance(self.text, str):
             raise ValueError("text must be a string")
-        if not isinstance(self.token_count, int):
-            raise ValueError("token_count must be an integer")
         if self.token_count < 0:
             raise ValueError("token_count must be non-negative")
         if (

--- a/tests/chunker/test_semantic_chunker.py
+++ b/tests/chunker/test_semantic_chunker.py
@@ -4,7 +4,7 @@ from typing import List
 import pytest
 
 from chonkie import SemanticChunker
-from chonkie.embeddings import Model2VecEmbeddings, OpenAIEmbeddings, CohereEmbeddings
+from chonkie.embeddings import CohereEmbeddings, Model2VecEmbeddings, OpenAIEmbeddings
 from chonkie.types import Chunk, SemanticChunk
 
 

--- a/tests/chunker/test_sentence_chunker.py
+++ b/tests/chunker/test_sentence_chunker.py
@@ -188,7 +188,7 @@ def test_sentence_chunker_min_sentences_per_chunk(tokenizer, sample_text):
     assert chunks[0].token_count == len(tokenizer.encode(sample_text))
 
 def test_sentence_chunker_min_characters_per_sentence(tokenizer):
-    """Test that SentenceChunker respects minimum characters per sentence and when less than min_characters_per_sentence, it is merged with the next sentence"""
+    """Test that SentenceChunker respects minimum characters per sentence and when less than min_characters_per_sentence, it is merged with the next sentence."""
     sample_text = "Hello!"
     chunker = SentenceChunker(tokenizer_or_token_counter=tokenizer, chunk_size=512, min_characters_per_sentence=20)
     chunks = chunker.chunk(sample_text)

--- a/tests/embeddings/test_auto_embeddings.py
+++ b/tests/embeddings/test_auto_embeddings.py
@@ -3,10 +3,10 @@
 import pytest
 
 from chonkie import AutoEmbeddings
+from chonkie.embeddings.cohere import CohereEmbeddings
 from chonkie.embeddings.model2vec import Model2VecEmbeddings
 from chonkie.embeddings.openai import OpenAIEmbeddings
 from chonkie.embeddings.sentence_transformer import SentenceTransformerEmbeddings
-from chonkie.embeddings.cohere import CohereEmbeddings
 
 
 @pytest.fixture

--- a/tests/embeddings/test_cohere_embeddings.py
+++ b/tests/embeddings/test_cohere_embeddings.py
@@ -3,7 +3,8 @@ import os
 import numpy as np
 import pytest
 
-from chonkie.embeddings.cohere import CohereEmbeddings 
+from chonkie.embeddings.cohere import CohereEmbeddings
+
 
 @pytest.fixture
 def embedding_model():


### PR DESCRIPTION
This pull request includes various changes to the `chonkie` package, focusing on embedding imports, docstring updates, and significant enhancements to the `OverlapRefinery` class. The most important changes include reordering imports, updating docstrings for consistency, and adding new methods to support recursive context handling in the `OverlapRefinery` class.

### Import Reordering and Cleanup:
* [`src/chonkie/__init__.py`](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408R16-L19): Reordered imports to maintain alphabetical order.
* [`src/chonkie/embeddings/__init__.py`](diffhunk://#diff-69b9908d38d6daa74572c7f51e92812b512ae8a4ed3bdce990a436eee53c6137R3-L6): Reordered imports to maintain alphabetical order.
* [`src/chonkie/embeddings/registry.py`](diffhunk://#diff-24ac16f8df6174d5a648298f8bd94c3736a99fe29ba0a84d38fdfd2b9ce5de23R6-L9): Reordered imports to maintain alphabetical order.

### Docstring Updates:
* [`src/chonkie/embeddings/cohere.py`](diffhunk://#diff-425a4f295b145e2b744bf46a03a2c2675cc461a60c80cb6be656fd585849537fR10-R12): Updated docstrings to ensure they end with a period for consistency. [[1]](diffhunk://#diff-425a4f295b145e2b744bf46a03a2c2675cc461a60c80cb6be656fd585849537fR10-R12) [[2]](diffhunk://#diff-425a4f295b145e2b744bf46a03a2c2675cc461a60c80cb6be656fd585849537fL90-R91) [[3]](diffhunk://#diff-425a4f295b145e2b744bf46a03a2c2675cc461a60c80cb6be656fd585849537fL178-R179) [[4]](diffhunk://#diff-425a4f295b145e2b744bf46a03a2c2675cc461a60c80cb6be656fd585849537fL190-R195)

### Enhancements to OverlapRefinery:
* [`src/chonkie/refinery/overlap.py`](diffhunk://#diff-80725268365cb5d6bae898943f18604b84bce3021014d1406a3db4d9bfa4723bL3-R36): Added new parameters and validation for `mode` and `method` in the `__init__` method. Introduced recursive context handling with new methods for splitting text and merging splits based on token counts. [[1]](diffhunk://#diff-80725268365cb5d6bae898943f18604b84bce3021014d1406a3db4d9bfa4723bL3-R36) [[2]](diffhunk://#diff-80725268365cb5d6bae898943f18604b84bce3021014d1406a3db4d9bfa4723bL38-R76) [[3]](diffhunk://#diff-80725268365cb5d6bae898943f18604b84bce3021014d1406a3db4d9bfa4723bL72-R96) [[4]](diffhunk://#diff-80725268365cb5d6bae898943f18604b84bce3021014d1406a3db4d9bfa4723bL91-R126) [[5]](diffhunk://#diff-80725268365cb5d6bae898943f18604b84bce3021014d1406a3db4d9bfa4723bR366-L344) [[6]](diffhunk://#diff-80725268365cb5d6bae898943f18604b84bce3021014d1406a3db4d9bfa4723bR409-R415) [[7]](diffhunk://#diff-80725268365cb5d6bae898943f18604b84bce3021014d1406a3db4d9bfa4723bR441-R680)