### PR TITLE
[Fix] Use default model in `AutoEmbeddings` if `Error: model not found` + bad `__repr__` for `SemanticSentence`

### DIFF
--- a/src/chonkie/embeddings/auto.py
+++ b/src/chonkie/embeddings/auto.py
@@ -1,5 +1,6 @@
 """AutoEmbeddings is a factory class for automatically loading embeddings."""
 
+import warnings
 from typing import Any, Union
 
 from .base import BaseEmbeddings
@@ -71,10 +72,12 @@ class AutoEmbeddings:
                     try:
                         return embeddings_cls(model, **kwargs)
                     except Exception as e:
-                        raise ValueError(
-                            f"Failed to load {embeddings_cls.__name__}: {e}"
+                        warnings.warn(
+                            f"Failed to load {embeddings_cls.__name__}: {e}. Falling back to default {embeddings_cls} model."
                         )
-            except Exception:
+                        return embeddings_cls(**kwargs)
+            except Exception as error:
+                warnings.warn(f"Failed to load embeddings via registry: {error}. Falling back to SentenceTransformerEmbeddings.")
                 # Fall back to SentenceTransformerEmbeddings if no matching implementation is found
                 from .sentence_transformer import SentenceTransformerEmbeddings
 

--- a/src/chonkie/types.py
+++ b/src/chonkie/types.py
@@ -274,7 +274,7 @@ class SemanticSentence(Sentence):
         return (
             f"SemanticSentence(text={self.text}, start_index={self.start_index}, "
             f"end_index={self.end_index}, token_count={self.token_count}, "
-            f"sentences={self.sentences})"
+            f"embedding={self.embedding})"
         )
 
 


### PR DESCRIPTION
This pull request includes several changes to improve error handling and the representation of the `SemanticSentence` class in the `chonkie` package. The most important changes are summarized below:

Error handling improvements:

* [`src/chonkie/embeddings/auto.py`](diffhunk://#diff-0e95a5656987bd1c00cac6f2cf536710a6262257c5a3a91a4a4f04608988b5cdR3): Added the `warnings` module to replace `ValueError` with warnings when loading embeddings fails, providing a fallback mechanism to the default model or `SentenceTransformerEmbeddings`. [[1]](diffhunk://#diff-0e95a5656987bd1c00cac6f2cf536710a6262257c5a3a91a4a4f04608988b5cdR3) [[2]](diffhunk://#diff-0e95a5656987bd1c00cac6f2cf536710a6262257c5a3a91a4a4f04608988b5cdL74-R80)

Class representation update:

* [`src/chonkie/types.py`](diffhunk://#diff-198c3a64562b333dd5b819d19fe9a8c1d76e400f6da24bd2070fa6d5f995e4a7L277-R277): Modified the `__repr__` method of the `SemanticSentence` class to include the `embedding` attribute instead of `sentences`.