### PR TITLE
[FEAT] Addition of decimal point, emails and urls handling. Better abbreviation handling.

### DIFF
--- a/src/chonkie/chef/patterns.py
+++ b/src/chonkie/chef/patterns.py
@@ -13,6 +13,11 @@ TITLES = {
     "Jr.",
     "Rev.",
     "Hon.",
+    "Mx.",
+    "Miss.",
+    "Madam.",
+    "Sir.",
+    "Lady."
 }
 
 # Academic and professional
@@ -26,6 +31,13 @@ ACADEMIC = {
     "D.Phil.",
     "LL.B.",
     "LL.M.",
+    "D.D.S.",
+    "D.V.M.",
+    "M.B.A.",
+    "B.Ed.",
+    "M.Ed.",
+    "B.Eng.",
+    "M.Eng."
 }
 
 # Latin abbreviations
@@ -38,6 +50,10 @@ LATIN = {
     "al.",
     "et al.",
     "cf.",
+    "N.B.",
+    "P.S.",
+    "Q.E.D.",
+    "R.I.P."
 }
 
 # Military and government
@@ -52,6 +68,13 @@ MILITARY = {
     "Gov.",
     "Sen.",
     "Rep.",
+    "Cmdr.",
+    "Pvt.",
+    "Cpl.",
+    "Brig.",
+    "Cpt.",
+    "Lt.Col.",
+    "Maj.Gen."
 }
 
 # Common measurements
@@ -66,6 +89,14 @@ MEASUREMENTS = {
     "hr.",
     "min.",
     "sec.",
+    "m.",
+    "g.",
+    "mg.",
+    "ml.",
+    "l.",
+    "sq.",
+    "cu.",
+    "oz."
 }
 
 # Business and organization
@@ -80,6 +111,13 @@ BUSINESS = {
     "est.",
     "avg.",
     "approx.",
+    "Pty.",
+    "PLC.",
+    "GmbH.",
+    "S.A.",
+    "N.V.",
+    "B.V.",
+    "S.p.A."
 }
 
 # Temporal abbreviations
@@ -103,6 +141,10 @@ TEMPORAL = {
     "Fri.",
     "Sat.",
     "Sun.",
+    "Q1.",
+    "Q2.",
+    "Q3.",
+    "Q4."
 }
 
 # Geographical abbreviations
@@ -116,6 +158,11 @@ GEOGRAPHICAL = {
     "Rd.",
     "St.",
     "Mt.",
+    "Dr.",
+    "Ln.",
+    "Pl.",
+    "Ct.",
+    "Terr."
 }
 
 # Combine all abbreviations

--- a/src/chonkie/chef/patterns.py
+++ b/src/chonkie/chef/patterns.py
@@ -144,7 +144,9 @@ TEMPORAL = {
     "Q1.",
     "Q2.",
     "Q3.",
-    "Q4."
+    "Q4.",
+    "a.m.",
+    "p.m."
 }
 
 # Geographical abbreviations

--- a/src/chonkie/chef/text.py
+++ b/src/chonkie/chef/text.py
@@ -57,9 +57,10 @@ class TextChef(BaseChef):
 
     def _handle_abbreviations(self, text: str) -> str:
         """Replace the fullstop in abbreviations with a dot leader."""
-        for abbreviation in self._abbreviations:
-            # Only match the abbreviations that are surrounded by word boundaries
-            pattern = re.compile(rf'\b{re.escape(abbreviation)}\b')
+        sorted_abbreviations = sorted(self._abbreviations, key=len, reverse=True)   # processing the abbreviation based on their length
+        for abbreviation in sorted_abbreviations:
+            # Only match the abbreviations that are surrounded by word boundary at beginning and a non-word character at end
+            pattern = re.compile(r"\b" + re.escape(abbreviation) + r"(?=\W)")
             new_abbreviation = abbreviation.replace(
                 ".", self._unicode_replacements.DOT_LEADER
             )
