### PR TITLE
Fix: shift to lazy imports inside `CohereEmbeddings`

### DIFF
--- a/src/chonkie/embeddings/cohere.py
+++ b/src/chonkie/embeddings/cohere.py
@@ -3,11 +3,13 @@
 import importlib
 import os
 import warnings
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
-import numpy as np
 import requests
-import tokenizers
+
+if TYPE_CHECKING:
+    import numpy as np
+    import tokenizers
 
 from .base import BaseEmbeddings
 
@@ -117,7 +119,7 @@ class CohereEmbeddings(BaseEmbeddings):
             timeout=timeout,
         )
 
-    def embed(self, text: str) -> np.ndarray:
+    def embed(self, text: str) -> "np.ndarray":
         """Generate embeddings for a single text."""
         token_count = self.count_tokens(text)
         if (
@@ -146,7 +148,7 @@ class CohereEmbeddings(BaseEmbeddings):
 
         raise RuntimeError("Unable to generate embeddings through Cohere.")
 
-    def embed_batch(self, texts: List[str]) -> List[np.ndarray]:
+    def embed_batch(self, texts: List[str]) -> List["np.ndarray"]:
         """Get embeddings for multiple texts using batched API calls."""
         if not texts:
             return []
@@ -211,10 +213,10 @@ class CohereEmbeddings(BaseEmbeddings):
         tokens = self._tokenizer.encode_batch(texts, add_special_tokens=False)
         return [len(t) for t in tokens]
 
-    def similarity(self, u: np.ndarray, v: np.ndarray) -> float:
+    def similarity(self, u: "np.ndarray", v: "np.ndarray") -> "np.float32":
         """Compute cosine similarity between two embeddings."""
         return np.divide(
-            np.dot(u, v), np.linalg.norm(u) * np.linalg.norm(v), dtype=float
+            np.dot(u, v), np.linalg.norm(u) * np.linalg.norm(v), dtype=np.float32
         )
 
     @property
@@ -222,7 +224,7 @@ class CohereEmbeddings(BaseEmbeddings):
         """Return the embedding dimension."""
         return self._dimension
 
-    def get_tokenizer_or_token_counter(self):
+    def get_tokenizer_or_token_counter(self) -> "tokenizers.Tokenizer":
         """Return a tokenizers tokenizer object of the current model."""
         return self._tokenizer
 

--- a/src/chonkie/embeddings/cohere.py
+++ b/src/chonkie/embeddings/cohere.py
@@ -242,8 +242,9 @@ class CohereEmbeddings(BaseEmbeddings):
 
         """
         if cls.is_available():
-            global np, ClientV2
+            global np, tokenizers, ClientV2
             import numpy as np
+            import tokenizers
             from cohere import ClientV2
         else:
             raise ImportError(


### PR DESCRIPTION
This pull request includes several changes to the `src/chonkie/embeddings/cohere.py` file, focusing on improving type hinting and ensuring that certain imports are only included during type checking. The main changes are as follows:

Type Hinting Improvements:
* Changed the return type of the `embed` method to use a string type hint for `np.ndarray`.
* Updated the `embed_batch` method to use a string type hint for `List[np.ndarray]`.
* Modified the `similarity` method to use string type hints for `np.ndarray` and `np.float32`.
* Added return type hints for `get_tokenizer_or_token_counter` method.

Conditional Imports:
* Added `TYPE_CHECKING` import and conditionally imported `numpy` and `tokenizers` to avoid unnecessary imports during runtime. [[1]](diffhunk://#diff-425a4f295b145e2b744bf46a03a2c2675cc461a60c80cb6be656fd585849537fL6-R11) [[2]](diffhunk://#diff-425a4f295b145e2b744bf46a03a2c2675cc461a60c80cb6be656fd585849537fL243-R247)