### PR TITLE
[Fix] Bug Duplicate Chunks #201

### DIFF
--- a/src/chonkie/chunker/recursive.py
+++ b/src/chonkie/chunker/recursive.py
@@ -207,14 +207,15 @@ class RecursiveChunker(BaseChunker):
             return self.tokenizer.count_tokens(text)
 
     def _create_chunk(
-        self, text: str, token_count: int, level: int, full_text: Optional[str] = None
+        self, text: str, token_count: int, level: int, start_offset: int, full_text: Optional[str] = None
     ) -> RecursiveChunk:
         """Create a chunk."""
+        print("Text in current chunk creation ", text)
         if full_text is None:
             full_text = text
         try:
-            start_index = full_text.index(text)
-            end_index = start_index + len(text)
+            start_index = start_offset
+            end_index = start_offset + len(text)
         except Exception as e:
             print(
                 f"Error getting start_index and end_index: {e}"
@@ -233,7 +234,7 @@ class RecursiveChunker(BaseChunker):
         )
 
     def _recursive_chunk(
-        self, text: str, level: int = 0, full_text: Optional[str] = None
+        self, text: str, level: int = 0, start_offset: int =0,full_text: Optional[str] = None
     ) -> Sequence[RecursiveChunk]:
         """Recursive chunking logic."""
         # First make sure the text is not empty
@@ -282,9 +283,10 @@ class RecursiveChunker(BaseChunker):
 
         # Recursively chunk the merged splits if they are too long
         chunks = []
+        current_offset = start_offset
         for split, token_count in zip(merged, merged_token_counts):
             if token_count > self.chunk_size:
-                chunks.extend(self._recursive_chunk(split, level + 1, full_text))
+                chunks.extend(self._recursive_chunk(split, level + 1, current_offset, full_text))
             else:
                 if self.return_type == "chunks":
                     if rule.delimiters is None and not rule.whitespace:
@@ -292,19 +294,20 @@ class RecursiveChunker(BaseChunker):
                         # And we don't want to encode/decode the text again, that would be inefficient
                         decoded_text = "".join(merged)
                         chunks.append(
-                            self._create_chunk(split, token_count, level, decoded_text)
+                            self._create_chunk(split, token_count, level, current_offset,decoded_text)
                         )
                     else:
                         chunks.append(
-                            self._create_chunk(split, token_count, level, full_text)
+                            self._create_chunk(split, token_count, level, current_offset, full_text)
                         )
                 elif self.return_type == "texts":
                     chunks.append(split)
+            current_offset += len(split)
         return chunks
 
     def chunk(self, text: str) -> Sequence[Chunk]:
         """Chunk the text."""
-        return self._recursive_chunk(text, level=0, full_text=text)
+        return self._recursive_chunk(text, level=0, full_text=text, start_offset=0)
 
     def __repr__(self) -> str:
         """Get a string representation of the recursive chunker."""


### PR DESCRIPTION
This PR resolves an issue where chunks containing repeating substrings were assigned duplicate start_index values, leading to overlapping chunks. The previous implementation relied on str.index(), which always returned the first occurrence of a substring in the full text, causing incorrect positioning when the same string appeared multiple times.

To address this, I introduced a start_offset variable to track the current position in the text as it’s processed. This offset is incremented based on the length of each processed split, ensuring that each chunk’s start_index reflects its actual location in the original text, rather than the first matching substring. Key changes include:

- Updated _create_chunk to use start_offset instead of full_text.index().
- Modified _recursive_chunk to pass and update start_offset through the recursion, maintaining accurate offsets for all chunks.


Note : I have a doubt of removing full_text argument as in this approach it is not getting used so i can remove it if you approve.