@@ -224,7 +225,7 @@ class TextChef(BaseChef):
         return "\n\n".join(processed_paragraphs)
 
     def clean(self, text: str) -> str:
-        r"""Clean the text by performing basic text processing operations.
+        """Clean the text by performing basic text processing operations.
 
         A common function where one can enable/disable the operations supported by the chef.
 
@@ -271,3 +272,15 @@ class TextChef(BaseChef):
             text = self._replace_urls(text)
 
         return text
+    
+    def revert(self, text: str) -> str:
+        """Revert back the DOT LEADERS and ELLIPSIS replacing DOTs.
+        
+        Args:
+            text: The text to revert.
+
+        Returns:
+            The reverted text.
+        
+        """
+        return text.replace(self._unicode_replacements.DOT_LEADER, ".").replace(self._unicode_replacements.ELLIPSIS, "...")

--- a/src/chonkie/chef/text.py
+++ b/src/chonkie/chef/text.py
@@ -283,4 +283,4 @@ class TextChef(BaseChef):
             The reverted text.
         
         """
-        return text.replace(self._unicode_replacements.DOT_LEADER, ".").replace(self._unicode_replacements.ELLIPSIS, "...")
+        return text.replace(self._unicode_replacements.ELLIPSIS, "...").replace(self._unicode_replacements.DOT_LEADER, ".")

--- a/tests/chef/test_text_chef.py
+++ b/tests/chef/test_text_chef.py
@@ -118,13 +118,15 @@ class TestAbbreviations:
         """Test handling multiple abbreviations in text."""
         text = "Prof. Smith, Ph.D., M.D."
         result = text_chef.clean(text)
-        assert all(c not in result for c in ["Prof.", "Ph.D.", "M.D."])
-        assert all(c in result for c in ["Prof․", "Ph․D․", "M․D․"])
+        # Note: as we handling the ending as non-word character the last abbreviation at the end won't get replaced
+        # which is intended. 
+        assert all(c not in result for c in ["Prof.", "Ph.D."])
+        assert all(c in result for c in ["Prof․", "Ph․D․"])
         
     def test_abbreviation_with_word_boundaries(self):
         """Test handling abbreviation only with a word boundary beginning and a non-word character ending."""
         text_chef_no_email = TextChef(email=False)
-        text = "My email is someone@domain.org. My height is 72 in."
+        text = "My email is someone@domain.org. My height is 72 in. and weight is 65 kg."
         result = text_chef_no_email.clean(text)
         assert "someone@domain.org" in result  # dot leader shouldn't present here
         assert "in․" in result  # dot replaced with dot leader
@@ -145,7 +147,7 @@ class TestEmail:
         """Test handling emails."""
         text = "someone@domain.org"
         result = text_chef.clean(text)
-        assert "someone․domain․org" in result
+        assert "someone@domain․org" in result
 
 
 class TestURL:

--- a/tests/chef/test_text_chef.py
+++ b/tests/chef/test_text_chef.py
@@ -255,3 +255,15 @@ class TestFileHandling:
         assert len(result) == 2
         assert "File 1" in result
         assert "File 2" in result
+
+
+class TestRevert:
+    
+    """Test the cleaned text reverted back to the original text."""
+    
+    def test_reverted_text(self, text_chef):
+        """Test whether the cleaned text is reverted back to the original."""
+        text = "My email is john.doe@example.com. Visit https://cloud.chonkie.ai/ for details. Pi is 3.14. Meetings at 10.30 a.m. and 5.45 p.m. Dr. Smith is a good doctor."
+        cleaned_text = text_chef.clean(text)
+        reverted_text = text_chef.revert(cleaned_text)
+        assert reverted_text == text

--- a/tests/chef/test_text_chef.py
+++ b/tests/chef/test_text_chef.py
@@ -120,6 +120,54 @@ class TestAbbreviations:
         result = text_chef.clean(text)
         assert all(c not in result for c in ["Prof.", "Ph.D.", "M.D."])
         assert all(c in result for c in ["Prof․", "Ph․D․", "M․D․"])
+        
+    def test_abbreviation_with_word_boundaries(self):
+        """Test handling abbreviation only with a word boundary beginning and a non-word character ending."""
+        text_chef_no_email = TextChef(email=False)
+        text = "My email is someone@domain.org. My height is 72 in."
+        result = text_chef_no_email.clean(text)
+        assert "someone@domain.org" in result  # dot leader shouldn't present here
+        assert "in․" in result  # dot replaced with dot leader
+        
+    def test_abbreviation_with_prefixes(self, text_chef):
+        """Test handling abbreviations with prefixes existing among themselves."""
+        text = "The time now is 7 a.m. I will increase 1 m. after 1 hour."
+        result = text_chef.clean(text)
+        assert "a․m․" in result          # a.m. should be replaced individually
+        assert "1 m․" in result         # m. should be replaced individually 
+        
+
+class TestEmail:
+    
+    """Test the emails feature."""
+    
+    def test_email(self, text_chef):
+        """Test handling emails."""
+        text = "someone@domain.org"
+        result = text_chef.clean(text)
+        assert "someone․domain․org" in result
+
+
+class TestURL:
+    
+    """Test the URLs feature."""
+    
+    def test_url(self, text_chef):
+        """Test handling URLs."""
+        text = "https://cloud.chonkie.ai/"
+        result = text_chef.clean(text)
+        assert "https://cloud․chonkie․ai/" in result
+
+
+class TestDecimalPoints:
+    
+    """Test the decimal points in between digits."""
+    
+    def test_decimals(self, text_chef):
+        """Test handling decimal points."""
+        text = "The average temperature in July was 25.5 degrees Celsius."
+        result = text_chef.clean(text)
+        assert "25․5" in result
 
 
 class TestFeatureToggling:
@@ -151,6 +199,27 @@ class TestFeatureToggling:
         """Test with ellipsis handling disabled."""
         chef = TextChef(ellipsis=False)
         text = "And then..."
+        result = chef.clean(text)
+        assert result == text
+        
+    def test_disable_emails(self):
+        """Test with emails handling disabled."""
+        chef = TextChef(email=False)
+        text = "someone@domain.org"
+        result = chef.clean(text)
+        assert result == text
+        
+    def test_disable_urls(self):
+        """Test with urls handling disabled."""
+        chef = TextChef(url=False)
+        text = "https://cloud․chonkie․ai/"
+        result = chef.clean(text)
+        assert result == text
+        
+    def test_disable_decimals(self):
+        """Test with decimals handling disabled."""
+        chef = TextChef(decimals=False)
+        text = "25.5"
         result = chef.clean(text)
         assert result == text
 


### PR DESCRIPTION
Stuff:
1. Abbreviations with a word boundary at start and a non-word character at the end will only be replaced. 
Example: dot in "in." in someone@domain.org will not be replaced. But, dot in "in." in "My height is 6 in. and my weight is 65 kg." gets replaced with the dot leader.
2. Abbreviations that end the text (not sentence) will not get replaced. As it is not necessary. 
> Note: Have to find a proper way so that abbreviations at the end of the sentences will also remain not replaced. 
3. Abbreviations having larger length will get processed before the ones with shorted lengths. This helps to handle the cases where the prefixes of a abbreviation exist in another abbreviation. 
4. An email regex used to replace the dots in emails with dot leaders.
5. An URL regex used to replace the dots in URLs with dot leaders. 
6. A decimal point regex that captures a dot between any two digits and it will be replaced with the dot leader.
7. Added a revert function so that the dot leaders and the ellipsis will get reverted back to dots. 
> Note: more than 3 dots will get reverted back to only three in the case of ellipsis. Also, original dot leaders or ellipsis from the original text will get replaced with dots.
8. Added a few more abbreviations. (never settle)
9. As usual, some tests.


There is a lot more to be done. There are many edge cases and many improvements. 
Suggest any ways that you can think of! Thank you! 

