### PR TITLE
[Chore] Bump version to v0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chonkie"
-version = "0.5.0"
+version = "0.5.1"
 description = "🦛 CHONK your texts with Chonkie ✨ - The no-nonsense RAG chunking library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -43,7 +43,7 @@ from .types import (
 )
 
 # This hippo grows with every release 🦛✨~
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __name__ = "chonkie"
 __author__ = "🦛 Chonkie AI Team"
 


### PR DESCRIPTION
This pull request includes a version update for the `chonkie` project. The version has been incremented from `0.5.0` to `0.5.1` in both the `pyproject.toml` file and the `src/chonkie/__init__.py` file.

Version update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the `version` field from `0.5.0` to `0.5.1`.
* [`src/chonkie/__init__.py`](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408L46-R46): Updated the `__version__` attribute from `0.5.0` to `0.5.1`.